### PR TITLE
Fix deadline column detection

### DIFF
--- a/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
@@ -65,7 +65,9 @@ export default {
     formattedValue() {
       try {
         // DEADLINE: barra proporcional
-        if (this.params.colDef?.TagControl === 'DEADLINE' || this.params.colDef?.tagControl === 'DEADLINE') {
+        const tagControl = this.params.colDef?.TagControl || this.params.colDef?.tagControl || '';
+        const fieldName = this.params.colDef?.field;
+        if (tagControl.toUpperCase() === 'DEADLINE' || fieldName === 'Deadline') {
           const value = this.params.value;
           if (!value) return '';
           // Parse data DEADLINE

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -261,7 +261,10 @@
     let deadlineColumns = [];
     if (props.content && props.content.columns && Array.isArray(props.content.columns)) {
       deadlineColumns = props.content.columns
-        .filter(col => (col.TagControl || col.tagControl || '').toUpperCase() === 'DEADLINE')
+        .filter(col => {
+          const tag = (col.TagControl || col.tagControl || '').toUpperCase();
+          return tag === 'DEADLINE' || col.field === 'Deadline';
+        })
         .map(col => col.id || col.field)
         .filter(Boolean);
     }
@@ -563,7 +566,8 @@
       return this.content.columns.map((col) => {
         const colCopy = { ...col };
         // Forçar configuração correta para colunas DEADLINE
-        if ((colCopy.TagControl || colCopy.tagControl || '').toUpperCase() === 'DEADLINE') {
+        const tag = (colCopy.TagControl || colCopy.tagControl || '').toUpperCase();
+        if (tag === 'DEADLINE' || colCopy.field === 'Deadline') {
           colCopy.cellRenderer = 'FormatterCellRenderer';
           delete colCopy.cellRendererFramework;
           delete colCopy.formatter;


### PR DESCRIPTION
## Summary
- restore Deadline formatting when `TagControl` is missing
- update renderer and column setup to also check field name

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68814dbce9908330bee8a4239953d04d