### PR TITLE
Fix deadline refresh in grid

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -262,7 +262,10 @@
     // Timer para atualizar células DEADLINE
     if (props.content && props.content.columns && Array.isArray(props.content.columns)) {
       deadlineColumns = props.content.columns
-        .filter(col => col.TagControl === 'DEADLINE')
+        .filter(col => {
+          const tc = col.TagControl || col.tagControl;
+          return tc && tc.toUpperCase() === 'DEADLINE';
+        })
         .map(col => col.id || col.field)
         .filter(Boolean);
     }


### PR DESCRIPTION
## Summary
- detect `tagControl` case-insensitively when scheduling deadline refresh

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688152d8729c8330bc7937140bd4884b