### PR TITLE
Disable selectable items flagged inactive

### DIFF
--- a/Project/DropdownCategories/src/components/ComponentSelector.vue
+++ b/Project/DropdownCategories/src/components/ComponentSelector.vue
@@ -19,8 +19,9 @@
         v-for="(component, idx) in filteredComponents"
         :key="component[valueField] || ('title-' + idx)"
         class="component-selector__item"
-        :class="component.__isTitle ? 'component-selector__item--title' : ''"
-        @click.stop="!component.__isTitle && selectComponent(component)"
+        :class="[component.__isTitle ? 'component-selector__item--title' : '',
+                  component.isEnabled === false ? 'component-selector__item--disabled' : '']"
+        @click.stop="!component.__isTitle && component.isEnabled !== false && selectComponent(component)"
       >
         <span class="component-selector__name" :style="nameStyle">{{ component?.[labelField] || '' }}</span>
       </div>
@@ -416,6 +417,10 @@ export default {
   gap: 10px;
   border: none;
   box-sizing: border-box;
+}
+.component-selector__item--disabled {
+  pointer-events: none;
+  opacity: 0.5;
 }
 .component-selector__item--title {
   font-weight: bold;

--- a/Project/DropdownUsers/src/components/UserSelector.vue
+++ b/Project/DropdownUsers/src/components/UserSelector.vue
@@ -41,7 +41,8 @@
           v-for="user in filteredUsers"
           :key="user.userID"
           class="user-selector__item"
-          @click.stop="selectUser(user)"
+          :class="{ disabled: user.isEnabled === false }"
+          @click.stop="user.isEnabled === false ? null : selectUser(user)"
         >
           <div class="avatar-outer">
             <div class="avatar-middle">
@@ -392,6 +393,10 @@ export default {
   transition: background 0.2s;
   gap: 10px;
   border: none;
+}
+.user-selector__item.disabled {
+  pointer-events: none;
+  opacity: 0.5;
 }
 .user-selector__item:hover {
   background: #f5f5f5;

--- a/Project/FormRender/Component/components/DynamicListField.vue
+++ b/Project/FormRender/Component/components/DynamicListField.vue
@@ -18,6 +18,7 @@
         v-for="option in options"
         :key="option.value"
         :value="option.value"
+        :disabled="option.isEnabled === false"
       >
         {{ option.label }}
       </option>

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -859,12 +859,16 @@
           headerCheckbox: !this.content.disableCheckboxes,
           selectAll: this.content.selectAll || "all",
           enableClickSelection: this.content.enableClickSelection,
+          isRowSelectable: rowNode =>
+            !(rowNode?.data && rowNode.data.isEnabled === false),
         };
       } else if (this.content.rowSelection === "single") {
         return {
           mode: "singleRow",
           checkboxes: !this.content.disableCheckboxes,
           enableClickSelection: this.content.enableClickSelection,
+          isRowSelectable: rowNode =>
+            !(rowNode?.data && rowNode.data.isEnabled === false),
         };
       } else {
         return {
@@ -975,6 +979,7 @@
   onRowClicked(event) {
   // Add null checks to prevent accessing properties of undefined objects
   if (!event || !event.data) return;
+  if (event.data.isEnabled === false) return;
 
   // Identifica a coluna clicada
   const colId = event.column?.getColId?.();

--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -413,6 +413,7 @@ export default {
           selectAll: this.content.selectAll || "all",
           enableClickSelection: this.content.enableClickSelection,
           isRowSelectable: (rowNode) => {
+            if (rowNode?.data && rowNode.data.isEnabled === false) return false;
             const cond = this.content.disableRowSelectionCondition;
             if (!cond) return true;
             let expr = cond.replace(/@([a-zA-Z0-9_çÇãÃáÁéÉíÍóÓúÚêÊôÔâÂàÀèÈìÌòÒùÙüÜñÑ]+)/g, (match, p1) => {
@@ -441,6 +442,8 @@ export default {
         return {
           mode: "singleRow",
           checkboxes: !this.content.disableCheckboxes,
+          isRowSelectable: rowNode =>
+            !(rowNode?.data && rowNode.data.isEnabled === false),
           enableClickSelection: this.content.enableClickSelection,
         };
       } else {
@@ -549,6 +552,7 @@ export default {
         )) ||
         (colDef && colDef.checkboxSelection);
       if (isSelectionCol) return;
+      if (event?.data && event.data.isEnabled === false) return;
       this.$emit("trigger-event", {
         name: "rowClicked",
         event: {


### PR DESCRIPTION
## Summary
- make datagrid rows unselectable if `isEnabled` is false
- avoid row click events for disabled rows
- disable options in dynamic lists when `isEnabled` is false
- allow dropdown items to ignore clicks when disabled

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882606672d083309bdf1c82035fb043