### PR TITLE
Fix DateTime editor registration

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -7,6 +7,7 @@
         :getMainMenuItems="getMainMenuItems" :isColumnMovable="isColumnMovable" :theme="theme" :getRowId="getRowId"
         :pagination="content.pagination" :paginationPageSize="content.paginationPageSize || 10"
         :paginationPageSizeSelector="false" :columnHoverHighlight="content.columnHoverHighlight" :locale-text="localeText"
+        :components="editorComponents"
         :singleClickEdit="true" @grid-ready="onGridReady" @row-selected="onRowSelected"
         @selection-changed="onSelectionChanged" @cell-value-changed="onCellValueChanged" @filter-changed="onFilterChanged"
         @sort-changed="onSortChanged" @row-clicked="onRowClicked" @first-data-rendered="onFirstDataRendered"
@@ -535,6 +536,10 @@
       createElement,
       /* wwEditor:end */
       onFirstDataRendered,
+      editorComponents: {
+        ListCellEditor,
+        DateTimeCellEditor,
+      },
     };
   },
     computed: {


### PR DESCRIPTION
## Summary
- register the DateTime and List cell editors for AG Grid
- expose them via `editorComponents` and pass to `<ag-grid-vue>`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68838efdb6288330a837cad63ff703d6