### PR TITLE
Fix Deadline cell editor update on Enter

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
@@ -22,6 +22,19 @@ export default class DateTimeCellEditor {
     };
     input.addEventListener('input', syncValue);
     input.addEventListener('change', syncValue);
+
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        // Ensure value is up to date before closing
+        this.value = e.target.value;
+        if (this.params && typeof this.params.stopEditing === 'function') {
+          this.params.stopEditing();
+        } else if (this.params && this.params.api) {
+          // Fallback for older grid versions
+          this.params.api.stopEditing();
+        }
+      }
+    });
     
     this.eInput = input;
   }


### PR DESCRIPTION
## Summary
- ensure the DateTime editor closes on Enter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68839b22c63083308193b8f5b85bd41b