### PR TITLE
Fix Deadline cell editor update on Enter

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
@@ -22,6 +22,20 @@ export default class DateTimeCellEditor {
     };
     input.addEventListener('input', syncValue);
     input.addEventListener('change', syncValue);
+
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.stopPropagation();
+        e.preventDefault();
+        this.value = e.target.value;
+
+        if (this.params && this.params.api) {
+          this.params.api.stopEditing();
+        } else if (this.params && typeof this.params.stopEditing === 'function') {
+          this.params.stopEditing();
+        }
+      }
+    });
     
     this.eInput = input;
   }


### PR DESCRIPTION
## Summary
- simplify Enter handling for DateTimeCellEditor to stop editing and keep the new value

## Testing
- `node -e "require('./Project/GridViewDinamica/src/components/DateTimeCellEditor.js'); console.log('ok');"`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68839b22c63083308193b8f5b85bd41b