### PR TITLE
Add fixed list editor for datasource fields

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -1,0 +1,58 @@
+export default class FixedListCellEditor {
+  init(params) {
+    this.params = params;
+    this.eGui = document.createElement('div');
+    this.eGui.style.width = '100%';
+    this.eGui.style.height = '100%';
+
+    // Fixed list options
+    this.options = [
+      { value: 1, label: 'Carro' },
+      { value: 2, label: 'Navio' },
+      { value: 3, label: 'Avi\u00E3o' }
+    ];
+
+    // Initial value
+    this.value = params.value;
+
+    const select = document.createElement('select');
+    select.style.width = '100%';
+    select.style.height = '100%';
+    select.style.fontSize = '13px';
+    select.style.borderRadius = '6px';
+    select.style.padding = '4px';
+
+    this.options.forEach(opt => {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.innerHTML = opt.label;
+      if (opt.value == this.value) option.selected = true;
+      select.appendChild(option);
+    });
+
+    select.addEventListener('change', e => {
+      this.value = e.target.value;
+    });
+
+    this.eGui.appendChild(select);
+    this.select = select;
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  afterGuiAttached() {
+    if (this.select) this.select.focus();
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  destroy() {}
+
+  isPopup() {
+    return false;
+  }
+}

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -38,6 +38,7 @@
   import UserCellRenderer from "./components/UserCellRenderer.vue";
   import ListFilterRenderer from "./components/ListFilterRenderer.js";
   import DateTimeCellEditor from "./components/DateTimeCellEditor.js";
+  import FixedListCellEditor from "./components/FixedListCellEditor.js";
   // Editor customizado inline para listas
   class ListCellEditor {
     init(params) {
@@ -88,6 +89,7 @@
   FormatterCellRenderer, // Add this line
   UserCellRenderer,
   ListCellEditor, // registrar editor customizado
+  FixedListCellEditor,
   DateTimeCellEditor,
   },
   props: {
@@ -538,6 +540,7 @@
       onFirstDataRendered,
       editorComponents: {
         ListCellEditor,
+        FixedListCellEditor,
         DateTimeCellEditor,
       },
     };
@@ -884,6 +887,11 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
               const optionsArr = Array.isArray(colCopy.options) ? colCopy.options : (Array.isArray(colCopy.listOptions) ? colCopy.listOptions : []);
               result.options = optionsArr;
               // O cellRenderer já aplica a formatação visual
+            }
+            // Editor fixo quando a coluna possui dataSource
+            if (colCopy.dataSource) {
+              result.editable = true;
+              result.cellEditor = FixedListCellEditor;
             }
             return result;
           }


### PR DESCRIPTION
## Summary
- implement `FixedListCellEditor` for GridViewDinamica
- register the new editor in `wwElement.vue`
- use it when column configuration includes a `dataSource`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6883a44d02ac83309c57f8e0c96ab72b