### PR TITLE
Use datasource list options in grid editors

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -6,11 +6,27 @@ export default class FixedListCellEditor {
     this.eGui.style.height = '100%';
 
     // Fixed list options
-    this.options = [
-      { value: 1, label: 'Carro' },
-      { value: 2, label: 'Navio' },
-      { value: 3, label: 'Avi\u00E3o' }
-    ];
+    let optionsArr = [];
+    if (Array.isArray(params.colDef.listOptions)) {
+      optionsArr = params.colDef.listOptions;
+    } else if (
+      typeof params.colDef.listOptions === 'string' &&
+      params.colDef.listOptions.trim() !== ''
+    ) {
+      optionsArr = params.colDef.listOptions.split(',').map(o => o.trim());
+    } else if (
+      params.colDef.dataSource &&
+      typeof params.colDef.dataSource.list_options === 'string' &&
+      params.colDef.dataSource.list_options.trim() !== ''
+    ) {
+      optionsArr = params.colDef.dataSource.list_options
+        .split(',')
+        .map(o => o.trim());
+    }
+
+    this.options = optionsArr.map(opt =>
+      typeof opt === 'object' ? opt : { value: opt, label: String(opt) }
+    );
 
     // Initial value
     this.value = params.value;

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -6,7 +6,25 @@ export default class ListCellEditor {
     this.eGui.style.height = '100%';
 
     // Opções da lista
-    const optionsArr = Array.isArray(params.colDef.options) ? params.colDef.options : (Array.isArray(params.colDef.listOptions) ? params.colDef.listOptions : []);
+    let optionsArr = [];
+    if (Array.isArray(params.colDef.options)) {
+      optionsArr = params.colDef.options;
+    } else if (Array.isArray(params.colDef.listOptions)) {
+      optionsArr = params.colDef.listOptions;
+    } else if (
+      typeof params.colDef.listOptions === 'string' &&
+      params.colDef.listOptions.trim() !== ''
+    ) {
+      optionsArr = params.colDef.listOptions.split(',').map(o => o.trim());
+    } else if (
+      params.colDef.dataSource &&
+      typeof params.colDef.dataSource.list_options === 'string' &&
+      params.colDef.dataSource.list_options.trim() !== ''
+    ) {
+      optionsArr = params.colDef.dataSource.list_options
+        .split(',')
+        .map(o => o.trim());
+    }
     this.options = optionsArr.map(opt => typeof opt === 'object' ? opt : { value: opt, label: String(opt) });
 
     // Valor inicial

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -46,7 +46,25 @@
       this.eGui = document.createElement('div');
       this.eGui.style.width = '100%';
       this.eGui.style.height = '100%';
-      const optionsArr = Array.isArray(params.colDef.options) ? params.colDef.options : (Array.isArray(params.colDef.listOptions) ? params.colDef.listOptions : []);
+      let optionsArr = [];
+      if (Array.isArray(params.colDef.options)) {
+        optionsArr = params.colDef.options;
+      } else if (Array.isArray(params.colDef.listOptions)) {
+        optionsArr = params.colDef.listOptions;
+      } else if (
+        typeof params.colDef.listOptions === 'string' &&
+        params.colDef.listOptions.trim() !== ''
+      ) {
+        optionsArr = params.colDef.listOptions.split(',').map(o => o.trim());
+      } else if (
+        params.colDef.dataSource &&
+        typeof params.colDef.dataSource.list_options === 'string' &&
+        params.colDef.dataSource.list_options.trim() !== ''
+      ) {
+        optionsArr = params.colDef.dataSource.list_options
+          .split(',')
+          .map(o => o.trim());
+      }
       this.options = optionsArr.map(opt => typeof opt === 'object' ? opt : { value: opt, label: String(opt) });
       this.value = params.value;
       const select = document.createElement('select');
@@ -642,19 +660,34 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
               formatter: colCopy.formatter
             }
           };
+          const dsOptions =
+            colCopy.dataSource &&
+            typeof colCopy.dataSource.list_options === 'string' &&
+            colCopy.dataSource.list_options.trim() !== ''
+              ? colCopy.dataSource.list_options
+                  .split(',')
+                  .map(o => o.trim())
+              : [];
           if (
             colCopy.cellDataType === 'list' ||
             (tagControl && tagControl.toUpperCase() === 'LIST')
           ) {
             result.editable = true;
             result.cellEditor = ListCellEditor;
-            const optionsArr = Array.isArray(colCopy.options) ? colCopy.options : (Array.isArray(colCopy.listOptions) ? colCopy.listOptions : []);
+            const optionsArr = Array.isArray(colCopy.options)
+              ? colCopy.options
+              : Array.isArray(colCopy.listOptions)
+              ? colCopy.listOptions
+              : dsOptions;
             result.options = optionsArr;
           }
           // Editor fixo quando a coluna possui dataSource
           if (colCopy.dataSource) {
             result.editable = true;
             result.cellEditor = FixedListCellEditor;
+            if (dsOptions.length) {
+              result.listOptions = dsOptions;
+            }
           }
           return result;
         }
@@ -707,6 +740,14 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
           }
           case "list":
             {
+              const dsOptions =
+                colCopy.dataSource &&
+                typeof colCopy.dataSource.list_options === 'string' &&
+                colCopy.dataSource.list_options.trim() !== ''
+                  ? colCopy.dataSource.list_options
+                      .split(',')
+                      .map(o => o.trim())
+                  : [];
               const result = {
                 ...commonProperties,
                 id: colCopy.id,
@@ -722,7 +763,11 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                 },
                 editable: true,
                 cellEditor: ListCellEditor,
-                options: Array.isArray(colCopy.options) ? colCopy.options : (Array.isArray(colCopy.listOptions) ? colCopy.listOptions : [])
+                options: Array.isArray(colCopy.options)
+                  ? colCopy.options
+                  : Array.isArray(colCopy.listOptions)
+                  ? colCopy.listOptions
+                  : dsOptions,
               };
               
               return result;
@@ -893,13 +938,25 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                 return `<span class="deadline-visual ${colorClass}" title="${tooltip}">${diff}</span>`;
               };
             }
+            const dsOptions =
+              colCopy.dataSource &&
+              typeof colCopy.dataSource.list_options === 'string' &&
+              colCopy.dataSource.list_options.trim() !== ''
+                ? colCopy.dataSource.list_options
+                    .split(',')
+                    .map(o => o.trim())
+                : [];
             if (
               colCopy.cellDataType === 'list' ||
               (tagControl && tagControl.toUpperCase() === 'LIST')
             ) {
               result.editable = true;
               result.cellEditor = ListCellEditor;
-              const optionsArr = Array.isArray(colCopy.options) ? colCopy.options : (Array.isArray(colCopy.listOptions) ? colCopy.listOptions : []);
+              const optionsArr = Array.isArray(colCopy.options)
+                ? colCopy.options
+                : Array.isArray(colCopy.listOptions)
+                ? colCopy.listOptions
+                : dsOptions;
               result.options = optionsArr;
               // O cellRenderer já aplica a formatação visual
             }
@@ -907,6 +964,9 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             if (colCopy.dataSource) {
               result.editable = true;
               result.cellEditor = FixedListCellEditor;
+              if (dsOptions.length) {
+                result.listOptions = dsOptions;
+              }
             }
             return result;
           }


### PR DESCRIPTION
## Summary
- update `FixedListCellEditor` and `ListCellEditor` to read options from column datasource
- adjust inline list editor in `wwElement.vue`
- pass datasource list options to column definitions so dropdowns use them when editing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6883cbd4c5388330837143ba514ac9e7