### PR TITLE
Implement searchable list cell editor

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -2,8 +2,16 @@ export default class FixedListCellEditor {
   init(params) {
     this.params = params;
     this.eGui = document.createElement('div');
-    this.eGui.style.width = '100%';
-    this.eGui.style.height = '100%';
+    this.eGui.className = 'list-editor';
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" class="search-input" placeholder="Search..." />
+        <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
+      </div>
+      <div class="filter-list"></div>
+    `;
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.listEl = this.eGui.querySelector('.filter-list');
 
     // Fixed list options
     let optionsArr = [];
@@ -27,31 +35,111 @@ export default class FixedListCellEditor {
     this.options = optionsArr.map(opt =>
       typeof opt === 'object' ? opt : { value: opt, label: String(opt) }
     );
+    this.filteredOptions = [...this.options];
 
-    // Initial value
     this.value = params.value;
 
-    const select = document.createElement('select');
-    select.style.width = '100%';
-    select.style.height = '100%';
-    select.style.fontSize = '13px';
-    select.style.borderRadius = '6px';
-    select.style.padding = '4px';
-
-    this.options.forEach(opt => {
-      const option = document.createElement('option');
-      option.value = opt.value;
-      option.innerHTML = opt.label;
-      if (opt.value == this.value) option.selected = true;
-      select.appendChild(option);
+    this.searchInput.addEventListener('input', e => {
+      this.filterOptions(e.target.value);
     });
 
-    select.addEventListener('change', e => {
-      this.value = e.target.value;
-    });
+    this.renderOptions();
+  }
 
-    this.eGui.appendChild(select);
-    this.select = select;
+  filterOptions(text) {
+    const t = text.toLowerCase();
+    this.filteredOptions = this.options.filter(opt => {
+      const label = this.stripHtml(String(this.formatOption(opt)));
+      return label.toLowerCase().includes(t);
+    });
+    this.renderOptions();
+  }
+
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+    const fontweight = 'font-weight:bold;';
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+      const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(
+        new Date(dateValue)
+      );
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(
+        new Date(dateValue)
+      );
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  formatOption(opt) {
+    const value = opt.label != null ? opt.label : opt.value;
+    const colDef = this.params.colDef || {};
+    const params = colDef.cellRendererParams || {};
+    try {
+      if (params.useCustomFormatter && typeof params.formatter === 'string') {
+        const fn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          params.formatter
+        );
+        return fn(
+          value,
+          {},
+          colDef,
+          this.getRoundedSpanColor.bind(this),
+          this.dateFormatter.bind(this)
+        );
+      } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+        const styled = this.getRoundedSpanColor(
+          value,
+          params.styleArray,
+          colDef.FieldDB
+        );
+        if (styled) return styled;
+      }
+    } catch (e) {
+      console.error('Format option error', e);
+    }
+    return value;
+  }
+
+  renderOptions() {
+    this.listEl.innerHTML = this.filteredOptions
+      .map(opt => {
+        const formatted = this.formatOption(opt);
+        const selected = opt.value == this.value ? ' selected' : '';
+        return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+      })
+      .join('');
+    this.listEl.querySelectorAll('.filter-item').forEach(el => {
+      el.addEventListener('click', () => {
+        this.value = el.getAttribute('data-value');
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing();
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing();
+        }
+      });
+    });
   }
 
   getGui() {
@@ -59,7 +147,7 @@ export default class FixedListCellEditor {
   }
 
   afterGuiAttached() {
-    if (this.select) this.select.focus();
+    if (this.searchInput) this.searchInput.focus();
   }
 
   getValue() {
@@ -69,6 +157,6 @@ export default class FixedListCellEditor {
   destroy() {}
 
   isPopup() {
-    return false;
+    return true;
   }
 }

--- a/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
@@ -64,6 +64,14 @@ export default {
   computed: {
     formattedValue() {
       try {
+        const rawValue = this.params.value;
+        let displayValue = rawValue;
+        if (Array.isArray(this.params.options)) {
+          const match = this.params.options.find(
+            opt => String(opt.value) === String(rawValue)
+          );
+          if (match) displayValue = match.label;
+        }
         // DEADLINE: barra proporcional
         if (this.params.colDef?.TagControl === 'DEADLINE' || this.params.colDef?.tagControl === 'DEADLINE') {
           const value = this.params.value;
@@ -157,16 +165,16 @@ export default {
             let borderRadius = '12px';
             if (this.params.colDef?.FieldDB === 'StatusID') borderRadius = '5px';
             // Função inline para aplicar o raio
-            function getRoundedSpanColorWithRadius(value, colorArray) {
-              if (!colorArray || !Array.isArray(colorArray) || !value) return value;
-              const matchingStyle = colorArray.find(item => item.Valor === value);
-              if (!matchingStyle) return value;
-              return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+            function getRoundedSpanColorWithRadius(matchVal, textVal, colorArray) {
+              if (!colorArray || !Array.isArray(colorArray) || !matchVal) return textVal;
+              const matchingStyle = colorArray.find(item => item.Valor === matchVal);
+              if (!matchingStyle) return textVal;
+              return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; display: inline-flex; align-items: center; padding: 0 12px;">${textVal}</span>`;
             }
-            const styledValue = getRoundedSpanColorWithRadius(this.params.value, styleArray);
+            const styledValue = getRoundedSpanColorWithRadius(rawValue, displayValue, styleArray);
             if (styledValue) return styledValue;
           }
-          return this.params.value;
+          return displayValue;
         }
 
         // Create a function from the formatter code with getRoundedSpanColor available
@@ -181,11 +189,11 @@ export default {
 
         // Execute the formatter with the cell value, row data, and helper functions
         return formatterFn(
-          this.params.value, 
-          this.params.data, 
+          displayValue,
+          this.params.data,
           this.params.colDef,
-          getRoundedSpanColor, // Pass the function as the fourth parameter
-          dateFormatter // Pass the dateFormatter function as the fifth parameter
+          getRoundedSpanColor,
+          dateFormatter
         );
       } catch (error) {
         console.error('Error in custom formatter:', error);

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -2,10 +2,18 @@ export default class ListCellEditor {
   init(params) {
     this.params = params;
     this.eGui = document.createElement('div');
-    this.eGui.style.width = '100%';
-    this.eGui.style.height = '100%';
+    this.eGui.className = 'list-editor';
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" class="search-input" placeholder="Search..." />
+        <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
+      </div>
+      <div class="filter-list"></div>
+    `;
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.listEl = this.eGui.querySelector('.filter-list');
 
-    // Opções da lista
+    // Build option array
     let optionsArr = [];
     if (Array.isArray(params.colDef.options)) {
       optionsArr = params.colDef.options;
@@ -25,33 +33,113 @@ export default class ListCellEditor {
         .split(',')
         .map(o => o.trim());
     }
-    this.options = optionsArr.map(opt => typeof opt === 'object' ? opt : { value: opt, label: String(opt) });
-
-    // Valor inicial
+    this.options = optionsArr.map(opt =>
+      typeof opt === 'object' ? opt : { value: opt, label: String(opt) }
+    );
+    this.filteredOptions = [...this.options];
     this.value = params.value;
 
-    // Cria o select customizado
-    const select = document.createElement('select');
-    select.style.width = '100%';
-    select.style.height = '100%';
-    select.style.fontSize = '13px';
-    select.style.borderRadius = '6px';
-    select.style.padding = '4px';
-
-    this.options.forEach(opt => {
-      const option = document.createElement('option');
-      option.value = opt.value;
-      option.innerHTML = opt.label;
-      if (opt.value == this.value) option.selected = true;
-      select.appendChild(option);
+    this.searchInput.addEventListener('input', e => {
+      this.filterOptions(e.target.value);
     });
 
-    select.addEventListener('change', e => {
-      this.value = e.target.value;
-    });
+    this.renderOptions();
+  }
 
-    this.eGui.appendChild(select);
-    this.select = select;
+  filterOptions(text) {
+    const t = text.toLowerCase();
+    this.filteredOptions = this.options.filter(opt => {
+      const label = this.stripHtml(String(this.formatOption(opt)));
+      return label.toLowerCase().includes(t);
+    });
+    this.renderOptions();
+  }
+
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+    const fontweight = 'font-weight:bold;';
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+      const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(
+        new Date(dateValue)
+      );
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(
+        new Date(dateValue)
+      );
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  formatOption(opt) {
+    const value = opt.label != null ? opt.label : opt.value;
+    const colDef = this.params.colDef || {};
+    const params = colDef.cellRendererParams || {};
+    try {
+      if (params.useCustomFormatter && typeof params.formatter === 'string') {
+        const fn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          params.formatter
+        );
+        return fn(
+          value,
+          {},
+          colDef,
+          this.getRoundedSpanColor.bind(this),
+          this.dateFormatter.bind(this)
+        );
+      } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+        const styled = this.getRoundedSpanColor(
+          value,
+          params.styleArray,
+          colDef.FieldDB
+        );
+        if (styled) return styled;
+      }
+    } catch (e) {
+      console.error('Format option error', e);
+    }
+    return value;
+  }
+
+  renderOptions() {
+    this.listEl.innerHTML = this.filteredOptions
+      .map(opt => {
+        const formatted = this.formatOption(opt);
+        const selected = opt.value == this.value ? ' selected' : '';
+        return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+      })
+      .join('');
+    this.listEl.querySelectorAll('.filter-item').forEach(el => {
+      el.addEventListener('click', () => {
+        this.value = el.getAttribute('data-value');
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing();
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing();
+        }
+      });
+    });
   }
 
   getGui() {
@@ -59,7 +147,7 @@ export default class ListCellEditor {
   }
 
   afterGuiAttached() {
-    if (this.select) this.select.focus();
+    if (this.searchInput) this.searchInput.focus();
   }
 
   getValue() {
@@ -69,6 +157,6 @@ export default class ListCellEditor {
   destroy() {}
 
   isPopup() {
-    return false;
+    return true;
   }
-} 
+}

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -1,5 +1,5 @@
 /* Filtro customizado para campos do tipo list */
-.list-filter {
+.list-filter, .list-editor {
   padding: 12px 12px 8px 12px;
   min-width: 260px;
   max-width: 350px;
@@ -46,21 +46,21 @@
   height: 0;
 }
 
-.list-filter .filter-list,
-.list-filter .filter-item,
-.list-filter .filter-label {
+:is(.list-filter, .list-editor) .filter-list,
+:is(.list-filter, .list-editor) .filter-item,
+:is(.list-filter, .list-editor) .filter-label {
   font-family: Roboto, Arial, sans-serif;
   font-size: 13px;
 }
-.list-filter .filter-header {
+:is(.list-filter, .list-editor) .filter-header {
   margin-bottom: 10px;
 }
-.list-filter .field-search {
+:is(.list-filter, .list-editor) .field-search {
   position: relative;
   padding: 0 0 10px 0;
 }
 
-.list-filter .search-input {
+:is(.list-filter, .list-editor) .search-input {
   width: 100%;
   padding: 7px 36px 7px 13px;
   border: 1px solid #ddd;
@@ -73,13 +73,13 @@
   box-sizing: border-box;
 }
 
-.list-filter .search-input::placeholder {
+:is(.list-filter, .list-editor) .search-input::placeholder {
   color: #aaa;
   font-size: 13px;
   font-family: Roboto, Arial, sans-serif;
 }
 
-.list-filter .search-icon {
+:is(.list-filter, .list-editor) .search-icon {
   position: absolute;
   right: 12px;
   top: 16px;
@@ -93,7 +93,7 @@
   justify-content: center;
 }
 
-.list-filter .search-icon i.material-symbols-outlined-search {
+:is(.list-filter, .list-editor) .search-icon i.material-symbols-outlined-search {
   font-family: 'Material Symbols Outlined';
   font-size: 19px;
   font-style: normal;
@@ -104,12 +104,12 @@
   display: inline-block;
   vertical-align: middle;
 }
-.list-filter .filter-list {
+:is(.list-filter, .list-editor) .filter-list {
   max-height: 180px;
   overflow-y: auto;
   margin-bottom: 10px;
 }
-.list-filter .select-all-row {
+:is(.list-filter, .list-editor) .select-all-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -122,7 +122,7 @@
   gap: 8px;
 }
 
-.list-filter .select-all-row label {
+:is(.list-filter, .list-editor) .select-all-row label {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -133,11 +133,11 @@
   width: 100%;
 }
 
-.list-filter .select-all-row label:hover {
+:is(.list-filter, .list-editor) .select-all-row label:hover {
   background: #f6f7fa;
 }
 
-.list-filter .select-all-checkbox {
+:is(.list-filter, .list-editor) .select-all-checkbox {
   width: 16px;
   height: 16px;
   border-radius: 5px;
@@ -149,7 +149,7 @@
   flex-shrink: 0;
 }
 
-.list-filter .filter-item {
+:is(.list-filter, .list-editor) .filter-item {
   display: flex;
   align-items: center;
   padding: 6px 0 6px 0;
@@ -161,15 +161,15 @@
   transition: background 0.15s;
 }
 
-.list-filter .filter-item:hover {
+:is(.list-filter, .list-editor) .filter-item:hover {
   background: #f6f7fa;
 }
 
-.list-filter .filter-item.selected {
+:is(.list-filter, .list-editor) .filter-item.selected {
   background: #f6f7fa;
 }
 
-.list-filter .filter-item input[type="checkbox"] {
+:is(.list-filter, .list-editor) .filter-item input[type="checkbox"] {
   width: 16px;
   height: 16px;
   border-radius: 5px;
@@ -181,16 +181,16 @@
   flex-shrink: 0;
 }
 
-.list-filter .filter-item input[type="checkbox"]:checked {
+:is(.list-filter, .list-editor) .filter-item input[type="checkbox"]:checked {
   background: #5e6a75;
   border-color: #5e6a75;
 }
 
-.list-filter .filter-item input[type="checkbox"]:focus {
+:is(.list-filter, .list-editor) .filter-item input[type="checkbox"]:focus {
   outline: none;
 }
 
-.list-filter .filter-label {
+:is(.list-filter, .list-editor) .filter-label {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -202,12 +202,12 @@
 }
 
 /* Estilos para opções de usuário com avatar */
-.list-filter .user-option {
+:is(.list-filter, .list-editor) .user-option {
   display: flex;
   align-items: center;
   gap: 8px;
 }
-.list-filter .avatar-outer {
+:is(.list-filter, .list-editor) .avatar-outer {
   width: 24px;
   height: 24px;
   border-radius: 50%;
@@ -218,7 +218,7 @@
   background: #fff;
   flex-shrink: 0;
 }
-.list-filter .avatar-middle {
+:is(.list-filter, .list-editor) .avatar-middle {
   width: 22px;
   height: 22px;
   border-radius: 50%;
@@ -228,7 +228,7 @@
   justify-content: center;
   background: #fff;
 }
-.list-filter .user-avatar {
+:is(.list-filter, .list-editor) .user-avatar {
   width: 18px;
   height: 18px;
   border-radius: 50%;
@@ -238,13 +238,13 @@
   justify-content: center;
   overflow: hidden;
 }
-.list-filter .user-avatar img {
+:is(.list-filter, .list-editor) .user-avatar img {
   width: 100%;
   height: 100%;
   object-fit: cover;
   border-radius: 50%;
 }
-.list-filter .user-initial {
+:is(.list-filter, .list-editor) .user-initial {
   width: 100%;
   height: 100%;
   display: flex;

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -44,8 +44,17 @@
     init(params) {
       this.params = params;
       this.eGui = document.createElement('div');
-      this.eGui.style.width = '100%';
-      this.eGui.style.height = '100%';
+      this.eGui.className = 'list-editor';
+      this.eGui.innerHTML = `
+        <div class="field-search">
+          <input type="text" class="search-input" placeholder="Search..." />
+          <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
+        </div>
+        <div class="filter-list"></div>
+      `;
+      this.searchInput = this.eGui.querySelector('.search-input');
+      this.listEl = this.eGui.querySelector('.filter-list');
+
       let optionsArr = [];
       if (Array.isArray(params.colDef.options)) {
         optionsArr = params.colDef.options;
@@ -65,32 +74,113 @@
           .split(',')
           .map(o => o.trim());
       }
-      this.options = optionsArr.map(opt => typeof opt === 'object' ? opt : { value: opt, label: String(opt) });
+      this.options = optionsArr.map(opt =>
+        typeof opt === 'object' ? opt : { value: opt, label: String(opt) }
+      );
+      this.filteredOptions = [...this.options];
       this.value = params.value;
-      const select = document.createElement('select');
-      select.style.width = '100%';
-      select.style.height = '100%';
-      select.style.fontSize = '13px';
-      select.style.borderRadius = '6px';
-      select.style.padding = '4px';
-      this.options.forEach(opt => {
-        const option = document.createElement('option');
-        option.value = opt.value;
-        option.innerHTML = opt.label;
-        if (opt.value == this.value) option.selected = true;
-        select.appendChild(option);
+
+      this.searchInput.addEventListener('input', e => {
+        this.filterOptions(e.target.value);
       });
-      select.addEventListener('change', e => {
-        this.value = e.target.value;
+
+      this.renderOptions();
+    }
+    filterOptions(text) {
+      const t = text.toLowerCase();
+      this.filteredOptions = this.options.filter(opt => {
+        const label = this.stripHtml(String(this.formatOption(opt)));
+        return label.toLowerCase().includes(t);
       });
-      this.eGui.appendChild(select);
-      this.select = select;
+      this.renderOptions();
+    }
+    stripHtml(html) {
+      const tmp = document.createElement('div');
+      tmp.innerHTML = html;
+      return tmp.textContent || tmp.innerText || '';
+    }
+    getRoundedSpanColor(value, colorArray, fieldName) {
+      if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+      const matchingStyle = colorArray.find(item => item.Valor === value);
+      if (!matchingStyle) return value;
+      const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+      const fontweight = 'font-weight:bold;';
+      return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+    }
+    dateFormatter(dateValue, lang) {
+      try {
+        if (!dateValue) return '';
+        const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+        const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+        const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(
+          new Date(dateValue)
+        );
+        const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(
+          new Date(dateValue)
+        );
+        return `${datePart} ${timePart}`;
+      } catch (error) {
+        return dateValue;
+      }
+    }
+    formatOption(opt) {
+      const value = opt.label != null ? opt.label : opt.value;
+      const colDef = this.params.colDef || {};
+      const params = colDef.cellRendererParams || {};
+      try {
+        if (params.useCustomFormatter && typeof params.formatter === 'string') {
+          const fn = new Function(
+            'value',
+            'row',
+            'colDef',
+            'getRoundedSpanColor',
+            'dateFormatter',
+            params.formatter
+          );
+          return fn(
+            value,
+            {},
+            colDef,
+            this.getRoundedSpanColor.bind(this),
+            this.dateFormatter.bind(this)
+          );
+        } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+          const styled = this.getRoundedSpanColor(
+            value,
+            params.styleArray,
+            colDef.FieldDB
+          );
+          if (styled) return styled;
+        }
+      } catch (e) {
+        console.error('Format option error', e);
+      }
+      return value;
+    }
+    renderOptions() {
+      this.listEl.innerHTML = this.filteredOptions
+        .map(opt => {
+          const formatted = this.formatOption(opt);
+          const selected = opt.value == this.value ? ' selected' : '';
+          return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+        })
+        .join('');
+      this.listEl.querySelectorAll('.filter-item').forEach(el => {
+        el.addEventListener('click', () => {
+          this.value = el.getAttribute('data-value');
+          if (this.params.api && this.params.api.stopEditing) {
+            this.params.api.stopEditing();
+          } else if (this.params.stopEditing) {
+            this.params.stopEditing();
+          }
+        });
+      });
     }
     getGui() { return this.eGui; }
-    afterGuiAttached() { if (this.select) this.select.focus(); }
+    afterGuiAttached() { if (this.searchInput) this.searchInput.focus(); }
     getValue() { return this.value; }
     destroy() {}
-    isPopup() { return false; }
+    isPopup() { return true; }
   }
   import './components/list-filter.css';
   
@@ -764,7 +854,8 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             cellRenderer: ((tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') ? "UserCellRenderer" : (colCopy.useCustomFormatter ? 'FormatterCellRenderer' : undefined)),
             cellRendererParams: {
               useCustomFormatter: colCopy.useCustomFormatter,
-              formatter: colCopy.formatter
+              formatter: colCopy.formatter,
+              // options will be added below when available
             }
           };
           const fieldKey = colCopy.id || colCopy.field;
@@ -779,17 +870,27 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
               : Array.isArray(colCopy.listOptions)
               ? colCopy.listOptions
               : dsOptions;
-            if (optionsArr.length) {
+            if (optionsArr.length && colCopy.editable) {
               result.editable = true;
               result.cellEditor = ListCellEditor;
               result.options = optionsArr;
+              result.cellRendererParams = {
+                ...result.cellRendererParams,
+                options: optionsArr,
+              };
             }
           }
           // Editor fixo quando a coluna possui dataSource
-          if (colCopy.dataSource && dsOptions.length) {
+          if (colCopy.dataSource && dsOptions.length && colCopy.editable) {
             result.editable = true;
             result.cellEditor = FixedListCellEditor;
             result.listOptions = dsOptions;
+            if (!result.cellRendererParams.options) {
+              result.cellRendererParams = {
+                ...result.cellRendererParams,
+                options: dsOptions,
+              };
+            }
           }
           return result;
         }
@@ -856,7 +957,8 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                 cellRenderer: colCopy.useCustomFormatter ? 'FormatterCellRenderer' : undefined,
                 cellRendererParams: {
                   useCustomFormatter: colCopy.useCustomFormatter,
-                  formatter: colCopy.formatter
+                  formatter: colCopy.formatter,
+                  // options will be added below when available
                 },
                 editable: false,
                 cellEditor: ListCellEditor,
@@ -866,7 +968,7 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                   ? colCopy.listOptions
                   : dsOptions,
               };
-              if (result.options && result.options.length) {
+              if (result.options && result.options.length && colCopy.editable) {
                 result.editable = true;
               }
               return result;
@@ -912,19 +1014,24 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             if (colCopy.textAlign) {
               baseCellStyle = params => ({ textAlign: colCopy.textAlign });
             }
-            // Cursor pointer para TicketNumber
-            if (colCopy.FieldDB === 'TicketNumber') {
+            // Cursor pointer para colunas editáveis
+            if (colCopy.cursor) {
+              const prevCellStyle = baseCellStyle;
+              baseCellStyle = params => ({
+                ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
+                cursor: colCopy.cursor
+              });
+            } else if (colCopy.editable) {
               const prevCellStyle = baseCellStyle;
               baseCellStyle = params => ({
                 ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
                 cursor: 'pointer'
               });
-            } else if (colCopy.cursor) {
-              // Adicionar cursor customizado se definido
+            } else if (colCopy.FieldDB === 'TicketNumber') {
               const prevCellStyle = baseCellStyle;
               baseCellStyle = params => ({
                 ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
-                cursor: colCopy.cursor
+                cursor: 'pointer'
               });
             }
             if (baseCellStyle) {
@@ -1048,18 +1155,28 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                 : Array.isArray(colCopy.listOptions)
                 ? colCopy.listOptions
                 : dsOptions;
-              if (optionsArr.length) {
+              if (optionsArr.length && colCopy.editable) {
                 result.editable = true;
                 result.cellEditor = ListCellEditor;
                 result.options = optionsArr;
+                result.cellRendererParams = {
+                  ...result.cellRendererParams,
+                  options: optionsArr,
+                };
               }
               // O cellRenderer já aplica a formatação visual
             }
             // Editor fixo quando a coluna possui dataSource
-            if (colCopy.dataSource && dsOptions.length) {
+            if (colCopy.dataSource && dsOptions.length && colCopy.editable) {
               result.editable = true;
               result.cellEditor = FixedListCellEditor;
               result.listOptions = dsOptions;
+              if (!result.cellRendererParams.options) {
+                result.cellRendererParams = {
+                  ...result.cellRendererParams,
+                  options: dsOptions,
+                };
+              }
             }
             return result;
           }


### PR DESCRIPTION
## Summary
- update list filter styles to share them with the new editor
- add a searchable dropdown editor for list cells
- integrate the improved editor into `wwElement.vue`
- show list labels in cells by passing options to cell renderer
- respect `editable` flag in column config and add pointer cursor for editable cells

## Testing
- `npm test` *(fails: missing package.json)*
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6883f8ad9aa0833088a9fe772586ab2a