### PR TITLE
Fix responsible user display

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1317,7 +1317,18 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
         event.data.ResponsibleUser = match.label || event.data.ResponsibleUser;
         if (match.photo || match.image || match.img) {
           event.data.PhotoUrl = match.photo || match.image || match.img;
+        } else {
+          // When the selected user has no photo, clear any existing one so the
+          // avatar with the initial is displayed
+          event.data.PhotoUrl = '';
         }
+      }
+      if (this.gridApi && event.node) {
+        this.gridApi.refreshCells({
+          rowNodes: [event.node],
+          columns: [fieldKey],
+          force: true
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary
- clear `PhotoUrl` when the selected user has no photo so the avatar switches to initials

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688409f54db08330af8ca5d659accacc