### PR TITLE
Fix deadline refresh on edit

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1034,7 +1034,10 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             // Handle date columns that are editable
             if (colCopy.cellDataType === 'dateString' && colCopy.editable) {
               result.cellDataType = 'dateString';
-              result.cellEditor = 'agDateStringCellEditor';
+              // Use the custom datetime editor for all date fields
+              result.cellEditor = DateTimeCellEditor;
+              // Ensure the raw string from the editor is kept as-is
+              result.valueParser = params => params.newValue;
             }
             // Add text alignment style for cells
             let baseCellStyle = undefined;
@@ -1094,6 +1097,8 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
               if (colCopy.editable) {
                 // use the class directly to avoid lookup issues
                 result.cellEditor = DateTimeCellEditor;
+                // Keep the returned datetime string without further parsing
+                result.valueParser = params => params.newValue;
               }
               result.cellRenderer = params => {
                 // Função utilitária para calcular diff e cor (idêntica ao FieldComponent.vue)
@@ -1351,6 +1356,21 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
         }
       }
       if (this.gridApi && event.node) {
+        this.gridApi.refreshCells({
+          rowNodes: [event.node],
+          columns: [fieldKey],
+          force: true
+        });
+      }
+    }
+  }
+  if (tag === 'DEADLINE' || colDef.cellDataType === 'dateString') {
+    const fieldKey = colDef.colId || colDef.field;
+    if (event.node && fieldKey) {
+      // Explicitly update the underlying data in case the grid does not
+      // automatically set the value from the editor
+      event.node.setDataValue(fieldKey, event.newValue);
+      if (this.gridApi) {
         this.gridApi.refreshCells({
           rowNodes: [event.node],
           columns: [fieldKey],


### PR DESCRIPTION
## Summary
- explicitly update row data when datetime fields change
- refresh cell after setting value so updates appear immediately

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6884f5adfc1c833084789480b74b34a0