### PR TITLE
Add reset filters action to GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1342,6 +1342,11 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
       this.gridApi.deselectAll();
     }
   },
+  resetFilters() {
+    if (this.gridApi) {
+      this.gridApi.setFilterModel(null);
+    }
+  },
   getRowId(params) {
   return this.resolveMappingFormula(this.content.idFormula, params.data);
   },

--- a/Project/GridViewDinamica/ww-config.js
+++ b/Project/GridViewDinamica/ww-config.js
@@ -147,6 +147,11 @@ export default {
     label: { en: 'Deselect All Rows' },
     args: []
   },
+  {
+    action: 'resetFilters',
+    label: { en: 'Reset Filters' },
+    args: []
+  },
   ],
   properties: {
   headerTitle: {


### PR DESCRIPTION
## Summary
- add a `resetFilters` action to GridViewDinamica configuration
- implement `resetFilters` method in the component to clear all filters

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6887ad2c484c833090cba6382862af55