### PR TITLE
Add close button to list editors

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -4,6 +4,7 @@ export default class FixedListCellEditor {
     this.eGui = document.createElement('div');
     this.eGui.className = 'list-editor';
     this.eGui.innerHTML = `
+      <span class="editor-close">&times;</span>
       <div class="field-search">
         <input type="text" class="search-input" placeholder="Search..." />
         <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
@@ -12,6 +13,7 @@ export default class FixedListCellEditor {
     `;
     this.searchInput = this.eGui.querySelector('.search-input');
     this.listEl = this.eGui.querySelector('.filter-list');
+    this.closeBtn = this.eGui.querySelector('.editor-close');
 
 
     const tag =
@@ -53,6 +55,16 @@ export default class FixedListCellEditor {
     this.searchInput.addEventListener('input', e => {
       this.filterOptions(e.target.value);
     });
+
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener('click', () => {
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing(true);
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing(true);
+        }
+      });
+    }
 
     this.renderOptions();
   }

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -4,6 +4,7 @@ export default class ListCellEditor {
     this.eGui = document.createElement('div');
     this.eGui.className = 'list-editor';
     this.eGui.innerHTML = `
+      <span class="editor-close">&times;</span>
       <div class="field-search">
         <input type="text" class="search-input" placeholder="Search..." />
         <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
@@ -12,6 +13,7 @@ export default class ListCellEditor {
     `;
     this.searchInput = this.eGui.querySelector('.search-input');
     this.listEl = this.eGui.querySelector('.filter-list');
+    this.closeBtn = this.eGui.querySelector('.editor-close');
 
     const tag =
       (params.colDef.TagControl ||
@@ -51,6 +53,16 @@ export default class ListCellEditor {
     this.searchInput.addEventListener('input', e => {
       this.filterOptions(e.target.value);
     });
+
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener('click', () => {
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing(true);
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing(true);
+        }
+      });
+    }
 
     this.renderOptions();
   }

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -257,3 +257,13 @@
   border-radius: 50%;
   letter-spacing: 0.5px;
 }
+
+:is(.list-filter, .list-editor) .editor-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  font-size: 16px;
+  color: #888;
+  cursor: pointer;
+  line-height: 1;
+}

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -46,6 +46,7 @@
       this.eGui = document.createElement('div');
       this.eGui.className = 'list-editor';
       this.eGui.innerHTML = `
+        <span class="editor-close">&times;</span>
         <div class="field-search">
           <input type="text" class="search-input" placeholder="Search..." />
           <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
@@ -54,6 +55,7 @@
       `;
       this.searchInput = this.eGui.querySelector('.search-input');
       this.listEl = this.eGui.querySelector('.filter-list');
+      this.closeBtn = this.eGui.querySelector('.editor-close');
 
       let optionsArr = [];
       if (Array.isArray(params.colDef.options)) {
@@ -83,6 +85,16 @@
       this.searchInput.addEventListener('input', e => {
         this.filterOptions(e.target.value);
       });
+
+      if (this.closeBtn) {
+        this.closeBtn.addEventListener('click', () => {
+          if (this.params.api && this.params.api.stopEditing) {
+            this.params.api.stopEditing(true);
+          } else if (this.params.stopEditing) {
+            this.params.stopEditing(true);
+          }
+        });
+      }
 
       this.renderOptions();
     }


### PR DESCRIPTION
## Summary
- add close button to ListCellEditor and FixedListCellEditor
- wire the button to cancel editing
- style the new button via `list-filter.css`
- expose the button in `wwElement.vue`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888182b9fa08330a49e0a2944d368f0