### PR TITLE
Add header visibility option to FormBuilder

### DIFF
--- a/Project/FormBuilder/Component/ww-config.js
+++ b/Project/FormBuilder/Component/ww-config.js
@@ -38,6 +38,22 @@ export default {
     }
     /* wwEditor:end */
     },
+    showCabecalhoFormBuilder: {
+    label: { en: 'Show Form Header' },
+    type: 'OnOff',
+    section: 'settings',
+    bindable: true,
+    defaultValue: true,
+    /* wwEditor:start */
+    bindingValidation: {
+    type: 'boolean',
+    tooltip: 'Show or hide the form builder header section'
+    },
+    propertyHelp: {
+    tooltip: 'Toggle visibility of the header area above the form builder'
+    }
+    /* wwEditor:end */
+    },
     fieldsJson: {
     label: { en: 'Fields JSON' },
     type: 'Text',

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -53,7 +53,7 @@ v-for="field in filteredAvailableFields"
 
 <!-- Form Builder Section -->
 <div class="form-builder">
-<div class="cabecalhoFormBuilder">
+<div v-if="content.showCabecalhoFormBuilder" class="cabecalhoFormBuilder">
 <div class="inputCabecalhoDiv">
 <input type="text" :value="translateText('Insert text')" class="inputCabecalho"/>
 </div>


### PR DESCRIPTION
## Summary
- allow toggling the form header
- expose new property in ww-config

## Testing
- `npm run build` *(fails: weweb not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888c6517940833099a6efe327e9dbcc