### PR TITLE
Add header HTML option to FormBuilder

### DIFF
--- a/Project/FormBuilder/Component/AI.md
+++ b/Project/FormBuilder/Component/AI.md
@@ -39,6 +39,7 @@ This component provides a complete form building system that combines available 
 ***Properties:***
 - availableFieldsTitle: string - Custom heading for the available fields container
 - formBuilderTitle: string - Custom heading for the form builder container
+- cabecalhoHtml: string - HTML content displayed inside the form header
 - fieldsJson: string - JSON string containing field definitions
 - defaultFields: array - Default fields to show when no JSON is provided
 - formJson: string - JSON string containing form definition with sections

--- a/Project/FormBuilder/Component/ww-config.js
+++ b/Project/FormBuilder/Component/ww-config.js
@@ -39,26 +39,42 @@ export default {
     /* wwEditor:end */
     },
     showCabecalhoFormBuilder: {
-    label: { en: 'Show Form Header' },
-    type: 'OnOff',
-    section: 'settings',
-    bindable: true,
-    defaultValue: true,
+        label: { en: 'Show Form Header' },
+        type: 'OnOff',
+        section: 'settings',
+        bindable: true,
+        defaultValue: true,
     /* wwEditor:start */
     bindingValidation: {
     type: 'boolean',
     tooltip: 'Show or hide the form builder header section'
     },
-    propertyHelp: {
-    tooltip: 'Toggle visibility of the header area above the form builder'
-    }
-    /* wwEditor:end */
-    },
-    fieldsJson: {
-    label: { en: 'Fields JSON' },
-    type: 'Text',
-    section: 'settings',
-    bindable: true,
+        propertyHelp: {
+        tooltip: 'Toggle visibility of the header area above the form builder'
+        }
+        /* wwEditor:end */
+        },
+        cabecalhoHtml: {
+            label: { en: 'Header HTML' },
+            type: 'Text',
+            section: 'settings',
+            bindable: true,
+            defaultValue: '',
+            /* wwEditor:start */
+            bindingValidation: {
+            type: 'string',
+            tooltip: 'HTML content to display inside the form header'
+            },
+            propertyHelp: {
+            tooltip: 'Custom HTML markup for the header area of the form builder'
+            }
+            /* wwEditor:end */
+        },
+        fieldsJson: {
+        label: { en: 'Fields JSON' },
+        type: 'Text',
+        section: 'settings',
+        bindable: true,
     defaultValue: '',
     /* wwEditor:start */
     bindingValidation: {

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -53,8 +53,7 @@ v-for="field in filteredAvailableFields"
 
 <!-- Form Builder Section -->
 <div class="form-builder">
-<div v-if="content.showCabecalhoFormBuilder" class="cabecalhoFormBuilder">
-
+<div v-if="content.showCabecalhoFormBuilder" class="cabecalhoFormBuilder" v-html="content.cabecalhoHtml">
 
 </div>
 <div style="display: flex; width:100%; justify-content:end; align-items:end; height:50px; padding:12px">


### PR DESCRIPTION
## Summary
- allow custom HTML for FormBuilder header via new property `cabecalhoHtml`
- render the provided HTML inside the header
- document the new property in the component docs

## Testing
- `npm run build` *(fails: `weweb` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cb87fd10833089c2a1ff926d7f3d