### PR TITLE
Add header HTML option to FormBuilder

### DIFF
--- a/Project/FormBuilder/Component/AI.md
+++ b/Project/FormBuilder/Component/AI.md
@@ -39,6 +39,7 @@ This component provides a complete form building system that combines available 
 ***Properties:***
 - availableFieldsTitle: string - Custom heading for the available fields container
 - formBuilderTitle: string - Custom heading for the form builder container
+- cabecalhoHtml: string - HTML content displayed inside the form header
 - fieldsJson: string - JSON string containing field definitions
 - defaultFields: array - Default fields to show when no JSON is provided
 - formJson: string - JSON string containing form definition with sections

--- a/Project/FormBuilder/Component/ww-config.js
+++ b/Project/FormBuilder/Component/ww-config.js
@@ -39,26 +39,42 @@ export default {
     /* wwEditor:end */
     },
     showCabecalhoFormBuilder: {
-    label: { en: 'Show Form Header' },
-    type: 'OnOff',
-    section: 'settings',
-    bindable: true,
-    defaultValue: true,
+        label: { en: 'Show Form Header' },
+        type: 'OnOff',
+        section: 'settings',
+        bindable: true,
+        defaultValue: true,
     /* wwEditor:start */
     bindingValidation: {
     type: 'boolean',
     tooltip: 'Show or hide the form builder header section'
     },
-    propertyHelp: {
-    tooltip: 'Toggle visibility of the header area above the form builder'
-    }
-    /* wwEditor:end */
-    },
-    fieldsJson: {
-    label: { en: 'Fields JSON' },
-    type: 'Text',
-    section: 'settings',
-    bindable: true,
+        propertyHelp: {
+        tooltip: 'Toggle visibility of the header area above the form builder'
+        }
+        /* wwEditor:end */
+        },
+        cabecalhoHtml: {
+            label: { en: 'Header HTML' },
+            type: 'Text',
+            section: 'settings',
+            bindable: true,
+            defaultValue: '',
+            /* wwEditor:start */
+            bindingValidation: {
+            type: 'string',
+            tooltip: 'HTML content to display inside the form header'
+            },
+            propertyHelp: {
+            tooltip: 'Custom HTML markup for the header area of the form builder'
+            }
+            /* wwEditor:end */
+        },
+        fieldsJson: {
+        label: { en: 'Fields JSON' },
+        type: 'Text',
+        section: 'settings',
+        bindable: true,
     defaultValue: '',
     /* wwEditor:start */
     bindingValidation: {

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -53,8 +53,7 @@ v-for="field in filteredAvailableFields"
 
 <!-- Form Builder Section -->
 <div class="form-builder">
-<div v-if="content.showCabecalhoFormBuilder" class="cabecalhoFormBuilder">
-
+<div v-if="content.showCabecalhoFormBuilder" class="cabecalhoFormBuilder" v-html="content.cabecalhoHtml">
 
 </div>
 <div style="display: flex; width:100%; justify-content:end; align-items:end; height:50px; padding:12px">
@@ -1448,9 +1447,10 @@ vertical-align: middle;
 width: 375px;
 }
 
-.inputCabecalhoDiv {
-width: 100%;
-height: 32px;
+
+:deep(.inputCabecalhoDiv) {
+    width: 100%;
+    height: 32px;
 }
 
 .cabecalhoFormBuilder
@@ -1463,9 +1463,8 @@ height: 32px;
     border-bottom: 1px solid rgb(218, 220, 222);  
 }
 
-.inputCabecalho
-{
-        font-size: 1.25rem;
+:deep(.inputCabecalho) {
+    font-size: 1.25rem;
     font-family: Roboto-Light, "Open Sans", Arial, sans-serif;
     border-radius: 4px;
     height: 30px;
@@ -1475,24 +1474,25 @@ height: 32px;
     border: 1px solid transparent;
     padding: 4px 8px;
     background: transparent;
-    width:100%;
+    width: 100%;
     color: rgb(79, 79, 79);
     padding-block: 3px;
     padding-inline: 4px;
 }
-.inputCabecalho:hover{
-    background-color:#dedede;
+
+:deep(.inputCabecalho:hover) {
+    background-color: #dedede;
 }
 
-.inputCabecalho:focus{
-    background-color:transparent;
+:deep(.inputCabecalho:focus) {
+    background-color: transparent;
     border: 1px solid rgb(79, 79, 79);
     outline: none;
 }
 
-.elementsformBuilderTop
-{
-        width: 100%;
+
+:deep(.elementsformBuilderTop) {
+    width: 100%;
     display: flex;
     -webkit-box-align: center;
     align-items: center;
@@ -1502,8 +1502,9 @@ height: 32px;
     column-gap: 24px;
 }
 
-.css-fvhee8 .header-footer-div{
-        width: 50%;
+
+:deep(.css-fvhee8 .header-footer-div) {
+    width: 50%;
     gap: 8px;
     display: flex;
     -webkit-box-align: center;
@@ -1513,12 +1514,11 @@ height: 32px;
     overflow: hidden;
 }
 
-.css-fvhee8 .header-footer-div > div.template-header
-{
-    max-width:23%;
+:deep(.css-fvhee8 .header-footer-div > div.template-header) {
+    max-width: 23%;
 }
 
-.status-header-display {
+:deep(.status-header-display) {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -1528,12 +1528,12 @@ height: 32px;
   font-size: 14px;
 }
 
-.status-tags {
+:deep(.status-tags) {
   display: flex;
   gap: 8px;
 }
 
-.tag {
+:deep(.tag) {
   border: 1px solid #c0c0c0;
   border-radius: 999px;
   padding: 4px 12px;
@@ -1543,13 +1543,13 @@ height: 32px;
   font-size: 13px;
 }
 
-.status-user {
+:deep(.status-user) {
   display: flex;
   align-items: center;
   gap: 16px;
 }
 
-.user-info {
+:deep(.user-info) {
   display: flex;
   align-items: center;
   gap: 6px;
@@ -1557,7 +1557,7 @@ height: 32px;
   font-size: 14px;
 }
 
-.user-icon {
+:deep(.user-icon) {
   width: 24px;
   height: 24px;
   display: inline-flex;
@@ -1569,7 +1569,7 @@ height: 32px;
   font-size: 14px;
 }
 
-.status-label {
+:deep(.status-label) {
   background-color: #5c74a4;
   color: #fff;
   padding: 4px 12px;


### PR DESCRIPTION
## Summary
- allow custom HTML for FormBuilder header via new property `cabecalhoHtml`
- render the provided HTML inside the header
- document the new property in the component docs
- ensure header HTML classes work with scoped styles

## Testing
- `npm run build` *(fails: `weweb` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cb87fd10833089c2a1ff926d7f3d