### PR TITLE
Fix FormBuilder overflow

### DIFF
--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -1232,12 +1232,16 @@ flex-direction: row;
 }
 
 .form-builder {
-width: 100%;
-border: 1px solid #e0e0e0;
-border-radius: 8px;
-background-color: #fff;
-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-
+    width: 100%;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background-color: #fff;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    flex: 1;
+    overflow-y: auto;
 }
 
 .field-definition-container{


### PR DESCRIPTION
## Summary
- add flex container height and overflow to keep sections inside the form builder

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6889046b57148330bd4bccaa93a1d50f