### PR TITLE
Ensure default section when input sections are null

### DIFF
--- a/Project/FormBuilderCadastros/Component/wwElement.vue
+++ b/Project/FormBuilderCadastros/Component/wwElement.vue
@@ -609,8 +609,27 @@ if (typeof window !== 'undefined') {
 window.FormFieldsJsonSave = data;
 }
 
-// Convert sections array to the format expected by the component
-formSections.value = data.sections || [];
+  // Convert sections array to the format expected by the component
+  const rawSections = Array.isArray(data.sections) ? [...data.sections] : [];
+  formSections.value = rawSections.filter(
+    (section) => section && typeof section === 'object'
+  );
+
+  const createEmptySection = () => ({
+    id: `section-${Date.now()}`,
+    title: { [currentLang.value]: translateText('New section') },
+    position: 1,
+    deleted: false,
+    fields: []
+  });
+
+  // Ensure at least one valid section exists
+  if (formSections.value.length === 0) {
+    formSections.value.push(createEmptySection());
+  }
+
+// Keep data.sections in sync
+data.sections = [...formSections.value];
 setFormData(data);
 } catch (error) {
 console.error('Error loading form data:', error);


### PR DESCRIPTION
## Summary
- handle null sections in `loadFormData`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688922a41e8483308ab9f7493da9149f