### PR TITLE
Fix onMove null reference

### DIFF
--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -414,28 +414,31 @@ console.error('Error updating sections order:', error);
 },
 fallbackOnBody: false,
 forceFallback: false,
-onMove: (evt) => {
-// Verifica se o elemento relacionado existe e está conectado ao DOM
-if (!evt.related || !evt.related.parentNode) {
-return false;
-}
+            onMove: (evt) => {
+              // Defensive checks to prevent errors when dragging
+              if (!evt || !evt.to) return false;
 
-// Verifica se o elemento está sendo movido para um container válido
-const targetContainer = evt.to;
-if (!targetContainer || !targetContainer.isConnected) {
-return false;
-}
+              // Verifica se o elemento relacionado existe e está conectado ao DOM
+              if (!evt.related || !evt.related.parentNode) {
+                return false;
+              }
 
-// Verifica se o elemento tem filhos antes de tentar acessar lastElementChild
-if (targetContainer.children && targetContainer.children.length > 0) {
-const lastChild = targetContainer.lastElementChild;
-if (!lastChild || !lastChild.isConnected) {
-return false;
-}
-}
+              // Verifica se o container de destino é válido
+              const targetContainer = evt.to;
+              if (!targetContainer || !targetContainer.isConnected) {
+                return false;
+              }
 
-return true;
-}
+              // Só verifica o último filho se existir
+              if (targetContainer.children && targetContainer.children.length > 0) {
+                const lastChild = targetContainer.lastElementChild;
+                if (!lastChild || !lastChild.isConnected) {
+                  return false;
+                }
+              }
+
+              return true;
+            }
 });
 
 // Inicializa o Sortable para cada container de campos


### PR DESCRIPTION
## Summary
- add defensive checks in FormBuilder's onMove handler

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688971d3bf0483308f6249161c015a90