### PR TITLE
Update CADASTROSFormRender value handling

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -484,7 +484,6 @@ export default {
         if (isChanged) {
           this.localValue = value;
           this.$emit('update:value', value);
-          await this.saveFieldValueToApi(value);
           this.originalValue = value;
         }
       }

--- a/Project/CADASTROSFormRender/Component/wwElement.vue
+++ b/Project/CADASTROSFormRender/Component/wwElement.vue
@@ -21,7 +21,7 @@
               :api-authorization="apiAuthorization" :ticket-id="ticketId" :company-id="companyId" :language="language"
               @update-section="updateFormState" @edit-section="editSection" @edit-field="editFormField"
               @remove-field="removeFormField" @select-field="selectFieldForProperties"
-              @remove-section="handleRemoveSection" />
+              @remove-section="handleRemoveSection" @update:value="updateFieldValue" />
           </div>
         </template>
       </div>
@@ -264,6 +264,17 @@ export default {
       }
     };
 
+    const updateFieldValue = ({ fieldId, value }) => {
+      const section = formSections.value.find(s => s.fields.some(f => f.id === fieldId));
+      if (section) {
+        const field = section.fields.find(f => f.id === fieldId);
+        if (field) {
+          field.value = value;
+          updateFormState();
+        }
+      }
+    };
+
     const selectFieldForProperties = (field) => {
     };
 
@@ -314,6 +325,7 @@ export default {
       allAvailableFields,
       editFormField,
       removeFormField,
+      updateFieldValue,
       selectFieldForProperties,
       editSection,
       handleRemoveSection,


### PR DESCRIPTION
## Summary
- stop saving field value via API in CADASTROSFormRender
- update form data locally when field value changes

## Testing
- `npm run build` *(fails: `weweb: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6889efa36dec8330a3055fc53117d5bd