### PR TITLE
Add scroll height option to CADASTROSFormRender

### DIFF
--- a/Project/CADASTROSFormRender/Component/ww-config.js
+++ b/Project/CADASTROSFormRender/Component/ww-config.js
@@ -257,6 +257,22 @@ export default {
                 tooltip: 'Set the user ID for the form'
             }
             /* wwEditor:end */
+        },
+        formHeight: {
+            label: { en: 'Form Height' },
+            type: 'Text',
+            section: 'settings',
+            bindable: true,
+            defaultValue: '',
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'Height of the form container (e.g., 400px, 60vh)'
+            },
+            propertyHelp: {
+                tooltip: 'Content above this height will scroll vertically'
+            }
+            /* wwEditor:end */
         }
     },
     triggerEvents: [

--- a/Project/CADASTROSFormRender/Component/wwElement.vue
+++ b/Project/CADASTROSFormRender/Component/wwElement.vue
@@ -1,8 +1,8 @@
 <template>
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
   <div class="form-builder-container">
-    <div class="form-builder">
-      <div class="form-sections-container scrollable" ref="formSectionsContainer">
+      <div class="form-builder">
+      <div class="form-sections-container scrollable" ref="formSectionsContainer" :style="formHeightStyle">
                 <!-- Estado de carregamento -->
         <div v-if="isLoading" class="loading-container">
           <div class="loading-spinner"></div>
@@ -95,6 +95,13 @@ export default {
     const ticketId = computed(() => props.ticketId || props.content.ticketId);
     const companyId = computed(() => props.content.companyId);
     const language = computed(() => props.content.language);
+
+    const formHeightStyle = computed(() => {
+      if (props.content.formHeight) {
+        return { maxHeight: props.content.formHeight };
+      }
+      return {};
+    });
 
     const loadFormData = () => {
       let formData = null;
@@ -338,7 +345,8 @@ export default {
       companyId,
       language,
       isLoading,
-      renderKey
+      renderKey,
+      formHeightStyle
     };
   }
 };


### PR DESCRIPTION
## Summary
- allow form height configuration in CADASTROSFormRender
- show new setting in ww-config

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_6889f8392f04833097dfba43827c3222