### PR TITLE
Fix dropdown position

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -647,7 +647,7 @@ export default {
             if (trigger && dropdown) {
               const scrollParent = this.getScrollParent(trigger);
               const triggerRect = trigger.getBoundingClientRect();
-              const dropdownHeight = 220; // max-height do dropdown
+              const dropdownHeight = Math.min(dropdown.scrollHeight, 220);
               let spaceBelow;
               if (scrollParent === document.body) {
                 spaceBelow = window.innerHeight - triggerRect.bottom;

--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -648,7 +648,7 @@ export default {
             if (trigger && dropdown) {
               const scrollParent = this.getScrollParent(trigger);
               const triggerRect = trigger.getBoundingClientRect();
-              const dropdownHeight = 220; // max-height do dropdown
+              const dropdownHeight = Math.min(dropdown.scrollHeight, 220);
               let spaceBelow;
               if (scrollParent === document.body) {
                 spaceBelow = window.innerHeight - triggerRect.bottom;


### PR DESCRIPTION
## Summary
- use `scrollHeight` to calculate dropdown height in CADASTROSFormRender
- apply the same fix to FormRender so dropdown opens upward when space below is insufficient

## Testing
- `npm run build` *(fails: `weweb` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889fcd6548c8330b804ee9b78d51850