### PR TITLE
Fix YES_NO parsing in Cadastros form

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -258,8 +258,8 @@ export default {
     parseBoolean(val) {
       if (typeof val === 'string') {
         const low = val.toLowerCase();
-        if (['true', '1', 'yes', 'sim'].includes(low)) return true;
-        if (['false', '0', 'no', 'nao', 'não'].includes(low)) return false;
+        if (['true', '1', 'yes', 'sim', 's', 'y'].includes(low)) return true;
+        if (['false', '0', 'no', 'nao', 'não', 'n'].includes(low)) return false;
       }
       return Boolean(val);
     },


### PR DESCRIPTION
## Summary
- ensure YES_NO fields recognize shorthand values

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b403ea49c8330832ca3a024609532