### PR TITLE
Fix YES_NO field initialization

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -271,10 +271,46 @@ export default {
       }
       return val ?? '';
     },
-    /* Demais métodos sem alteração */
+    updateValue(event) {
+      let value = event.target.value;
+      switch (this.field.fieldType) {
+        case 'DECIMAL':
+          value = value === '' ? null : parseFloat(value);
+          break;
+        case 'INTEGER':
+          value = value === '' ? null : parseInt(value, 10);
+          break;
+        case 'YES_NO':
+          value = this.parseBoolean(value);
+          break;
+        default:
+          break;
+      }
+      this.localValue = value;
+      this.$emit('update:value', value);
+    }
   },
-  mounted() { /* Sem alteração */ },
-  beforeDestroy() { /* Sem alteração */ }
+  mounted() {
+    if (this.field.fieldType === 'FORMATED_TEXT' && this.$refs.rte) {
+      this.$refs.rte.innerHTML = this.localValue || '';
+    }
+    if (this.field.fieldType === 'YES_NO') {
+      const parsed = this.parseBoolean(this.field.value);
+      this.localValue = parsed;
+      this.originalValue = parsed;
+    }
+    if (this.field.fieldType === 'DEADLINE') {
+      this.deadlineTimer = setInterval(() => {
+        this.dataNow = new Date();
+      }, 1000);
+    }
+  },
+  beforeDestroy() {
+    if (this.deadlineTimer) {
+      clearInterval(this.deadlineTimer);
+      this.deadlineTimer = null;
+    }
+  }
 };
 </script>
 


### PR DESCRIPTION
## Summary
- ensure YES_NO radio inputs show saved values
- send value updates from CADASTROSFormRender FieldComponent

## Testing
- `npm -v`


------
https://chatgpt.com/codex/tasks/task_e_688b43c390048330ba7996431c7c7a9e