### PR TITLE
Fix DropdownCategories initial selection updates

### DIFF
--- a/Project/DropdownCategories/src/components/ComponentSelector.vue
+++ b/Project/DropdownCategories/src/components/ComponentSelector.vue
@@ -191,11 +191,8 @@ export default {
     initialSelectedId: {
       immediate: true,
       handler(newId) {
-        // Só atualiza se não houver selectedComponentId definido
-        if (!this.selectedComponentId) {
-          const component = this.normalizedDatasource.find(u => String(u?.[this.valueField] || '') === String(newId));
-          this.selectedComponent = component || null;
-        }
+        const component = this.normalizedDatasource.find(u => String(u?.[this.valueField] || '') === String(newId));
+        this.selectedComponent = component || null;
       }
     },
     selectedComponent(newComponent) {

--- a/Project/DropdownCategories/src/wwElement.vue
+++ b/Project/DropdownCategories/src/wwElement.vue
@@ -70,6 +70,18 @@ export default {
             );
         }
     },
+    mounted() {
+        if (this.content.initialSelectedId) {
+            if (this._setSelectedComponentId) this._setSelectedComponentId(this.content.initialSelectedId);
+            this.selectedComponentId = this.content.initialSelectedId;
+        }
+    },
+    watch: {
+        'content.initialSelectedId'(newVal) {
+            if (this._setSelectedComponentId) this._setSelectedComponentId(newVal);
+            this.selectedComponentId = newVal;
+        }
+    },
     methods: {
         onComponentSelected(componentId) {
             if (this._setSelectedComponentId) this._setSelectedComponentId(componentId);


### PR DESCRIPTION
## Summary
- ensure `initialSelectedId` watch doesn't ignore updates
- sync `initialSelectedId` into the wrapper component state

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b90ac1c7c8330a3cec888434a9aa9