### PR TITLE
Prevent empty dropdown in input mode

### DIFF
--- a/Project/DropdownCategories/src/components/ComponentSelector.vue
+++ b/Project/DropdownCategories/src/components/ComponentSelector.vue
@@ -14,7 +14,7 @@
       />
       <span class="dropdown-arrow">&#9662;</span>
     </div>
-    <div v-if="isOpen" class="component-selector__dropdown">
+    <div v-if="isOpen && (!inputMode || filteredComponents.length > 0)" class="component-selector__dropdown">
       <div
         v-for="(component, idx) in filteredComponents"
         :key="component[valueField] || ('title-' + idx)"


### PR DESCRIPTION
## Summary
- hide the dropdown list container in `DropdownCategories` when the component is in input mode and there are no items to display

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688caa401d448330834c17d343c2b66a