### PR TITLE
fix: retain formatted text value on blur

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -319,7 +319,12 @@ export default {
       return val ?? '';
     },
     updateValue(event) {
-      let value = event.target.value;
+      let value;
+      if (this.field.fieldType === 'FORMATED_TEXT') {
+        value = this.localValue;
+      } else {
+        value = event.target.value;
+      }
       switch (this.field.fieldType) {
         case 'DECIMAL':
           value = value === '' ? null : parseFloat(value);
@@ -335,6 +340,9 @@ export default {
       }
       this.localValue = value;
       this.$emit('update:value', value);
+    },
+    onContentEditableInput(event) {
+      this.localValue = event.target.innerHTML;
     },
     toggleDropdown() {
       if (this.field.is_readonly) return;


### PR DESCRIPTION
## Summary
- keep FORMATED_TEXT contenteditable values from clearing on blur
- track rich text changes via onContentEditableInput

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689258937d708330b37c8b4f2d2da97c