### PR TITLE
fix: enable formatted text toolbar

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -344,6 +344,29 @@ export default {
     onContentEditableInput(event) {
       this.localValue = event.target.innerHTML;
     },
+    format(cmd) {
+      this.$refs.rte && this.$refs.rte.focus();
+      document.execCommand(cmd, false, null);
+    },
+    setColor(event) {
+      this.$refs.rte && this.$refs.rte.focus();
+      document.execCommand('foreColor', false, event.target.value);
+      this.currentColor = event.target.value;
+    },
+    insertLink() {
+      this.$refs.rte && this.$refs.rte.focus();
+      const url = prompt('Digite a URL do link:');
+      if (url) {
+        document.execCommand('createLink', false, url);
+      }
+    },
+    insertImage() {
+      this.$refs.rte && this.$refs.rte.focus();
+      const url = prompt('Digite a URL da imagem:');
+      if (url) {
+        document.execCommand('insertImage', false, url);
+      }
+    },
     toggleDropdown() {
       if (this.field.is_readonly) return;
       this.dropdownOpen = !this.dropdownOpen;


### PR DESCRIPTION
## Summary
- restore formatting toolbar for FORMATED_TEXT fields by defining missing methods

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68925af417388330a24c6f4cced54bc6