### PR TITLE
fix: retain selection when changing text color

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -149,7 +149,14 @@
             <button type="button" @click="insertImage" title="Inserir imagem"><span class="material-symbols-outlined">image</span></button>
             <button type="button" class="color-btn" :style="{ color: currentColor }" title="Cor do texto">
               <span style="font-weight:bold; font-size:16px;">A</span>
-              <input type="color" @input="setColor($event)" :value="currentColor" class="color-input" title="Cor do texto" />
+              <input
+                type="color"
+                @mousedown="saveSelection"
+                @input="setColor($event)"
+                :value="currentColor"
+                class="color-input"
+                title="Cor do texto"
+              />
             </button>
           </div>
           <div
@@ -220,6 +227,7 @@ export default {
       dataNow: new Date(),
       showDeadlinePicker: false,
       currentColor: '#699d8c',
+      savedSelection: null,
       isUserInput: false,
     };
   },
@@ -348,8 +356,21 @@ export default {
       this.$refs.rte && this.$refs.rte.focus();
       document.execCommand(cmd, false, null);
     },
+    saveSelection() {
+      const sel = window.getSelection();
+      if (sel && sel.rangeCount > 0) {
+        this.savedSelection = sel.getRangeAt(0);
+      }
+    },
     setColor(event) {
-      this.$refs.rte && this.$refs.rte.focus();
+      if (this.$refs.rte) {
+        this.$refs.rte.focus();
+      }
+      const sel = window.getSelection();
+      if (this.savedSelection && sel) {
+        sel.removeAllRanges();
+        sel.addRange(this.savedSelection);
+      }
       document.execCommand('foreColor', false, event.target.value);
       this.currentColor = event.target.value;
     },

--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -146,7 +146,14 @@
             <button type="button" @click="insertImage" title="Inserir imagem"><span class="material-symbols-outlined">image</span></button>
             <button type="button" class="color-btn" :style="{ color: currentColor }" title="Cor do texto">
               <span style="font-weight:bold; font-size:16px;">A</span>
-              <input type="color" @input="setColor($event)" :value="currentColor" class="color-input" title="Cor do texto" />
+              <input
+                type="color"
+                @mousedown="saveSelection"
+                @input="setColor($event)"
+                :value="currentColor"
+                class="color-input"
+                title="Cor do texto"
+              />
             </button>
           </div>
           <div
@@ -240,6 +247,7 @@ export default {
       dataNow: new Date(),
       showDeadlinePicker: false,
       currentColor: '#699d8c',
+      savedSelection: null,
       isUserInput: false,
     }
   },
@@ -632,8 +640,21 @@ export default {
       this.$refs.rte && this.$refs.rte.focus();
       document.execCommand(cmd, false, null);
     },
+    saveSelection() {
+      const sel = window.getSelection();
+      if (sel && sel.rangeCount > 0) {
+        this.savedSelection = sel.getRangeAt(0);
+      }
+    },
     setColor(event) {
-      this.$refs.rte && this.$refs.rte.focus();
+      if (this.$refs.rte) {
+        this.$refs.rte.focus();
+      }
+      const sel = window.getSelection();
+      if (this.savedSelection && sel) {
+        sel.removeAllRanges();
+        sel.addRange(this.savedSelection);
+      }
       document.execCommand('foreColor', false, event.target.value);
       this.currentColor = event.target.value;
     },


### PR DESCRIPTION
## Summary
- preserve selected text when picking a color in FORMATED_TEXT toolbar
- apply same fix to base FormRender component

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68925c8c7c288330877e9fa766933d16