### PR TITLE
feat: add grid-wide cursor option

### DIFF
--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -284,9 +284,23 @@ export default {
         const headerClass = headerAlign ? `ag-header-align-${headerAlign}` : undefined;
         const baseCellStyle = cellAlign ? { textAlign: cellAlign } : undefined;
 
+        const applyCursor = (result) => {
+          const cursor = this.content.cellCursor ?? col.cursor;
+          if (cursor) {
+            const userCellStyle = result.cellStyle;
+            result.cellStyle = (params) => ({
+              ...(typeof userCellStyle === 'function'
+                ? userCellStyle(params)
+                : userCellStyle || {}),
+              cursor,
+            });
+          }
+          return result;
+        };
+
         switch (col.cellDataType) {
           case "action": {
-            return {
+            const result = {
               ...commonProperties,
               headerName: col.headerName,
               cellRenderer: "ActionCellRenderer",
@@ -303,10 +317,11 @@ export default {
               headerClass,
               ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
             };
+            return applyCursor(result);
 
           }
-          case "custom":
-            return {
+          case "custom": {
+            const result = {
               ...commonProperties,
               headerName: col.headerName,
               field: col.field,
@@ -322,9 +337,11 @@ export default {
               headerClass,
               ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
             };
+            return applyCursor(result);
+          }
 
           case "image": {
-            return {
+            const result = {
               ...commonProperties,
               headerName: col.headerName,
               field: col.field,
@@ -338,10 +355,11 @@ export default {
               headerClass,
               ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
             };
-            
+            return applyCursor(result);
+
           }
           case "boolean": {
-            return {
+            const result = {
               ...commonProperties,
               headerName: col.headerName,
               field: col.field,
@@ -374,6 +392,7 @@ export default {
               headerClass,
               ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
             };
+            return applyCursor(result);
           }
           case "list":
           default: {
@@ -410,15 +429,8 @@ export default {
               console.log('Configurando filtro customizado para coluna:', col.headerName);
               result.filter = ListFilterRenderer;
             }
-            // Adicionar cursor customizado se definido
-            if (col.cursor) {
-              const userCellStyle = result.cellStyle;
-              result.cellStyle = params => ({
-                ...(typeof userCellStyle === 'function' ? userCellStyle(params) : userCellStyle || {}),
-                cursor: col.cursor
-              });
-            }
-            return result;
+
+            return applyCursor(result);
           }
         }
       });

--- a/Project/GridViewSimples/ww-config.js
+++ b/Project/GridViewSimples/ww-config.js
@@ -28,6 +28,7 @@ export default {
         "cellFontFamily",
         "cellFontSize",
         "cellSelectionBorderColor",
+        "cellCursor",
       ],
       ["menuTitle", "menuTextColor", "menuBackgroundColor"],
       [
@@ -377,6 +378,42 @@ export default {
         type: "string",
         cssSupports: "color",
       },
+    },
+    cellCursor: {
+      type: "TextSelect",
+      label: "Cursor",
+      options: {
+        options: [
+          { value: null, label: "Default", default: true },
+          { value: "default", label: "Default Cursor" },
+          { value: "pointer", label: "Pointer (mãozinha)" },
+          { value: "text", label: "Text (texto)" },
+          { value: "move", label: "Move (mover)" },
+          { value: "crosshair", label: "Crosshair (mira)" },
+          { value: "not-allowed", label: "Not Allowed (proibido)" },
+          { value: "help", label: "Help (ajuda)" },
+          { value: "wait", label: "Wait (aguarde)" },
+          { value: "progress", label: "Progress (progresso)" },
+          { value: "copy", label: "Copy (copiar)" },
+          { value: "grab", label: "Grab (pegar)" },
+          { value: "zoom-in", label: "Zoom In" },
+          { value: "zoom-out", label: "Zoom Out" }
+        ],
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "string",
+        tooltip: "Tipo de cursor ao passar o mouse sobre as células",
+      },
+      propertyHelp: {
+        tooltip:
+          "Defina o cursor do mouse para todas as células da grid. Se vazio, será usado o cursor de cada coluna.",
+      },
+      /* wwEditor:end */
     },
     columnHoverHighlight: {
       type: "OnOff",


### PR DESCRIPTION
## Summary
- add global `cellCursor` option to set cursor style for all cells
- apply grid-wide cursor with column-level fallback

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68947a8cc6208330bdaa65cf32aa98e9