### PR TITLE
feat: include field in row click event

### DIFF
--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -570,6 +570,7 @@ export default {
     onRowClicked(event) {
       const colId = event.column && event.column.getColId && event.column.getColId();
       const colDef = event.column && event.column.colDef;
+      const field = colDef && colDef.field;
       const clickedTarget = event.event && event.event.target;
       const clickedOnSelection =
         clickedTarget &&
@@ -595,6 +596,7 @@ export default {
           id: event.node.id,
           index: event.node.sourceRowIndex,
           displayIndex: event.rowIndex,
+          field,
         },
       });
     },
@@ -646,6 +648,7 @@ export default {
         id: 0,
         index: 0,
         displayIndex: 0,
+        field: Object.keys(data[0])[0],
       };
     },
     /* wwEditor:end */

--- a/Project/GridViewSimples/ww-config.js
+++ b/Project/GridViewSimples/ww-config.js
@@ -126,6 +126,7 @@ export default {
         id: 0,
         index: 0,
         displayIndex: 0,
+        field: "field",
       },
       getTestEvent: "getRowClickedTestEvent",
     },


### PR DESCRIPTION
## Summary
- expose clicked column field on rowClicked events in GridViewSimples
- document new field attribute in rowClicked event configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894800a5df88330a0899f55e787965e