### PR TITLE
Format calendar shift hours in AM/PM

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -21,32 +21,32 @@
             <td>
               <select v-model="day.shift1" :disabled="!day.active">
                 <option value=""></option>
-                <option v-for="hour in hours" :key="hour" :value="hour">
-                  {{ hour }}
+                <option v-for="hour in hours" :key="hour.value" :value="hour.value">
+                  {{ hour.label }}
                 </option>
               </select>
             </td>
             <td>
               <select v-model="day.shift2" :disabled="!day.active">
                 <option value=""></option>
-                <option v-for="hour in hours" :key="hour" :value="hour">
-                  {{ hour }}
+                <option v-for="hour in hours" :key="hour.value" :value="hour.value">
+                  {{ hour.label }}
                 </option>
               </select>
             </td>
             <td>
               <select v-model="day.shift3" :disabled="!day.active">
                 <option value=""></option>
-                <option v-for="hour in hours" :key="hour" :value="hour">
-                  {{ hour }}
+                <option v-for="hour in hours" :key="hour.value" :value="hour.value">
+                  {{ hour.label }}
                 </option>
               </select>
             </td>
             <td>
               <select v-model="day.shift4" :disabled="!day.active">
                 <option value=""></option>
-                <option v-for="hour in hours" :key="hour" :value="hour">
-                  {{ hour }}
+                <option v-for="hour in hours" :key="hour.value" :value="hour.value">
+                  {{ hour.label }}
                 </option>
               </select>
             </td>
@@ -176,9 +176,14 @@ export default {
       },
     ]);
 
-    const hours = Array.from({ length: 24 }, (_, i) =>
-      `${String(i).padStart(2, "0")}:00`
-    );
+    const hours = Array.from({ length: 24 }, (_, i) => {
+      const hour = i % 12 || 12;
+      const period = i < 12 ? "AM" : "PM";
+      return {
+        value: `${String(i).padStart(2, "0")}:00`,
+        label: `${hour}:00 ${period}`,
+      };
+    });
 
     const currentDate = ref(new Date());
     const excludedDates = ref([]);


### PR DESCRIPTION
## Summary
- Display shift selection times in 12-hour AM/PM format while keeping 24-hour values.
- Generate hours list with corresponding AM/PM labels for Calendar component.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895eb2c20d88330a5d2a931998474ad