### PR TITLE
Fix timezone issue when displaying excluded calendar dates

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -259,7 +259,8 @@ export default {
     }
 
     function formatDate(dateString) {
-      const date = new Date(dateString);
+      const [year, month, day] = dateString.split("-");
+      const date = new Date(year, month - 1, day);
       return isNaN(date) ? "" : date.toLocaleDateString();
     }
 


### PR DESCRIPTION
## Summary
- parse excluded date strings by components to avoid timezone shift

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896299f6ccc833081b03453cee422dc