### PR TITLE
feat(calendar): add dataSource prop to populate component

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -121,6 +121,7 @@ export default {
   props: {
     content: { type: Object, required: true },
     uid: { type: String, required: true },
+    dataSource: { type: [Object, String], default: null },
     /* wwEditor:start */
     wwEditorState: { type: Object, required: true },
     /* wwEditor:end */
@@ -260,6 +261,12 @@ export default {
     watch(
       () => props.content,
       (val) => loadDataSource(val?.dataSource),
+      { deep: true, immediate: true }
+    );
+
+    watch(
+      () => props.dataSource,
+      (val) => loadDataSource(val),
       { deep: true, immediate: true }
     );
 


### PR DESCRIPTION
## Summary
- add `dataSource` prop that accepts a JSON object or string to initialize calendar
- watch `dataSource` prop and load values when it changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689639dd7324833099bf1a5fdd829a88