### PR TITLE
feat(calendar): add dataSource prop to populate component

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -121,6 +121,7 @@ export default {
   props: {
     content: { type: Object, required: true },
     uid: { type: String, required: true },
+    dataSource: { type: [Object, String], default: null },
     /* wwEditor:start */
     wwEditorState: { type: Object, required: true },
     /* wwEditor:end */
@@ -258,8 +259,14 @@ export default {
     );
 
     watch(
-      () => props.content,
-      (val) => loadDataSource(val?.dataSource),
+      () => props.content.dataSource,
+      (val) => loadDataSource(val),
+      { deep: true, immediate: true }
+    );
+
+    watch(
+      () => props.dataSource,
+      (val) => loadDataSource(val),
       { deep: true, immediate: true }
     );
 

--- a/Project/CALENDARIO/ww-config.js
+++ b/Project/CALENDARIO/ww-config.js
@@ -53,6 +53,7 @@ export default {
         ],
       ],
       customSettingsPropertiesOrder: [
+        "dataSource",
         "rowData",
         "idFormula",
         "generateColumns",
@@ -762,6 +763,22 @@ export default {
           type: "string",
           cssSupports: "line-height",
         },
+      },
+      dataSource: {
+        label: { en: "Data Source" },
+        type: "Text",
+        section: "settings",
+        bindable: true,
+        defaultValue: "",
+        /* wwEditor:start */
+        bindingValidation: {
+          validations: [
+            { type: "object" },
+            { type: "string" },
+          ],
+          tooltip: "JSON object or string to initialize calendar values",
+        },
+        /* wwEditor:end */
       },
       rowData: {
         label: { en: "Data" },


### PR DESCRIPTION
## Summary
- add `dataSource` prop that accepts a JSON object or string to initialize calendar
- watch `content.dataSource` and external `dataSource` prop for changes
- expose `dataSource` in component config so it can be set in the editor

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689639dd7324833099bf1a5fdd829a88