### PR TITLE
feat: add customizable height for excluded dates table

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -89,7 +89,7 @@
             <th class="headerHoras">{{ translateText('Action') }}</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody class="excluded-body" :style="{ maxHeight: excludedDatesHeight }">
           <tr>
             <td><input class="inputDate" type="date" v-model="newExcludedDate" /></td>
             <td><button class="buttonFormat" @click="addExcludedDate">{{ translateText('Add') }}</button></td>
@@ -122,6 +122,7 @@ export default {
     content: { type: Object, required: true },
     uid: { type: String, required: true },
     dataSource: { type: [Object, String], default: null },
+    excludedDatesHeight: { type: String, default: "150px" },
     /* wwEditor:start */
     wwEditorState: { type: Object, required: true },
     /* wwEditor:end */
@@ -342,6 +343,7 @@ export default {
       cancelCopy,
       showConfirm,
       calendarValues,
+      excludedDatesHeight: props.excludedDatesHeight,
       translateText,
     };
   },
@@ -394,6 +396,42 @@ font-family: "Roboto", sans-serif;
   padding: 4px;
   text-align: center;
   height:38px;
+}
+
+.excluded-dates thead,
+.excluded-dates .excluded-body tr {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.excluded-body {
+  display: block;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.excluded-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.excluded-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.excluded-body::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.excluded-body:hover::-webkit-scrollbar-thumb {
+  background-color: #888;
+}
+
+.excluded-body:hover {
+  scrollbar-color: #888 transparent;
 }
 
 .shift-table td {


### PR DESCRIPTION
## Summary
- allow configuring excluded dates table height
- add scrollable body with modern hover scrollbar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963f89201c833087b26205a86a9a18