### PR TITLE
feat: add customizable height for excluded dates table

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -89,7 +89,7 @@
             <th class="headerHoras">{{ translateText('Action') }}</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody class="excluded-body" :style="{ maxHeight: excludedDatesHeight }">
           <tr>
             <td><input class="inputDate" type="date" v-model="newExcludedDate" /></td>
             <td><button class="buttonFormat" @click="addExcludedDate">{{ translateText('Add') }}</button></td>
@@ -122,6 +122,7 @@ export default {
     content: { type: Object, required: true },
     uid: { type: String, required: true },
     dataSource: { type: [Object, String], default: null },
+    excludedDatesHeight: { type: String, default: "150px" },
     /* wwEditor:start */
     wwEditorState: { type: Object, required: true },
     /* wwEditor:end */
@@ -211,6 +212,20 @@ export default {
     const excludedDates = ref([]);
     const newExcludedDate = ref("");
     const showConfirm = ref(false);
+
+    const excludedDatesHeight = ref(
+      props.content.excludedDatesHeight || props.excludedDatesHeight
+    );
+
+    watch(
+      () => props.content.excludedDatesHeight,
+      (val) => (excludedDatesHeight.value = val)
+    );
+
+    watch(
+      () => props.excludedDatesHeight,
+      (val) => (excludedDatesHeight.value = val)
+    );
 
     function loadDataSource(ds) {
       let parsed = ds;
@@ -342,6 +357,7 @@ export default {
       cancelCopy,
       showConfirm,
       calendarValues,
+      excludedDatesHeight,
       translateText,
     };
   },
@@ -394,6 +410,42 @@ font-family: "Roboto", sans-serif;
   padding: 4px;
   text-align: center;
   height:38px;
+}
+
+.excluded-dates thead,
+.excluded-dates .excluded-body tr {
+  display: table;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.excluded-body {
+  display: block;
+  overflow-y: auto;
+  overflow-x: hidden;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.excluded-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.excluded-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.excluded-body::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: 3px;
+}
+
+.excluded-body:hover::-webkit-scrollbar-thumb {
+  background-color: #888;
+}
+
+.excluded-body:hover {
+  scrollbar-color: #888 transparent;
 }
 
 .shift-table td {

--- a/Project/CALENDARIO/ww-config.js
+++ b/Project/CALENDARIO/ww-config.js
@@ -54,6 +54,7 @@ export default {
       ],
       customSettingsPropertiesOrder: [
         "dataSource",
+        "excludedDatesHeight",
         "rowData",
         "idFormula",
         "generateColumns",
@@ -779,6 +780,14 @@ export default {
           tooltip: "JSON object or string to initialize calendar values",
         },
         /* wwEditor:end */
+      },
+      excludedDatesHeight: {
+        label: { en: "Excluded dates table height" },
+        type: "Length",
+        section: "settings",
+        options: { noRange: true },
+        bindable: true,
+        defaultValue: "150px",
       },
       rowData: {
         label: { en: "Data" },


### PR DESCRIPTION
## Summary
- allow configuring excluded dates table height
- add scrollable body with modern hover scrollbar
- expose excludedDatesHeight in ww-config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963f89201c833087b26205a86a9a18