### PR TITLE
fix: keep excluded dates table header aligned with scrollbar

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -425,6 +425,7 @@ font-family: "Roboto", sans-serif;
   overflow-x: hidden;
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;
+  scrollbar-gutter: stable;
 }
 
 .excluded-body::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- ensure excluded dates header stays aligned when scrollbar appears

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896498360608330a82509aac5965bd3