### PR TITLE
Fix misalignment in calendar excluded dates table

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -420,6 +420,10 @@ font-family: "Roboto", sans-serif;
   table-layout: fixed;
 }
 
+.excluded-dates thead {
+  width: calc(100% - 6px);
+}
+
 .excluded-body {
   display: block;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- ensure excluded dates table header width matches scrollable body to keep columns aligned

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68964e4e6f9c8330a0bd83c27c7b88dd