### PR TITLE
feat: update calendar times to 15-minute intervals

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -213,9 +213,9 @@ export default {
       },
     ]);
 
-    const hours = Array.from({ length: 48 }, (_, i) => {
-      const hour24 = Math.floor(i / 2);
-      const minutes = i % 2 === 0 ? "00" : "30";
+    const hours = Array.from({ length: 96 }, (_, i) => {
+      const hour24 = Math.floor(i / 4);
+      const minutes = ["00", "15", "30", "45"][i % 4];
       const hour = hour24 % 12 || 12;
       const period = hour24 < 12 ? "AM" : "PM";
       return {


### PR DESCRIPTION
## Summary
- display calendar time options at 15-minute intervals

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6896641fe3f88330a6c597a4912d283c