### PR TITLE
Handle empty calendar data source

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -147,7 +147,7 @@ export default {
       return text;
     };
 
-    const weekDays = ref([
+    const defaultWeekDays = [
       {
         name: "Mon",
         label: translateText("Monday"),
@@ -211,7 +211,9 @@ export default {
         shift2Start: "",
         shift2End: "",
       },
-    ]);
+    ];
+
+    const weekDays = ref(defaultWeekDays.map((day) => ({ ...day })));
 
     const hours = Array.from({ length: 96 }, (_, i) => {
       const hour24 = Math.floor(i / 4);
@@ -265,19 +267,30 @@ export default {
       (val) => (excludedDatesHeight.value = val)
     );
 
+    function resetDataSource() {
+      weekDays.value = defaultWeekDays.map((day) => ({ ...day }));
+      excludedDates.value = [];
+    }
+
     function loadDataSource(ds) {
       let parsed = ds;
-      if (!parsed) return;
+      if (!parsed || (typeof parsed === "string" && !parsed.trim())) {
+        resetDataSource();
+        return;
+      }
       if (typeof parsed === "string") {
         try {
           parsed = JSON.parse(parsed);
         } catch (e) {
+          resetDataSource();
           return;
         }
       }
 
-      if (Array.isArray(parsed.weekDays)) {
-        const updatedDays = weekDays.value.map((day) => {
+      if (!Array.isArray(parsed.weekDays) || parsed.weekDays.length === 0) {
+        resetDataSource();
+      } else {
+        const updatedDays = defaultWeekDays.map((day) => {
           const dayData = parsed.weekDays.find((d) => d.name === day.name) || {};
           return {
             ...day,
@@ -290,9 +303,9 @@ export default {
         });
         weekDays.value = updatedDays;
       }
-      if (Array.isArray(parsed.excludedDates)) {
-        excludedDates.value = [...parsed.excludedDates];
-      }
+      excludedDates.value = Array.isArray(parsed.excludedDates)
+        ? [...parsed.excludedDates]
+        : [];
     }
 
     const calendarValues = ref({
@@ -312,14 +325,15 @@ export default {
     );
 
     watch(
-      () => props.content.dataSource,
-      (val) => loadDataSource(val),
-      { deep: true, immediate: true }
-    );
-
-    watch(
-      () => props.dataSource,
-      (val) => loadDataSource(val),
+      [() => props.content.dataSource, () => props.dataSource],
+      ([contentDS, propDS]) => {
+        const ds = propDS ?? contentDS;
+        if (ds && (typeof ds !== "string" || ds.trim())) {
+          loadDataSource(ds);
+        } else {
+          resetDataSource();
+        }
+      },
       { deep: true, immediate: true }
     );
 


### PR DESCRIPTION
## Summary
- create default week day template and reset helper
- reset calendar data when provided data source is empty
- load calendar data only when a valid data source is supplied

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68968e3a04dc8330b990711f40a13fc5