### PR TITLE
Format excluded dates using locale variable

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -97,7 +97,14 @@
           :style="{ maxHeight: excludedDatesHeight }"
         >
           <tr>
-            <td style="width:155px"><input class="inputDate" type="date" v-model="newExcludedDate" /></td>
+            <td style="width:155px">
+              <input
+                class="inputDate"
+                type="date"
+                v-model="newExcludedDate"
+                :lang="lang"
+              />
+            </td>
             <td>
               <button class="buttonFormat" @click="addExcludedDate">
                 {{ translateText('Add') }}
@@ -144,6 +151,11 @@ export default {
   },
   setup(props) {
     const translateText = (text) => text;
+
+    const lang =
+      window.wwLib?.wwVariable?.getValue(
+        "aa44dc4c-476b-45e9-a094-16687e063342"
+      ) || navigator.language;
 
     const defaultWeekDays = [
       { name: "Mon", label: translateText("Monday"), active: false, shift1Start: "", shift1End: "", shift2Start: "", shift2End: "" },
@@ -306,7 +318,7 @@ export default {
     function formatDate(dateString) {
       const [year, month, day] = dateString.split("-");
       const date = new Date(year, month - 1, day);
-      return isNaN(date) ? "" : date.toLocaleDateString();
+      return isNaN(date) ? "" : date.toLocaleDateString(lang);
     }
 
     function confirmCopy() {
@@ -389,6 +401,8 @@ export default {
       translateText,
       isInconsistent,
       hasHourInconsistency,
+
+      lang,
 
       // refs/estado da tabela de excluídos
       excludedRoot,


### PR DESCRIPTION
## Summary
- use WW variable for language to format excluded dates in Calendar component
- apply locale to excluded date input field

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b6d65c6a083309b5d55d05733cd0b