### PR TITLE
feat(calendario): add configurable calendar message

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -81,46 +81,56 @@
     <!-- Tabela de datas excluídas com correção de borda e alinhamento -->
     <div>
       <h3 class="h3">{{ translateText('Exclude dates') }}</h3>
-      <div class="excluded-dates"
-      ref="excludedRoot"
-      :class="{ 'has-scroll': excludedHasScroll }"> 
-      <table>
-        <thead>
-          <tr>
-            <th style="width:155px" class="headerDias">{{ translateText('Date') }}</th>
-            <th class="headerHoras">{{ translateText('Action') }}</th>
-          </tr>
-        </thead>
-        <tbody
-          class="excluded-body"
-          ref="excludedBodyEl"
-          :style="{ maxHeight: excludedDatesHeight }"
+      <div class="excluded-dates-wrapper">
+        <div
+          class="excluded-dates"
+          ref="excludedRoot"
+          :class="{ 'has-scroll': excludedHasScroll }"
         >
-          <tr>
-            <td style="width:155px">
-              <input
-                class="inputDate"
-                type="date"
-                v-model="newExcludedDate"
-                :lang="lang"
-              />
-            </td>
-            <td>
-              <button class="buttonFormat" @click="addExcludedDate">
-                {{ translateText('Add') }}
-              </button>
-            </td>
-          </tr>
-          <tr v-for="date in excludedDates" :key="date">
-            <td style="width:155px">{{ formatDate(date) }}</td>
-            <td>
-              <button class="buttonFormat" @click="removeExcluded(date)">
-                {{ translateText('Delete') }}
-              </button>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+          <table>
+            <thead>
+              <tr>
+                <th style="width:155px" class="headerDias">{{ translateText('Date') }}</th>
+                <th class="headerHoras">{{ translateText('Action') }}</th>
+              </tr>
+            </thead>
+            <tbody
+              class="excluded-body"
+              ref="excludedBodyEl"
+              :style="{ maxHeight: excludedDatesHeight }"
+            >
+              <tr>
+                <td style="width:155px">
+                  <input
+                    class="inputDate"
+                    type="date"
+                    v-model="newExcludedDate"
+                    :lang="lang"
+                  />
+                </td>
+                <td>
+                  <button class="buttonFormat" @click="addExcludedDate">
+                    {{ translateText('Add') }}
+                  </button>
+                </td>
+              </tr>
+              <tr v-for="date in excludedDates" :key="date">
+                <td style="width:155px">{{ formatDate(date) }}</td>
+                <td>
+                  <button class="buttonFormat" @click="removeExcluded(date)">
+                    {{ translateText('Delete') }}
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p
+          v-if="showDefaultCalendarMessage"
+          class="default-calendar-message"
+        >
+          {{ translateText(defaultCalendarMessage) }}
+        </p>
       </div>
     </div>
 
@@ -145,6 +155,12 @@ export default {
     uid: { type: String, required: true },
     dataSource: { type: [Object, String], default: null },
     excludedDatesHeight: { type: String, default: "150px" },
+    showDefaultCalendarMessage: { type: Boolean, default: false },
+    defaultCalendarMessage: {
+      type: String,
+      default:
+        "No specific operating calendar is defined for this contract. The standard operating calendar is in use.",
+    },
     /* wwEditor:start */
     wwEditorState: { type: Object, required: true },
     /* wwEditor:end */
@@ -218,6 +234,32 @@ export default {
     const excludedDatesHeight = ref(props.content.excludedDatesHeight || props.excludedDatesHeight);
     watch(() => props.content.excludedDatesHeight, (v) => (excludedDatesHeight.value = v));
     watch(() => props.excludedDatesHeight, (v) => (excludedDatesHeight.value = v));
+
+    const showDefaultCalendarMessage = ref(
+      props.content.showDefaultCalendarMessage || props.showDefaultCalendarMessage
+    );
+    watch(
+      () => props.content.showDefaultCalendarMessage,
+      (v) => (showDefaultCalendarMessage.value = v)
+    );
+    watch(
+      () => props.showDefaultCalendarMessage,
+      (v) => (showDefaultCalendarMessage.value = v)
+    );
+
+    const defaultCalendarMessage = ref(
+      props.content.defaultCalendarMessage ||
+        props.defaultCalendarMessage ||
+        "No specific operating calendar is defined for this contract. The standard operating calendar is in use."
+    );
+    watch(
+      () => props.content.defaultCalendarMessage,
+      (v) => (defaultCalendarMessage.value = v)
+    );
+    watch(
+      () => props.defaultCalendarMessage,
+      (v) => (defaultCalendarMessage.value = v)
+    );
 
     function resetDataSource() {
       weekDays.value = defaultWeekDays.map((day) => ({ ...day }));
@@ -398,6 +440,8 @@ export default {
       showConfirm,
       calendarValues,
       excludedDatesHeight,
+      showDefaultCalendarMessage,
+      defaultCalendarMessage,
       translateText,
       isInconsistent,
       hasHourInconsistency,
@@ -499,6 +543,19 @@ export default {
   overflow: hidden;
   display: inline-block; /* casa com a largura da tabela interna */
   margin-top: 0px;
+}
+
+.excluded-dates-wrapper {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.default-calendar-message {
+  font-family: "Roboto", sans-serif;
+  font-size: 12px;
+  color: red;
+  font-style: italic;
 }
 
 .h3 {

--- a/Project/CALENDARIO/ww-config.js
+++ b/Project/CALENDARIO/ww-config.js
@@ -55,6 +55,8 @@ export default {
       customSettingsPropertiesOrder: [
         "dataSource",
         "excludedDatesHeight",
+        "showDefaultCalendarMessage",
+        "defaultCalendarMessage",
         "rowData",
         "idFormula",
         "generateColumns",
@@ -788,6 +790,28 @@ export default {
         options: { noRange: true },
         bindable: true,
         defaultValue: "150px",
+      },
+      showDefaultCalendarMessage: {
+        label: { en: "Show default calendar message" },
+        type: "OnOff",
+        section: "settings",
+        bindable: true,
+        defaultValue: false,
+        /* wwEditor:start */
+        bindingValidation: {
+          type: "boolean",
+          tooltip: "Display message about default operating calendar",
+        },
+        /* wwEditor:end */
+      },
+      defaultCalendarMessage: {
+        label: { en: "Default calendar message" },
+        type: "Text",
+        section: "settings",
+        bindable: true,
+        defaultValue:
+          "No specific operating calendar is defined for this contract. The standard operating calendar is in use.",
+        hidden: (content) => !content.showDefaultCalendarMessage,
       },
       rowData: {
         label: { en: "Data" },


### PR DESCRIPTION
## Summary
- allow toggling of default calendar message near excluded dates table
- support custom message text when the flag is enabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd9f21c848330923ee3ae8f4ed79e