### PR TITLE
feat(attachments): truncate long filenames

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -288,6 +288,14 @@ export default {
     cursor: pointer;
 }
 
+.file-name {
+    width: 100%;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .file-actions {
     position: absolute;
     top: 4px;


### PR DESCRIPTION
## Summary
- ensure file names longer than the container are truncated with an ellipsis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfe7225788330ba39d20b88a83861