### PR TITLE
fix: keep close button visible for PDF

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -47,6 +47,7 @@
         <div class="modal-content" :class="{ 'pdf-viewer': currentFile && currentFile.isPdf }">
             <div class="modal-top-actions">
                 <button
+                    v-if="currentFile && !currentFile.isPdf"
                     class="modal-action-button"
                     @click="downloadFile(currentFile)"
                 >
@@ -455,8 +456,8 @@ export default {
 
     .modal-top-actions {
         position: absolute;
-        top: -35px;
-        right: -75px;
+        top: 10px;
+        right: 10px;
         display: flex;
         gap: 8px;
         z-index: 2;


### PR DESCRIPTION
## Summary
- hide download action in modal when viewing PDFs
- keep close button inside viewport for PDF previews

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e132a17388330ac42e5855514ccca