### PR TITLE
Show placeholder for unsupported attachments

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -87,7 +87,13 @@
                     <div class="modal-file-name">{{ currentFile.file.name }}</div>
                 </template>
                 <template v-else>
-                    <p class="no-preview">Preview not available for this file type.</p>
+                    <div class="file-not-viewable">
+                        <i
+                            v-if="currentFile"
+                            :class="['modal-file-icon', getFileIcon(currentFile.file.name)]"
+                        ></i>
+                        <p class="no-preview">This file cannot be viewed</p>
+                    </div>
                 </template>
             </div>
             <button
@@ -514,6 +520,22 @@ export default {
 
     .nav-button i.material-symbols-outlined {
         color: #fff;
+    }
+
+    .file-not-viewable {
+        width: 600px;
+        height: 400px;
+        background: #fff;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        border-radius: 4px;
+    }
+
+    .modal-file-icon {
+        font-size: 120px;
+        margin-bottom: 16px;
     }
 
     .no-preview {


### PR DESCRIPTION
## Summary
- Display placeholder icon and message for non-image/PDF attachments
- Style modal placeholder with large centered icon

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c175234833080a7186edc9c8339