### PR TITLE
feat(TimeLine): add DataSource support

### DIFF
--- a/Project/TimeLine/ww-config.js
+++ b/Project/TimeLine/ww-config.js
@@ -26,7 +26,7 @@ export default {
         "eventsAlignment",
       ],
     ],
-    customSettingsPropertiesOrder: [["data"]],
+    customSettingsPropertiesOrder: [["dataSource", "data"]],
   },
   properties: {
     // Marker styling
@@ -254,6 +254,24 @@ export default {
         type: "string",
         tooltip:
           'The alignment of timeline events\n\nFor vertical: "left", "right", or "alternate"\nFor horizontal: "top" or "bottom"',
+      },
+      /* wwEditor:end */
+    },
+
+    dataSource: {
+      label: { en: "Data Source" },
+      type: "Text",
+      section: "settings",
+      bindable: true,
+      defaultValue: "",
+      /* wwEditor:start */
+      bindingValidation: {
+        validations: [
+          { type: "array" },
+          { type: "string" },
+          { type: "object" },
+        ],
+        tooltip: "JSON array or string to initialize timeline data",
       },
       /* wwEditor:end */
     },


### PR DESCRIPTION
## Summary
- allow TimeLine to load events from a JSON dataSource
- set marker icons per event using `IcoEventType`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f5ba2f3b88330a05270bdd56cb22f