### PR TITLE
feat: display activity added card

### DIFF
--- a/Project/TimeLine/src/wwElement.vue
+++ b/Project/TimeLine/src/wwElement.vue
@@ -34,7 +34,38 @@
 
           <!-- Event content -->
           <div class="ww-timeline__content" @click.stop="onClick(item)">
-            <wwElement v-bind="content.timelineElement" class="ww-timeline__content-element" />
+            <template v-if="(item.TagControl || item.tagControl) === 'ActivityAdded'">
+              <div class="activity-added-card">
+                <div class="activity-added-card__left">
+                  <div class="activity-added-card__title">{{ item.Title }}</div>
+                  <div class="activity-added-card__field">
+                    Responsible User: {{ getFieldValue(item, 'ResponsibleUserID') }}
+                  </div>
+                  <div class="activity-added-card__field">
+                    Start Time: {{ formatDate(getFieldValue(item, 'StartTime')) }}
+                  </div>
+                  <div class="activity-added-card__field">
+                    End Time: {{ formatDate(getFieldValue(item, 'EndTime')) }}
+                  </div>
+                  <div class="activity-added-card__field">
+                    Total: {{ formatDuration(getFieldValue(item, 'TotalMinutes')) }}
+                  </div>
+                  <div class="activity-added-card__field">
+                    Description: {{ getFieldValue(item, 'Description') }}
+                  </div>
+                </div>
+                <div class="activity-added-card__right">
+                  <div class="activity-added-card__created-by">{{ item.CreatedByName }}</div>
+                  <div class="activity-added-card__created-date">{{ formatDate(item.CreatedDate) }}</div>
+                </div>
+              </div>
+            </template>
+            <template v-else>
+              <wwElement
+                v-bind="content.timelineElement"
+                class="ww-timeline__content-element"
+              />
+            </template>
           </div>
         </wwLayoutItemContext>
       </div>
@@ -64,7 +95,41 @@ export default {
     const { width: containerWidth } = useElementSize(containerRef);
 
     const events = ref([]);
-    const getItemIcon = (item) => item.IcoEventType || "";
+    const getItemIcon = (item) =>
+      item.IcoEventType || props.content.markerIcon || "";
+
+    const getFieldValue = (item, fieldName) => {
+      const list = item?.FieldNewValue || [];
+      const target = String(fieldName).toLowerCase();
+      const found = list.find((f) => {
+        const key =
+          f?.Field || f?.field || f?.Name || f?.name || f?.Key || f?.key || "";
+        return String(key).toLowerCase() === target;
+      });
+      return found ? found.Value ?? found.value ?? "" : "";
+    };
+
+    const formatDate = (value) => {
+      if (!value) return "";
+      const date = new Date(value);
+      if (isNaN(date.getTime())) return value;
+      return date.toLocaleString("en-US", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: true,
+      });
+    };
+
+    const formatDuration = (minutes) => {
+      const total = parseInt(minutes, 10);
+      if (isNaN(total)) return minutes || "";
+      const h = Math.floor(total / 60);
+      const m = total % 60;
+      return `${h}:${m.toString().padStart(2, "0")}`;
+    };
 
     // For horizontal timeline, calculate total content width based on actual content
     const connectorWidth = computed(() => {
@@ -119,6 +184,9 @@ export default {
     return {
       events,
       getItemIcon,
+      getFieldValue,
+      formatDate,
+      formatDuration,
       validAlignment,
       containerRef,
       connectorWidth,
@@ -507,5 +575,32 @@ export default {
 
   .ww-timeline--horizontal .ww-timeline__content-element {
     align-items: center;
+  }
+
+  .activity-added-card {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+
+    &__left {
+      flex: 1;
+    }
+
+    &__right {
+      text-align: right;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: flex-end;
+    }
+
+    &__title {
+      font-weight: 600;
+      margin-bottom: 0.25rem;
+    }
+
+    &__field {
+      margin-bottom: 0.25rem;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- render custom card when timeline event TagControl is ActivityAdded
- show user, times, description, and creator info with duration formatting
- ensure field lookup and date formatting work and fall back to default marker icon

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f743a26b8833096eee2f5468ed0d7