### PR TITLE
feat: add OnUpload event for attachment component

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -106,7 +106,7 @@
 </template>
 
 <script>
-    import { ref, computed, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 
 export default {
     name: 'Anexos',
@@ -118,7 +118,8 @@ export default {
         /* wwEditor:end */
         uid: { type: String, required: true },
     },
-    setup(props) {
+    emits: ['trigger-event'],
+    setup(props, { emit }) {
         const files = ref([]);
         const fileInput = ref(null);
         const isModalOpen = ref(false);
@@ -169,6 +170,28 @@ export default {
                 isPdf: file.type === 'application/pdf',
             }));
             files.value.push(...selected);
+
+            selected.forEach(({ file, url }) => {
+                const payload = {
+                    p_action: 'insert',
+                    p_workspace_id: props.content?.workspaceId ?? null,
+                    p_ticket_id: props.content?.ticketId ?? null,
+                    p_LoggerUserID: props.content?.loggerUserId ?? null,
+                    p_filename: file.name,
+                    p_fileextension: file.name.split('.').pop(),
+                    p_filesize: file.size,
+                    p_bucket: props.content?.bucket ?? null,
+                    p_objectpath: url,
+                    p_attachment_id: null,
+                    file,
+                };
+
+                emit('trigger-event', {
+                    name: 'onUpload',
+                    event: { value: payload },
+                });
+            });
+
             event.target.value = '';
         }
 

--- a/Project/Anexos/ww-config.js
+++ b/Project/Anexos/ww-config.js
@@ -54,4 +54,35 @@ export default {
             /* wwEditor:end */
         },
     },
+    events: {
+        onUpload: {
+            label: { en: 'On Upload' },
+            event: 'onUpload',
+            value: {
+                type: 'object',
+                label: { en: 'Uploaded file data' },
+            },
+        },
+    },
+    triggerEvents: [
+        {
+            name: 'onUpload',
+            label: { en: 'On file uploaded' },
+            event: {
+                value: {
+                    p_action: '',
+                    p_workspace_id: '',
+                    p_ticket_id: '',
+                    p_LoggerUserID: '',
+                    p_filename: '',
+                    p_fileextension: '',
+                    p_filesize: 0,
+                    p_bucket: '',
+                    p_objectpath: '',
+                    p_attachment_id: '',
+                    file: null,
+                },
+            },
+        },
+    ],
 };


### PR DESCRIPTION
## Summary
- add `onUpload` event to attachments component to trigger workflows with file metadata
- register `onUpload` trigger in configuration for workflow visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689f87cb578883309545a176f0046a96