### PR TITLE
feat: add data source to attachments component

### DIFF
--- a/Project/Anexos/ww-config.js
+++ b/Project/Anexos/ww-config.js
@@ -53,6 +53,23 @@ export default {
             },
             /* wwEditor:end */
         },
+        dataSource: {
+            label: {
+                en: 'Data Source',
+            },
+            type: 'array',
+            bindable: true,
+            defaultValue: [],
+            /* wwEditor:start */
+            bindingValidation: {
+                validations: [
+                    {
+                        type: 'array',
+                    },
+                ],
+            },
+            /* wwEditor:end */
+        },
     },
     events: {
         onUpload: {


### PR DESCRIPTION
## Summary
- allow Anexos component to receive an external data source
- map incoming attachment metadata and fetch signed URLs for previews

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a26b2ad6008330b372ffa0c7a42e32