### PR TITLE
feat: add text file icon

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -647,6 +647,9 @@ export default {
         case "ppt":
         case "pptx":
           return "fa-solid fa-file-powerpoint";
+        case "txt":
+        case "text":
+          return "fa-solid fa-file-lines";
         default:
           return "fa-solid fa-file";
       }


### PR DESCRIPTION
## Summary
- display a specific icon for text attachments in Anexos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a34d157f0c8330999fe2f65bbdeaf6