### PR TITLE
fix: set placeholder font size for InputMentions

### DIFF
--- a/Project/InputMentions/src/wwElement.vue
+++ b/Project/InputMentions/src/wwElement.vue
@@ -815,6 +815,7 @@ export default {
             content: attr(data-placeholder);
             float: left;
             color: #adb5bd;
+            font-size: 13px;
             pointer-events: none;
             height: 0;
         }


### PR DESCRIPTION
## Summary
- ensure InputMentions placeholder uses a 13px font size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fae7d3fc8330bb123335d7ec32dd