### PR TITLE
feat: add multi-column display to ComboMultiColunas

### DIFF
--- a/Project/ComboMultiColunas/ww-config.js
+++ b/Project/ComboMultiColunas/ww-config.js
@@ -169,6 +169,7 @@ export default {
                 'selectOnClick',
                 'virtualScrollBuffer',
                 'virtualScrollMinItemSize',
+                'columns',
             ],
             ['searchTitle', 'showSearch', 'searchBy', 'autoFocus'],
             'formInfobox',
@@ -861,6 +862,40 @@ export default {
             bindingValidation: {
                 type: 'boolean',
                 tooltip: 'A boolean that defines if the option is automatically unselected on click: `true | false`',
+            },
+            /* wwEditor:end */
+        },
+
+        columns: {
+            label: 'Columns',
+            section: 'settings',
+            states: true,
+            bindable: true,
+            responsive: true,
+            type: 'Array',
+            options: (_, sidepanelContent) => {
+                return {
+                    item: {
+                        type: 'Object',
+                        options: {
+                            item: {
+                                column: {
+                                    type: 'ObjectPropertyPath',
+                                    options: { object: sidepanelContent.optionProperties || {} },
+                                    defaultValue: '',
+                                },
+                            },
+                        },
+                    },
+                };
+            },
+            /* wwEditor:start */
+            bindingValidation: {
+                validations: [{ type: 'array' }],
+                tooltip: `An array of objects defining which properties of the choices are displayed as columns. Ex: [{column: "['key1']"}]`,
+            },
+            propertyHelp: {
+                tooltip: 'Which properties of the choices are displayed as columns in the options list.',
             },
             /* wwEditor:end */
         },


### PR DESCRIPTION
## Summary
- add new `columns` setting to choose which data source fields appear as columns
- render selected columns in option list as a grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a625a562d083309f54e6fb92ff4e43