### PR TITLE
feat: add column headers and widths

### DIFF
--- a/Project/ComboMultiColunas/src/wwElement_Option.vue
+++ b/Project/ComboMultiColunas/src/wwElement_Option.vue
@@ -116,13 +116,13 @@ export default {
         });
 
         const columns = computed(() => props.content.columns || []);
-        const columnsPaths = computed(() =>
-            columns.value.filter(col => col && col.column).map(col => col.column)
-        );
+        const parsedColumns = computed(() => columns.value.filter(col => col && col.column));
+        const columnsPaths = computed(() => parsedColumns.value.map(col => col.column));
+        const columnsWidths = computed(() => parsedColumns.value.map(col => col.width || '1fr'));
         const hasColumns = computed(() => columnsPaths.value.length > 0);
         const columnsStyle = computed(() => ({
             display: 'grid',
-            'grid-template-columns': `repeat(${columnsPaths.value.length}, 1fr)`,
+            'grid-template-columns': columnsWidths.value.join(' '),
             flex: '1',
             'align-items': 'center',
             gap: '8px',

--- a/Project/ComboMultiColunas/src/wwElement_OptionList.vue
+++ b/Project/ComboMultiColunas/src/wwElement_OptionList.vue
@@ -1,4 +1,8 @@
 <template>
+    <div v-if="hasColumns" class="ww-select-option-header" :style="columnsStyle">
+        <span v-for="(header, index) in columnsHeaders" :key="index">{{ header }}</span>
+    </div>
+
     <DynamicScroller
         v-if="/*virtualScroll &&*/ filteredOptions.length > 0"
         style="height: 100%"
@@ -100,6 +104,18 @@ export default {
             const items = rawData.value;
             return Array.isArray(items) ? items : [];
         });
+
+        const columns = computed(() => props.content.columns || []);
+        const parsedColumns = computed(() => columns.value.filter(col => col && col.column));
+        const columnsHeaders = computed(() => parsedColumns.value.map(col => col.header || ''));
+        const columnsWidths = computed(() => parsedColumns.value.map(col => col.width || '1fr'));
+        const hasColumns = computed(() => columnsHeaders.value.length > 0);
+        const columnsStyle = computed(() => ({
+            display: 'grid',
+            'grid-template-columns': columnsWidths.value.join(' '),
+            'align-items': 'center',
+            gap: '8px',
+        }));
 
         const optionProperties = computed(() => {
             if (!options.value || options.value.length === 0) return {};
@@ -208,6 +224,9 @@ export default {
         return {
             emptyStateText,
             filteredOptions,
+            hasColumns,
+            columnsHeaders,
+            columnsStyle,
             virtualScroll,
             virtualScrollSizeDependencies,
             virtualScrollMinItemSize,

--- a/Project/ComboMultiColunas/ww-config.js
+++ b/Project/ComboMultiColunas/ww-config.js
@@ -884,6 +884,14 @@ export default {
                                     options: { object: sidepanelContent.optionProperties || {} },
                                     defaultValue: '',
                                 },
+                                header: {
+                                    type: 'Text',
+                                    defaultValue: '',
+                                },
+                                width: {
+                                    type: 'Text',
+                                    defaultValue: '',
+                                },
                             },
                         },
                     },
@@ -892,7 +900,7 @@ export default {
             /* wwEditor:start */
             bindingValidation: {
                 validations: [{ type: 'array' }],
-                tooltip: `An array of objects defining which properties of the choices are displayed as columns. Ex: [{column: "['key1']"}]`,
+                tooltip: `An array of objects defining which properties of the choices are displayed as columns. Ex: [{column: "['key1']", header: 'Name', width: '100px'}]`,
             },
             propertyHelp: {
                 tooltip: 'Which properties of the choices are displayed as columns in the options list.',


### PR DESCRIPTION
## Summary
- allow configuring header and width for each column in ComboMultiColunas
- display column headers and apply per-column widths in option list
- adjust option rendering to respect column widths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62b797578833099eaad343a9d0a29