### PR TITLE
feat: add option color mappings and group indent

### DIFF
--- a/Project/ComboAgrupador/src/wwElement_Option.vue
+++ b/Project/ComboAgrupador/src/wwElement_Option.vue
@@ -85,13 +85,24 @@ export default {
         const mappingLabel = inject('_wwSelect:mappingLabel', ref(null));
         const mappingValue = inject('_wwSelect:mappingValue', ref(null));
         const mappingDisabled = inject('_wwSelect:mappingDisabled', ref(null));
+        const mappingBgColor = inject('_wwSelect:mappingBgColor', ref(null));
+        const mappingFontColor = inject('_wwSelect:mappingFontColor', ref(null));
 
         // Styles
+        const resolvedBgColor = computed(() => {
+            const path = toValue(mappingBgColor);
+            return path ? wwLib.resolveObjectPropertyPath(props.localData, path) : null;
+        });
+        const resolvedFontColor = computed(() => {
+            const path = toValue(mappingFontColor);
+            return path ? wwLib.resolveObjectPropertyPath(props.localData, path) : null;
+        });
+
         const optionStyles = computed(() => {
             return {
                 padding: props.content.optionPadding,
-                'background-color': props.content.optionBgColor,
-                color: props.content.optionFontColor,
+                'background-color': resolvedBgColor.value || props.content.optionBgColor,
+                color: resolvedFontColor.value || props.content.optionFontColor,
                 'font-family': props.content.optionFontFamily,
                 'font-size': props.content.optionFontSize,
                 'font-weight': props.content.optionFontWeight,

--- a/Project/ComboAgrupador/src/wwElement_OptionList.vue
+++ b/Project/ComboAgrupador/src/wwElement_OptionList.vue
@@ -396,7 +396,7 @@ export default {
 }
 
 .ww-select-grouped-option {
-    padding-left: 1.5em;
+    margin-left: 1em;
 }
 </style>
 

--- a/Project/ComboAgrupador/src/wwElement_Select.vue
+++ b/Project/ComboAgrupador/src/wwElement_Select.vue
@@ -184,6 +184,8 @@ export default {
         const mappingLabel = computed(() => props.content.mappingLabel);
         const mappingValue = computed(() => props.content.mappingValue);
         const mappingDisabled = computed(() => props.content.mappingDisabled);
+        const mappingBgColor = computed(() => props.content.optionBgColorField);
+        const mappingFontColor = computed(() => props.content.optionFontColorField);
         const showSearch = computed(() => props.content.showSearch);
         const allowScrollingWhenOpen = computed(() => props.content.allowScrollingWhenOpen);
 
@@ -845,6 +847,8 @@ export default {
         provide('_wwSelect:mappingLabel', mappingLabel);
         provide('_wwSelect:mappingValue', mappingValue);
         provide('_wwSelect:mappingDisabled', mappingDisabled);
+        provide('_wwSelect:mappingBgColor', mappingBgColor);
+        provide('_wwSelect:mappingFontColor', mappingFontColor);
         provide('_wwSelect:rawData', rawData);
         provide('_wwSelect:options', options);
         provide('_wwSelect:type', selectType);

--- a/Project/ComboAgrupador/ww-config.js
+++ b/Project/ComboAgrupador/ww-config.js
@@ -145,6 +145,8 @@ export default {
             'mappingValue',
             'mappingDisabled',
             'groupBy',
+            'optionBgColorField',
+            'optionFontColorField',
             'initValueSingle',
             'initValueMulti',
             'allowScrollingWhenOpen',
@@ -345,6 +347,28 @@ export default {
                 tooltip: 'Choose the property used to group the options.',
             },
             /* wwEditor:end */
+        },
+        optionBgColorField: {
+            label: 'Background color column',
+            section: 'settings',
+            states: true,
+            bindable: true,
+            responsive: true,
+            type: 'ObjectPropertyPath',
+            options: (_, sidepanelContent) => ({
+                object: sidepanelContent.optionProperties || {},
+            }),
+        },
+        optionFontColorField: {
+            label: 'Font color column',
+            section: 'settings',
+            states: true,
+            bindable: true,
+            responsive: true,
+            type: 'ObjectPropertyPath',
+            options: (_, sidepanelContent) => ({
+                object: sidepanelContent.optionProperties || {},
+            }),
         },
         initValueSingle: {
             type: 'Text',


### PR DESCRIPTION
## Summary
- indent grouped options for clearer hierarchy
- allow datasource columns to control item background and font colors
- wire new color mapping fields through select and option components

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/NewCode/Project/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a9caec13288330adeca80f717f2d0a