### PR TITLE
Add ticket ID parameter when loading grid options

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -28,7 +28,9 @@ export default class FixedListCellEditor {
 
     // Fixed list options
     let optionsArr = [];
-    if (Array.isArray(params.colDef.listOptions)) {
+    if (Array.isArray(params.options)) {
+      optionsArr = params.options;
+    } else if (Array.isArray(params.colDef.listOptions)) {
       optionsArr = params.colDef.listOptions;
     } else if (
       typeof params.colDef.listOptions === 'string' &&

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -26,7 +26,9 @@ export default class ListCellEditor {
 
     // Build option array
     let optionsArr = [];
-    if (Array.isArray(params.colDef.options)) {
+    if (Array.isArray(params.options)) {
+      optionsArr = params.options;
+    } else if (Array.isArray(params.colDef.options)) {
       optionsArr = params.colDef.options;
     } else if (Array.isArray(params.colDef.listOptions)) {
       optionsArr = params.colDef.listOptions;


### PR DESCRIPTION
## Summary
- include `p_ticketid` when requesting combo options for GridView
- fetch and store API options per row using the row's `TicketID`
- read runtime `options` in list editors so combos display API data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5f079fd08330b538903e31d603e6