### PR TITLE
feat: custom date editor and filter

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
@@ -1,61 +1,43 @@
 export default class DateTimeCellEditor {
+  constructor() {
+    this.languageVarId = 'aa44dc4c-476b-45e9-a094-16687e063342';
+  }
+
+  getLanguage() {
+    try {
+      return (
+        window?.wwLib?.wwVariable?.getValue?.(this.languageVarId) || 'en'
+      );
+    } catch (e) {
+      return 'en';
+    }
+  }
+
   init(params) {
     this.params = params;
+    this.lang = this.getLanguage();
     const input = document.createElement('input');
-    input.type = 'datetime-local';
+    input.type = 'date';
+    input.lang = this.lang;
     input.style.width = '100%';
     input.style.height = '100%';
     input.style.fontSize = '13px';
     input.style.borderRadius = '6px';
     input.style.padding = '4px';
 
-    // Set initial value if provided
     if (params.value) {
-      input.value = this.toDateTimeLocal(params.value);
+      const date = new Date(params.value);
+      if (!isNaN(date.getTime())) {
+        input.value = this.toISODate(date);
+      }
     }
 
-    // keep value in sync so getValue works even after element removal
-    this.value = input.value;
-
-    const syncValue = e => {
-      this.value = e.target.value;
-    };
-    input.addEventListener('input', syncValue);
-    input.addEventListener('change', syncValue);
-
-    input.addEventListener('keydown', e => {
-      if (e.key === 'Enter') {
-        e.stopPropagation();
-        e.preventDefault();
-        this.value = e.target.value;
-
-        if (this.params && this.params.api) {
-          this.params.api.stopEditing();
-        } else if (this.params && typeof this.params.stopEditing === 'function') {
-          this.params.stopEditing();
-        }
-      }
-    });
-    
     this.eInput = input;
   }
 
-  toDateTimeLocal(value) {
-    try {
-      // handle formats like 'YYYY-MM-DD HH:mm:ss+00' or ISO strings
-      let v = value;
-      if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?([\+\-]\d{2})?$/.test(v)) {
-        v = v.replace(' ', 'T');
-        if (/([\+\-]\d{2})(\d{2})?$/.test(v)) v = v.replace(/([\+\-]\d{2})(\d{2})?$/, '$1:$2');
-        if (/([\+\-]\d{2})$/.test(v)) v = v.replace(/([\+\-]\d{2})$/, '$1:00');
-      }
-      const d = new Date(v);
-      if (!isNaN(d.getTime())) {
-        const pad = n => n.toString().padStart(2, '0');
-        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-      }
-    } catch(e) {}
-    return value;
+  toISODate(date) {
+    const pad = n => n.toString().padStart(2, '0');
+    return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
   }
 
   getGui() {
@@ -63,12 +45,14 @@ export default class DateTimeCellEditor {
   }
 
   afterGuiAttached() {
-    if (this.eInput) this.eInput.focus();
+    if (this.eInput) {
+      this.eInput.focus();
+      this.eInput.showPicker?.();
+    }
   }
 
   getValue() {
-    // return the cached value to avoid issues if the element was removed
-    return this.value;
+    return this.eInput.value || '';
   }
 
   destroy() {}

--- a/Project/GridViewDinamica/src/components/DateTimeFilter.js
+++ b/Project/GridViewDinamica/src/components/DateTimeFilter.js
@@ -1,0 +1,68 @@
+export default class DateTimeFilter {
+  constructor() {
+    this.languageVarId = 'aa44dc4c-476b-45e9-a094-16687e063342';
+  }
+
+  getLanguage() {
+    try {
+      return (
+        window?.wwLib?.wwVariable?.getValue?.(this.languageVarId) || 'en'
+      );
+    } catch (e) {
+      return 'en';
+    }
+  }
+
+  init(params) {
+    this.params = params;
+    this.lang = this.getLanguage();
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'ag-date-filter';
+    this.eGui.style.display = 'flex';
+    this.eGui.style.gap = '4px';
+    this.eGui.innerHTML = `
+      <input type="date" class="from-date" style="flex:1;" lang="${this.lang}" />
+      <input type="date" class="to-date" style="flex:1;" lang="${this.lang}" />
+    `;
+    this.fromInput = this.eGui.querySelector('.from-date');
+    this.toInput = this.eGui.querySelector('.to-date');
+    const listener = () => this.params.filterChangedCallback();
+    this.fromInput.addEventListener('input', listener);
+    this.toInput.addEventListener('input', listener);
+  }
+
+  isFilterActive() {
+    return this.fromInput.value !== '' || this.toInput.value !== '';
+  }
+
+  doesFilterPass(params) {
+    const value = this.params.valueGetter({ data: params.data });
+    if (!value) return false;
+    const date = new Date(value);
+    if (isNaN(date.getTime())) return false;
+    const from = this.fromInput.value ? new Date(this.fromInput.value) : null;
+    const to = this.toInput.value ? new Date(this.toInput.value) : null;
+    if (from && date < from) return false;
+    if (to && date > to) return false;
+    return true;
+  }
+
+  getModel() {
+    if (!this.isFilterActive()) return null;
+    return {
+      from: this.fromInput.value || null,
+      to: this.toInput.value || null,
+    };
+  }
+
+  setModel(model) {
+    this.fromInput.value = model?.from || '';
+    this.toInput.value = model?.to || '';
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  destroy() {}
+}

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -38,6 +38,7 @@
   import UserCellRenderer from "./components/UserCellRenderer.vue";
   import ListFilterRenderer from "./components/ListFilterRenderer.js";
   import DateTimeCellEditor from "./components/DateTimeCellEditor.js";
+  import DateTimeFilter from "./components/DateTimeFilter.js";
   import FixedListCellEditor from "./components/FixedListCellEditor.js";
   // Editor customizado inline para listas
   class ListCellEditor {
@@ -786,6 +787,7 @@
         ListCellEditor,
         FixedListCellEditor,
         DateTimeCellEditor,
+        DateTimeFilter,
       },
     };
   },
@@ -1143,7 +1145,7 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             if (colCopy.headerAlign) {
               result.headerClass = `ag-header-align-${colCopy.headerAlign}`;
             }
-            // Formatação especial para DEADLINE
+            // Formatação especial para campos de usuário ou data
             const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontrol || '').toUpperCase();
             const identifier = (colCopy.FieldDB || '').toUpperCase();
 
@@ -1163,35 +1165,46 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                 };
               }
             }
-            if (tagControl === 'DEADLINE') {
-              result.filter = 'agDateColumnFilter';
+            const isDeadline = tagControl === 'DEADLINE';
+            const cellType = (colCopy.cellDataType || '').toUpperCase();
+            const isDateField =
+              isDeadline ||
+              tagControl === 'DATE' ||
+              tagControl === 'DATETIME' ||
+              identifier.includes('DATE') ||
+              cellType === 'DATE' ||
+              cellType === 'DATETIME';
+            if (isDateField) {
+              result.filter = DateTimeFilter;
               // Remove default date configuration applied above
               delete result.cellDataType;
+              // Format value for display
+              result.valueFormatter = params => {
+                const val = params.value;
+                if (!val) return '';
+                const date = val instanceof Date ? val : new Date(val);
+                if (isNaN(date.getTime())) return val;
+                try {
+                  const lang =
+                    window?.wwLib?.wwVariable?.getValue?.('aa44dc4c-476b-45e9-a094-16687e063342') ||
+                    'en';
+                  return new Intl.DateTimeFormat(lang, {
+                    day: '2-digit',
+                    month: '2-digit',
+                    year: 'numeric',
+                  }).format(date);
+                } catch (e) {
+                  return val;
+                }
+              };
+
               if (colCopy.editable) {
                 // use the class directly to avoid lookup issues
                 result.cellEditor = DateTimeCellEditor;
-
-                // Format value for display when editing ends
-                result.valueFormatter = params => {
-                  if (typeof params.value === 'string' && params.value) {
-                    try {
-                      const date = new Date(params.value);
-                      if (!isNaN(date.getTime())) {
-                        const pad = n => n.toString().padStart(2, '0');
-                        return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
-                      }
-                    } catch (e) {
-                      return params.value;
-                    }
-                  }
-                  if (params.value instanceof Date && !isNaN(params.value.getTime())) {
-                    const pad = n => n.toString().padStart(2, '0');
-                    return `${params.value.getFullYear()}-${pad(params.value.getMonth() + 1)}-${pad(params.value.getDate())} ${pad(params.value.getHours())}:${pad(params.value.getMinutes())}:${pad(params.value.getSeconds())}`;
-                  }
-                  return params.value || '';
-                };
                 delete result.valueParser;
               }
+            }
+            if (isDeadline) {
               result.cellRenderer = params => {
                 // Função utilitária para calcular diff e cor (idêntica ao FieldComponent.vue)
                 function normalizeDeadline(val) {


### PR DESCRIPTION
## Summary
- switch DateTimeCellEditor to native date input and trigger browser picker
- replace text fields in DateTimeFilter with localized date inputs
- display date cells formatted via Intl.DateTimeFormat using language variable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e0110448330a92aa238514e0bb4