### PR TITLE
feat: add group navigation to dropdown users

### DIFF
--- a/Project/DropdownUsers/src/components/UserSelector.vue
+++ b/Project/DropdownUsers/src/components/UserSelector.vue
@@ -27,19 +27,34 @@
     </div>
 
     <div v-if="isOpen" class="user-selector__dropdown">
-      <div class="user-selector__search">
-        <input
-          v-model="search"
-          type="text"
-          :placeholder="searchPlaceholder"
-          class="user-selector__input"
-          :style="inputStyle"
-        />
-        <span class="material-symbols-outlined user-selector__icon">search</span>
-      </div>
+      <template v-if="currentGroup">
+        <div class="user-selector__group-header">
+          <span
+            class="material-symbols-outlined user-selector__back"
+            @click="backToRoot"
+            >chevron_left</span
+          >
+          <span class="user-selector__group-title" :style="nameStyle">
+            {{ currentGroup.name }}
+          </span>
+        </div>
+        <div class="user-selector__group-count">{{ currentGroupCountLabel }}</div>
+      </template>
+      <template v-else>
+        <div class="user-selector__search">
+          <input
+            v-model="search"
+            type="text"
+            :placeholder="searchPlaceholder"
+            class="user-selector__input"
+            :style="inputStyle"
+          />
+          <span class="material-symbols-outlined user-selector__icon">search</span>
+        </div>
+      </template>
 
       <div class="user-selector__list">
-        <template v-if="groupBy">
+        <template v-if="groupBy && !currentGroup">
           <div
             class="user-selector__group"
             v-for="group in groupedUsers.groups"
@@ -72,6 +87,12 @@
                   </div>
                 </div>
                 <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
+                <span
+                  v-if="user.groupUsers?.length"
+                  class="material-symbols-outlined user-selector__chevron"
+                  @click.stop="openGroup(user)"
+                  >chevron_right</span
+                >
               </div>
             </div>
           </div>
@@ -98,6 +119,12 @@
               </div>
             </div>
             <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
+            <span
+              v-if="user.groupUsers?.length"
+              class="material-symbols-outlined user-selector__chevron"
+              @click.stop="openGroup(user)"
+              >chevron_right</span
+            >
           </div>
         </template>
 
@@ -107,7 +134,7 @@
             :key="user.id"
             class="user-selector__item"
             :class="{ disabled: user.isEnabled === false }"
-            @click.stop="user.isEnabled === false ? null : selectUser(user)"
+            @click.stop="user.isEnabled === false || user.groupUsers?.length ? null : selectUser(user)"
           >
             <div class="avatar-outer">
               <div class="avatar-middle">
@@ -124,6 +151,12 @@
               </div>
             </div>
             <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
+            <span
+              v-if="user.groupUsers?.length"
+              class="material-symbols-outlined user-selector__chevron"
+              @click.stop="openGroup(user)"
+              >chevron_right</span
+            >
           </div>
         </template>
 
@@ -166,12 +199,15 @@ export default {
       search: '',
       isOpen: false,
       selectedUser: null,
-      selectedUserIdVar: null
+      selectedUserIdVar: null,
+      currentGroup: null,
+      groupStack: []
     };
   },
   computed: {
     filteredUsers() {
-      const list = Array.isArray(this.datasource) ? this.datasource : [];
+      const source = this.currentGroup ? this.currentGroup.groupUsers || [] : this.datasource;
+      const list = Array.isArray(source) ? source : [];
       if (!this.search) return list;
       const q = this.search.toLowerCase();
       return list.filter(u => String(u.name || '').toLowerCase().includes(q));
@@ -220,6 +256,10 @@ export default {
     containerStyle() {
       return this.maxWidth ? { maxWidth: typeof this.maxWidth === 'number' ? `${this.maxWidth}px` : this.maxWidth } : {};
     },
+    currentGroupCountLabel() {
+      const count = this.currentGroup?.groupUsers?.length || 0;
+      return `${count} ${count === 1 ? 'member' : 'members'}`;
+    },
   },
   created() {
     if (typeof wwLib !== 'undefined' && wwLib.wwVariable && wwLib.wwVariable.useComponentVariable) {
@@ -267,20 +307,40 @@ export default {
   methods: {
     toggleDropdown() {
       this.isOpen = !this.isOpen;
+      if (!this.isOpen) {
+        this.currentGroup = null;
+        this.groupStack = [];
+        this.search = '';
+      }
     },
     closeDropdown(event) {
       if (this.isOpen && !(this.$refs.dropdownRoot?.contains?.(event.target))) {
         this.isOpen = false;
+        this.currentGroup = null;
+        this.groupStack = [];
+        this.search = '';
       }
     },
     async selectUser(user) {
       this.selectedUser = user;
       this.isOpen = false;
+      this.currentGroup = null;
       this.$emit('user-selected', user.id);
       this.$emit('trigger-event', {
         name: 'onChange',
         event: { value: user?.id || '' }
       });
+    },
+    openGroup(group) {
+      if (group.groupUsers && group.groupUsers.length) {
+        this.groupStack.push(this.currentGroup);
+        this.currentGroup = group;
+        this.search = '';
+      }
+    },
+    backToRoot() {
+      this.currentGroup = this.groupStack.pop() || null;
+      this.search = '';
     },
     handleClickOutside(event) {
       this.closeDropdown(event);
@@ -481,6 +541,31 @@ export default {
 }
 .user-selector__item:hover {
   background: #f5f5f5;
+}
+.user-selector__chevron {
+  margin-left: auto;
+  font-size: 20px;
+  color: #888;
+  cursor: pointer;
+}
+.user-selector__group-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px 4px;
+}
+.user-selector__back {
+  cursor: pointer;
+  font-size: 20px;
+  color: #444;
+}
+.user-selector__group-title {
+  flex: 1;
+}
+.user-selector__group-count {
+  font-size: 12px;
+  padding: 0 12px 8px;
+  color: #888;
 }
 .user-selector__group-label {
   padding: 4px 12px;


### PR DESCRIPTION
## Summary
- add chevron navigation for groups in user dropdown
- support browsing group members with back navigation and count display
- pluralize member count and restore previous group list when going back

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ac9fd3dda483309fa27fcc8cb11907