### PR TITLE
Evita seleção de grupos em DropDownUsers

### DIFF
--- a/Project/DropdownUsers/src/components/UserSelector.vue
+++ b/Project/DropdownUsers/src/components/UserSelector.vue
@@ -73,7 +73,13 @@
                 :key="user.id"
                 class="user-selector__item"
                 :class="{ disabled: user.isEnabled === false }"
-                @click.stop="user.isEnabled === false ? null : selectUser(user)"
+                @click.stop="
+                  user.isEnabled === false
+                    ? null
+                    : isGroupLabel(group.label)
+                      ? openGroup(user)
+                      : selectUser(user)
+                "
               >
                 <div class="avatar-outer">
                   <div class="avatar-middle">
@@ -82,7 +88,17 @@
                         <img :src="user.PhotoURL || user.PhotoUrl" alt="User Photo" />
                       </template>
                       <template v-else>
-                        <span class="user-selector__initial" :style="initialStyle">
+                        <span
+                          v-if="isGroupLabel(group.label)"
+                          class="material-symbols-outlined user-selector__group-icon"
+                        >
+                          groups
+                        </span>
+                        <span
+                          v-else
+                          class="user-selector__initial"
+                          :style="initialStyle"
+                        >
                           {{ getInitial(user.name) }}
                         </span>
                       </template>
@@ -357,6 +373,10 @@ export default {
     getInitial(name) {
       return name ? String(name).trim().charAt(0).toUpperCase() : '';
     },
+    isGroupLabel(label) {
+      const value = String(label || '').toUpperCase();
+      return ['GROUP', 'GROUPS', 'GRUPO', 'GRUPOS'].includes(value);
+    },
     initializeSelectedUser() {
       const targetId = this.selectedUserId || this.initialSelectedId;
       const user = (this.datasource || []).find(u => String(u.id) === String(targetId));
@@ -438,6 +458,15 @@ export default {
   color: #fff;
   border-radius: 50%;
   letter-spacing: 0.5px;
+}
+.user-selector__group-icon {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: #fff;
 }
 .user-selector__name {
   font-size: 15px;


### PR DESCRIPTION
## Summary
- Impede a seleção de itens com label de grupo e abre o grupo ao clicar
- Exibe ícone `groups` no avatar de itens de grupo
- Adiciona utilitário `isGroupLabel` e estilos para o ícone

## Testing
- `npm test` *(falha: package.json não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68aca900b86c83309f60988ad2e7eb55