### PR TITLE
Show group name when assigning team

### DIFF
--- a/Project/DropdownUsers/src/components/UserSelector.vue
+++ b/Project/DropdownUsers/src/components/UserSelector.vue
@@ -355,7 +355,7 @@ export default {
     },
     selectedLabel() {
       if (this.selectedGroup && this.selectedUser) return this.selectedUser.name;
-      if (this.selectedGroup && !this.selectedUser) return 'Assign to team';
+      if (this.selectedGroup && !this.selectedUser) return this.selectedGroup.name;
       return this.selectedUser ? this.selectedUser.name : this.unassignedLabel;
     },
   },


### PR DESCRIPTION
## Summary
- display group name when selecting Assign to team in DropDownUsers

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acbaf3417c833091410aee512874c6