### PR TITLE
feat: add initial group selection to DropDownUsers

### DIFF
--- a/Project/DropdownUsers/src/components/UserSelector.vue
+++ b/Project/DropdownUsers/src/components/UserSelector.vue
@@ -271,6 +271,7 @@ export default {
     unassignedLabel: { type: String, default: 'Unassigned' },
     searchPlaceholder: { type: String, default: 'Search user...' },
     initialSelectedId: [String, Number, Object],
+    initialGroupId: [String, Number],
     selectedUserId: [String, Number, Object],
     uid: String,
     maxWidth: [String, Number],
@@ -383,13 +384,15 @@ export default {
         this.setSelectedFromValue(newVal);
       }
     },
-    initialSelectedId(newVal) {
-      this.setSelectedFromValue(newVal);
+    initialSelectedId() {
+      this.initializeSelectedUser();
+    },
+    initialGroupId() {
+      this.initializeSelectedUser();
     },
     datasource: {
       handler() {
-        const target = this.selectedUserId || this.initialSelectedId;
-        this.setSelectedFromValue(target);
+        this.initializeSelectedUser();
       },
       deep: true
     },
@@ -472,7 +475,20 @@ export default {
       return ['GROUP', 'GROUPS', 'GRUPO', 'GRUPOS'].includes(value);
     },
     initializeSelectedUser() {
-      const target = this.selectedUserId || this.initialSelectedId;
+      let target = this.selectedUserId;
+      const hasSelected = target !== undefined && target !== null && target !== '';
+      if (!hasSelected) {
+        const groupId =
+          this.initialGroupId !== undefined && this.initialGroupId !== null && this.initialGroupId !== ''
+            ? this.initialGroupId
+            : null;
+        const userId =
+          this.initialSelectedId !== undefined && this.initialSelectedId !== null && this.initialSelectedId !== ''
+            ? this.initialSelectedId
+            : null;
+
+        target = groupId !== null ? { userid: userId, groupid: groupId } : userId;
+      }
       this.setSelectedFromValue(target);
     },
     setSelectedFromValue(value) {
@@ -482,20 +498,27 @@ export default {
         return;
       }
       if (typeof value === 'object') {
-        const group = value.groupid != null ? (this.datasource || []).find(u => String(u.id) === String(value.groupid)) : null;
+        const hasGroupId = value.groupid !== undefined && value.groupid !== null && value.groupid !== '';
+        const group = hasGroupId ? (this.datasource || []).find(u => String(u.id) === String(value.groupid)) : null;
         this.selectedGroup = group || null;
-        if (group && value.userid != null) {
+
+        const hasUserId = value.userid !== undefined && value.userid !== null && value.userid !== '';
+        if (group && hasUserId) {
           const user = (group.groupUsers || []).find(u => String(u.id) === String(value.userid));
           this.selectedUser = user || null;
-        } else if (group && value.userid == null) {
+        } else if (group && !hasUserId) {
           this.selectedUser = null;
-        } else {
+        } else if (hasUserId) {
           const user = (this.datasource || []).find(u => String(u.id) === String(value.userid));
           this.selectedUser = user || null;
           this.selectedGroup = null;
+        } else {
+          this.selectedUser = null;
+          this.selectedGroup = null;
         }
       } else {
-        const user = (this.datasource || []).find(u => String(u.id) === String(value));
+        const hasId = value !== undefined && value !== null && value !== '';
+        const user = hasId ? (this.datasource || []).find(u => String(u.id) === String(value)) : null;
         this.selectedUser = user || null;
         this.selectedGroup = null;
       }

--- a/Project/DropdownUsers/ww-config.js
+++ b/Project/DropdownUsers/ww-config.js
@@ -159,6 +159,12 @@ export default {
             defaultValue: '',
             bindable: true,
         },
+        initialGroupId: {
+            label: { en: 'Initial group ID' },
+            type: 'text',
+            defaultValue: '',
+            bindable: true,
+        },
         maxWidth: {
             label: { en: 'Max width' },
             type: 'text',


### PR DESCRIPTION
## Summary
- allow initializing dropdown with a specific group by ID
- combine initial user and group IDs for selection
- expose initialGroupId in ww-config for configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc273a4ec8330b321a43ee4c3ba0f