### PR TITLE
feat: add initial group selection to DropDownUsers

### DIFF
--- a/Project/DropdownUsers/ww-config.js
+++ b/Project/DropdownUsers/ww-config.js
@@ -159,6 +159,12 @@ export default {
             defaultValue: '',
             bindable: true,
         },
+        initialGroupId: {
+            label: { en: 'Initial group ID' },
+            type: 'text',
+            defaultValue: '',
+            bindable: true,
+        },
         maxWidth: {
             label: { en: 'Max width' },
             type: 'text',


### PR DESCRIPTION
## Summary
- allow initializing dropdown with a specific group by ID
- combine initial user and group IDs for selection
- expose initialGroupId in ww-config for configuration
- update selection when initial IDs change
- recursively locate groups and users so initialGroupId preselects the correct group

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc273a4ec8330b321a43ee4c3ba0f