### PR TITLE
fix: pass initial group ID to dropdown users selector

### DIFF
--- a/Project/DropdownUsers/src/wwElement.vue
+++ b/Project/DropdownUsers/src/wwElement.vue
@@ -14,6 +14,7 @@
         :input-font-weight="content.inputFontWeight"
         :unassigned-label="content.unassignedLabel"
         :search-placeholder="content.searchPlaceholder"
+        :initial-group-id="content.initialGroupId"
         :initial-selected-id="content.initialSelectedId"
         :selected-user-id="selectedUserId"
         :max-width="content.maxWidth"


### PR DESCRIPTION
## Summary
- forward `initialGroupId` prop to UserSelector so groups can be preselected

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aceec07a5883308913352424b9b112