### PR TITLE
feat: add grouped responsible user editor

### DIFF
--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="responsible-user-editor">
+    <UserSelector
+      ref="selector"
+      :datasource="options"
+      group-by="type"
+      :selected-user-id="params.value"
+      @user-selected="onSelected"
+    />
+  </div>
+</template>
+
+<script>
+import { ref, onMounted, nextTick } from 'vue';
+import UserSelector from '../../../DropdownUsers/src/components/UserSelector.vue';
+
+export default {
+  name: 'ResponsibleUserCellEditor',
+  components: { UserSelector },
+  props: {
+    params: { type: Object, required: true }
+  },
+  setup(props) {
+    const options = ref([]);
+    const value = ref(props.params.value || null);
+    const selector = ref(null);
+
+    const loadOptions = async () => {
+      if (props.params.options && props.params.options.length) {
+        options.value = props.params.options;
+        return;
+      }
+      try {
+        const lang = window.wwLib?.wwVariable?.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+        const companyId = window.wwLib?.wwVariable?.getValue('5d099f04-cd42-41fd-94ad-22d4de368c3a');
+        const apiUrl = window.wwLib?.wwVariable?.getValue('1195995b-34c3-42a5-b436-693f0f4f8825');
+        const apiKey = window.wwLib?.wwVariable?.getValue('d180be98-8926-47a7-b7f1-6375fbb95fa3');
+        const apiAuth = window.wwLib?.wwVariable?.getValue('dfcde09f-42f3-4b5c-b2e8-4314650655db');
+        const fetchOptions = {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...(companyId ? { p_idcompany: companyId } : {}),
+            ...(lang ? { p_language: lang } : {})
+          })
+        };
+        if (apiKey) fetchOptions.headers['apikey'] = apiKey;
+        if (apiAuth) fetchOptions.headers['Authorization'] = apiAuth;
+        const response = await fetch(apiUrl + 'getLookupGroupsAndUsers', fetchOptions);
+        const data = await response.json();
+        options.value = Array.isArray(data) ? data : [];
+      } catch (e) {
+        options.value = [];
+      }
+    };
+
+    const onSelected = (val) => {
+      value.value = val;
+      if (props.params.api && props.params.api.stopEditing) {
+        props.params.api.stopEditing();
+      } else if (props.params.stopEditing) {
+        props.params.stopEditing();
+      }
+    };
+
+    const getValue = () => value.value;
+    const isPopup = () => true;
+
+    onMounted(async () => {
+      await loadOptions();
+      nextTick(() => {
+        selector.value && selector.value.toggleDropdown && selector.value.toggleDropdown();
+      });
+    });
+
+    return { options, onSelected, getValue, isPopup, selector };
+  }
+};
+</script>
+
+<style scoped>
+.responsible-user-editor {
+  min-width: 220px;
+}
+</style>
+

--- a/Project/GridViewDinamica/src/components/UserCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/UserCellRenderer.vue
@@ -1,18 +1,60 @@
 <template>
-<div v-if="name" class="user-cell" :style="pointerStyle">
-    <div class="avatar-outer">
-      <div class="avatar-middle">
-        <div class="user-cell__avatar">
-          <template v-if="photo">
-            <img :src="photo" alt="User Photo" />
-          </template>
-          <template v-else>
-            <span class="user-cell__initial">{{ initial }}</span>
-          </template>
+  <div v-if="selectedLabel" class="user-cell" :class="{ 'user-cell--group-user': selectedGroup && selectedUser }" :style="pointerStyle">
+    <template v-if="selectedGroup && selectedUser">
+      <div class="avatar-outer group-avatar-wrapper selected-group-avatar">
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="groupPhoto">
+              <img :src="groupPhoto" alt="Group Photo" />
+            </template>
+            <template v-else>
+              <span class="material-symbols-outlined user-cell__group-icon">groups</span>
+            </template>
+          </div>
         </div>
       </div>
-    </div>
-    <span class="user-cell__name">{{ name }}</span>
+      <div class="avatar-outer selected-user-avatar">
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="userPhoto">
+              <img :src="userPhoto" alt="User Photo" />
+            </template>
+            <template v-else>
+              <span class="user-cell__initial">{{ userInitial }}</span>
+            </template>
+          </div>
+        </div>
+      </div>
+    </template>
+    <template v-else-if="selectedGroup">
+      <div class="avatar-outer group-avatar-wrapper">
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="groupPhoto">
+              <img :src="groupPhoto" alt="Group Photo" />
+            </template>
+            <template v-else>
+              <span class="material-symbols-outlined user-cell__group-icon">groups</span>
+            </template>
+          </div>
+        </div>
+      </div>
+    </template>
+    <template v-else>
+      <div class="avatar-outer">
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="userPhoto">
+              <img :src="userPhoto" alt="User Photo" />
+            </template>
+            <template v-else>
+              <span class="user-cell__initial">{{ userInitial }}</span>
+            </template>
+          </div>
+        </div>
+      </div>
+    </template>
+    <span class="user-cell__name">{{ selectedLabel }}</span>
   </div>
 </template>
 
@@ -25,40 +67,54 @@ export default {
       required: true
     }
   },
+  data() {
+    return {
+      optionsCache: []
+    };
+  },
+  async created() {
+    if (!this.params.options || !this.params.options.length) {
+      this.optionsCache = await this.fetchOptions();
+    }
+  },
   computed: {
-    name() {
-      const direct =
-        this.params?.data?.ResponsibleUser ||
-        this.params?.data?.Username ||
-        this.params?.data?.UserName ||
-        '';
-      if (direct) return direct;
-      const value = this.params?.value;
-      const opts = this.params?.options || [];
-      if (Array.isArray(opts)) {
-        const match = opts.find(o => String(o.value) === String(value));
-        if (match && match.label) return match.label;
-      }
-      return '';
+    options() {
+      return (this.params.options && this.params.options.length) ? this.params.options : this.optionsCache;
     },
-    photo() {
-      const direct =
-        this.params?.data?.PhotoUrl ||
-        this.params?.data?.PhotoURL ||
-        this.params?.data?.UserPhoto ||
-        '';
-      if (direct) return direct;
-      const value = this.params?.value;
-      const opts = this.params?.options || [];
-      if (Array.isArray(opts)) {
-        const match = opts.find(o => String(o.value) === String(value));
-        if (match) return match.photo || match.image || match.img || '';
+    selectedGroup() {
+      const val = this.params.value;
+      if (val && typeof val === 'object' && val.groupid) {
+        return this.findGroupById(val.groupid);
       }
-      return '';
+      return null;
     },
-    initial() {
-      const n = this.name;
-      return n ? n.trim().charAt(0).toUpperCase() : '';
+    selectedUser() {
+      const val = this.params.value;
+      if (val && typeof val === 'object') {
+        if (val.userid && val.groupid) {
+          const grp = this.findGroupById(val.groupid);
+          if (grp) return (grp.groupUsers || []).find(u => String(u.id) === String(val.userid)) || null;
+        } else if (val.userid) {
+          return this.findUserById(val.userid);
+        }
+      } else if (val) {
+        return this.findUserById(val);
+      }
+      return null;
+    },
+    selectedLabel() {
+      if (this.selectedGroup && this.selectedUser) return this.selectedUser.name;
+      if (this.selectedGroup) return this.selectedGroup.name;
+      return this.selectedUser ? this.selectedUser.name : '';
+    },
+    userPhoto() {
+      return this.selectedUser?.PhotoURL || this.selectedUser?.PhotoUrl || this.selectedUser?.photo || '';
+    },
+    groupPhoto() {
+      return this.selectedGroup?.PhotoURL || this.selectedGroup?.PhotoUrl || this.selectedGroup?.photo || '';
+    },
+    userInitial() {
+      return this.selectedUser ? this.getInitial(this.selectedUser.name) : '';
     },
     isEditable() {
       const editable = this.params.colDef?.editable;
@@ -74,6 +130,60 @@ export default {
     pointerStyle() {
       return this.isEditable ? { cursor: 'pointer' } : {};
     }
+  },
+  methods: {
+    async fetchOptions() {
+      try {
+        const lang = window.wwLib?.wwVariable?.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+        const companyId = window.wwLib?.wwVariable?.getValue('5d099f04-cd42-41fd-94ad-22d4de368c3a');
+        const apiUrl = window.wwLib?.wwVariable?.getValue('1195995b-34c3-42a5-b436-693f0f4f8825');
+        const apiKey = window.wwLib?.wwVariable?.getValue('d180be98-8926-47a7-b7f1-6375fbb95fa3');
+        const apiAuth = window.wwLib?.wwVariable?.getValue('dfcde09f-42f3-4b5c-b2e8-4314650655db');
+        const fetchOptions = {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...(companyId ? { p_idcompany: companyId } : {}),
+            ...(lang ? { p_language: lang } : {})
+          })
+        };
+        if (apiKey) fetchOptions.headers['apikey'] = apiKey;
+        if (apiAuth) fetchOptions.headers['Authorization'] = apiAuth;
+        const response = await fetch(apiUrl + 'getLookupGroupsAndUsers', fetchOptions);
+        const data = await response.json();
+        return Array.isArray(data) ? data : [];
+      } catch (e) {
+        return [];
+      }
+    },
+    findGroupById(id, list = this.options) {
+      for (const item of list || []) {
+        if (String(item.id) === String(id) && Array.isArray(item.groupUsers)) {
+          return item;
+        }
+        if (Array.isArray(item.groupUsers) && item.groupUsers.length) {
+          const found = this.findGroupById(id, item.groupUsers);
+          if (found) return found;
+        }
+      }
+      return null;
+    },
+    findUserById(id, list = this.options) {
+      for (const item of list || []) {
+        const hasGroup = Array.isArray(item.groupUsers) && item.groupUsers.length > 0;
+        if (String(item.id) === String(id) && !hasGroup) {
+          return item;
+        }
+        if (hasGroup) {
+          const found = this.findUserById(id, item.groupUsers);
+          if (found) return found;
+        }
+      }
+      return null;
+    },
+    getInitial(name) {
+      return name ? String(name).trim().charAt(0).toUpperCase() : '';
+    }
   }
 };
 </script>
@@ -83,6 +193,21 @@ export default {
   display: flex;
   align-items: center;
   gap: 10px;
+}
+.user-cell--group-user {
+  gap: 0;
+}
+.user-cell--group-user .selected-group-avatar {
+  margin-right: -8px;
+  position: relative;
+  z-index: 1;
+}
+.user-cell--group-user .selected-user-avatar {
+  position: relative;
+  z-index: 2;
+}
+.group-avatar-wrapper {
+  position: relative;
 }
 .avatar-outer {
   width: 32px;
@@ -132,6 +257,10 @@ export default {
   color: #fff;
   border-radius: 50%;
   letter-spacing: 0.5px;
+}
+.user-cell__group-icon {
+  color: #fff;
+  font-size: 18px;
 }
 .user-cell__name {
   font-size: 12px;


### PR DESCRIPTION
## Summary
- add cell editor using UserSelector for ResponsibleUserID fields
- show group and user avatars in grid cells
- load ResponsibleUser options from getLookupGroupsAndUsers
- remove stray return in wwElement causing compile error
- remove duplicate tagControl declaration in wwElement
- expose selectedRows and its setter in GridViewDinamica and drop unused Vue imports

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad896f3f7483309df557e39e7386af