### PR TITLE
Fix ResponsibleUserID cell editor not opening

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -947,10 +947,10 @@
             sortable: colCopy.sortable,
             filter: ListFilterRenderer,
             cellRenderer: 'UserCellRenderer',
-            editable: !!colCopy.editable,
+            editable: colCopy.editable !== false,
           };
           result.cellRendererParams = params => ({ options: getDsOptions(params) });
-          if (colCopy.editable) {
+          if (colCopy.editable !== false) {
             result.cellEditor = ResponsibleUserCellEditor;
             result.cellEditorParams = params => ({ options: getDsOptions(params) });
           }


### PR DESCRIPTION
## Summary
- Default ResponsibleUserID columns to editable
- Always attach ResponsibleUserCellEditor unless editing disabled

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade245b4b4833084cff2d063f76afb