### PR TITLE
fix: handle ResponsibleUserID column editing

### DIFF
--- a/Project/DropdownUsers/src/components/UserSelector.vue
+++ b/Project/DropdownUsers/src/components/UserSelector.vue
@@ -361,7 +361,12 @@ export default {
     },
   },
   created() {
-    if (typeof wwLib !== 'undefined' && wwLib.wwVariable && wwLib.wwVariable.useComponentVariable) {
+    if (
+      this.uid &&
+      typeof wwLib !== 'undefined' &&
+      wwLib.wwVariable &&
+      wwLib.wwVariable.useComponentVariable
+    ) {
       this.selectedUserIdVar = wwLib.wwVariable.useComponentVariable({
         uid: this.uid,
         name: 'selectedUserId',

--- a/Project/GridViewDinamica/src/components/UserSelector.vue
+++ b/Project/GridViewDinamica/src/components/UserSelector.vue
@@ -361,7 +361,12 @@ export default {
     },
   },
   created() {
-    if (typeof wwLib !== 'undefined' && wwLib.wwVariable && wwLib.wwVariable.useComponentVariable) {
+    if (
+      this.uid &&
+      typeof wwLib !== 'undefined' &&
+      wwLib.wwVariable &&
+      wwLib.wwVariable.useComponentVariable
+    ) {
       this.selectedUserIdVar = wwLib.wwVariable.useComponentVariable({
         uid: this.uid,
         name: 'selectedUserId',

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -910,12 +910,24 @@
           if (!isNaN(Number(val))) return Number(val);
           return undefined;
         }
+
+        // Converte diferentes representações para booleano, com valor padrão
+        function parseEditable(val, defaultVal = false) {
+          if (val === undefined || val === null || val === '') return defaultVal;
+          if (typeof val === 'string') {
+            const lowered = val.toLowerCase();
+            if (lowered === 'false' || lowered === '0') return false;
+            if (lowered === 'true' || lowered === '1') return true;
+          }
+          return Boolean(val);
+        }
         
         const minWidth = toNumber(colCopy.minWidth) || toNumber(colCopy.MinWidth) || 80;
         const isFlex = colCopy.widthAlgo === 'flex';
         const width = isFlex ? undefined : minWidth;
         const flex = isFlex ? (colCopy.flex ?? 1) : undefined;
         const maxWidth = toNumber(colCopy.maxWidth) || undefined;
+        const baseEditable = parseEditable(colCopy.editable);
         const commonProperties = {
           minWidth,
           ...(width ? { width } : {}),
@@ -923,7 +935,7 @@
           ...(maxWidth ? { maxWidth } : {}),
           pinned: colCopy.pinned === "none" ? false : colCopy.pinned,
           hide: !!colCopy.hide,
-          editable: !!colCopy.editable, // <-- garantir editable
+          editable: baseEditable,
           ...(colCopy.pinned === 'left' ? { lockPinned: true, lockPosition: true } : {}),
           context: { FieldDB: colCopy.FieldDB, TagControl: colCopy.TagControl, id: colCopy.id }
         };
@@ -934,23 +946,25 @@
           const colOpts = this.columnOptions[fieldKey] || {};
           return colOpts[ticketId] || colOpts['*'] || [];
         };
-        const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontrol || '').toUpperCase();
-        const identifier = (colCopy.FieldDB || '').toUpperCase();
+        const rawTagControl = colCopy.TagControl ?? colCopy.tagControl ?? colCopy.tagcontrol ?? '';
+        const rawIdentifier = colCopy.FieldDB ?? '';
+        const tagControl = rawTagControl.toString().trim().toUpperCase();
+        const identifier = rawIdentifier.toString().trim().toUpperCase();
 
         if (tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') {
+          const isEditable = colCopy.editable == null ? true : parseEditable(colCopy.editable);
           const result = {
             ...commonProperties,
-
             colId: colCopy.id,
             headerName: colCopy.headerName,
             field: colCopy.field,
             sortable: colCopy.sortable,
             filter: ListFilterRenderer,
             cellRenderer: 'UserCellRenderer',
-            editable: !!colCopy.editable,
+            editable: isEditable,
           };
           result.cellRendererParams = params => ({ options: getDsOptions(params) });
-          if (colCopy.editable) {
+          if (isEditable) {
             result.cellEditor = ResponsibleUserCellEditor;
             result.cellEditorParams = params => ({ options: getDsOptions(params) });
           }


### PR DESCRIPTION
## Summary
- normalize TagControl/FieldDB detection for ResponsibleUserID columns
- default ResponsibleUserID columns to editable unless explicitly disabled
- parse string/number values for editable flags
- skip component variable creation when `uid` is missing to prevent `selectedUserId` errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade245b4b4833084cff2d063f76afb