### PR TITLE
Handle user and group fallbacks for ResponsibleUserID cells

### DIFF
--- a/Project/GridViewDinamica/src/components/UserCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/UserCellRenderer.vue
@@ -86,6 +86,11 @@ export default {
       if (val && typeof val === 'object' && val.groupid) {
         return this.findGroupById(val.groupid);
       }
+      const name = this.params.data?.AssignedGroupName;
+      if (name) {
+        const photo = this.params.data?.AssignedGroupPhoto || this.params.data?.GroupPhotoURL || this.params.data?.GroupPhotoUrl;
+        return { name, photo };
+      }
       return null;
     },
     selectedUser() {
@@ -99,6 +104,11 @@ export default {
         }
       } else if (val) {
         return this.findUserById(val);
+      }
+      const name = this.params.data?.ResponsibleUser || this.params.data?.Username || this.params.data?.UserName;
+      if (name) {
+        const photo = this.params.data?.PhotoURL || this.params.data?.PhotoUrl || this.params.data?.UserPhoto;
+        return { name, photo };
       }
       return null;
     },


### PR DESCRIPTION
## Summary
- add fallbacks for ResponsibleUser and AssignedGroupName when rendering ResponsibleUserID cells
- ensure user and group avatars render with appropriate icons and names

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0acb8180833094acaefcc90b730d