### PR TITLE
fix: normalize responsible user labels

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -52,9 +52,20 @@ export default class FixedListCellEditor {
         .map(o => o.trim());
     }
 
-    this.options = optionsArr.map(opt =>
-      typeof opt === 'object' ? opt : { value: opt, label: String(opt) }
-    );
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
+        const labelKey = findKey('label') || findKey('name');
+        const valueKey = findKey('value') || findKey('id');
+        return {
+          ...opt,
+          value: valueKey ? opt[valueKey] : opt.value,
+          label: labelKey ? opt[labelKey] : opt.label || opt.name
+        };
+      }
+      return { value: opt, label: String(opt) };
+    };
+    this.options = optionsArr.map(normalize);
     this.filteredOptions = [...this.options];
 
     this.value = params.value;

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -51,9 +51,20 @@ export default class ListCellEditor {
         .split(',')
         .map(o => o.trim());
     }
-    this.options = optionsArr.map(opt =>
-      typeof opt === 'object' ? opt : { value: opt, label: String(opt) }
-    );
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
+        const labelKey = findKey('label') || findKey('name');
+        const valueKey = findKey('value') || findKey('id');
+        return {
+          ...opt,
+          value: valueKey ? opt[valueKey] : opt.value,
+          label: labelKey ? opt[labelKey] : opt.label || opt.name
+        };
+      }
+      return { value: opt, label: String(opt) };
+    };
+    this.options = optionsArr.map(normalize);
     this.filteredOptions = [...this.options];
     this.value = params.value;
 


### PR DESCRIPTION
## Summary
- normalize option objects case-insensitively so responsible user names display correctly
- apply option mapping in user renderer and list editors

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68aecb242e688330a2593674bc651cd7