### PR TITLE
feat: group responsible user options

### DIFF
--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
@@ -36,20 +36,46 @@ export default {
       return undefined;
     };
 
-    const mapOptions = list =>
-      (list || []).map(item => {
-        const children = getProp(item, 'groupUsers');
-        return {
-          ...item,
-          id: getProp(item, 'id', 'value'),
-          name: getProp(item, 'name', 'label'),
-          value: getProp(item, 'value', 'id'),
-          label: getProp(item, 'label', 'name'),
-          ...(Array.isArray(children) && children.length
-            ? { groupUsers: mapOptions(children) }
-            : {})
-        };
-      });
+    const mapOptions = list => {
+      const arr = Array.isArray(list) ? list : [];
+      const hasNested = arr.some(it => Array.isArray(getProp(it, 'groupUsers')) && getProp(it, 'groupUsers').length);
+      if (hasNested) {
+        return arr.map(item => {
+          const children = getProp(item, 'groupUsers');
+          return {
+            ...item,
+            id: getProp(item, 'id', 'value'),
+            name: getProp(item, 'name', 'label'),
+            value: getProp(item, 'value', 'id'),
+            label: getProp(item, 'label', 'name'),
+            ...(Array.isArray(children) && children.length ? { groupUsers: mapOptions(children) } : {})
+          };
+        });
+      }
+
+      const groups = {};
+      const users = [];
+      for (const raw of arr) {
+        const id = getProp(raw, 'id', 'value');
+        const name = getProp(raw, 'name', 'label');
+        const type = String(getProp(raw, 'type') || '').toLowerCase();
+        if (type === 'group') {
+          groups[id] = { ...raw, id, name, value: id, label: name, groupUsers: [] };
+        } else {
+          const gid = getProp(raw, 'groupId', 'groupid', 'group_id', 'group');
+          users.push({ ...raw, id, name, value: id, label: name, groupId: gid });
+        }
+      }
+
+      const result = Object.values(groups);
+      for (const usr of users) {
+        const gid = usr.groupId;
+        delete usr.groupId;
+        if (gid != null && groups[gid]) groups[gid].groupUsers.push(usr);
+        else result.push(usr);
+      }
+      return result;
+    };
 
 
     const loadOptions = async () => {


### PR DESCRIPTION
## Summary
- group responsible user options by type
- build nested groups in cell editor and renderer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aed3c36a608330aec7ffc6ee5b7424