### PR TITLE
Fix group assignment list and grid refresh

### DIFF
--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
@@ -129,6 +129,31 @@ export default {
 
     const onSelected = (val) => {
       value.value = val;
+
+      const meta = selector.value;
+      const colId = props.params.column?.getColId
+        ? props.params.column.getColId()
+        : props.params.column?.colId;
+
+      if (props.params.node?.setDataValue) {
+        props.params.node.setDataValue(colId, val);
+      } else if (props.params.data && colId != null) {
+        props.params.data[colId] = val;
+      }
+
+      if (props.params.data && meta) {
+        props.params.data.ResponsibleUser = meta.selectedUser?.name || null;
+        props.params.data.AssignedGroupName = meta.selectedGroup?.name || null;
+      }
+
+      if (props.params.api?.refreshCells) {
+        props.params.api.refreshCells({
+          rowNodes: props.params.node ? [props.params.node] : undefined,
+          columns: colId ? [colId] : undefined,
+          force: true
+        });
+      }
+
       if (props.params.api && props.params.api.stopEditing) {
         props.params.api.stopEditing();
       } else if (props.params.stopEditing) {

--- a/Project/GridViewDinamica/src/components/UserCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/UserCellRenderer.vue
@@ -269,6 +269,10 @@ export default {
     },
     getInitial(name) {
       return name ? String(name).trim().charAt(0).toUpperCase() : '';
+    },
+    refresh(params) {
+      this.params = params;
+      return true;
     }
   }
 };

--- a/Project/GridViewDinamica/src/components/UserSelector.vue
+++ b/Project/GridViewDinamica/src/components/UserSelector.vue
@@ -212,35 +212,37 @@
         </template>
 
         <template v-else>
-          <div
-            v-for="user in filteredUsers"
-            :key="user.id !== null ? user.id : 'assign'"
-            class="user-selector__item"
-            :class="{ disabled: user.isEnabled === false }"
-            @click.stop="user.isEnabled === false || user.groupUsers?.length ? null : selectUser(user)"
-          >
-            <div class="avatar-outer">
-              <div class="avatar-middle">
-                <div class="user-selector__avatar">
-                  <template v-if="user.PhotoURL || user.PhotoUrl">
-                    <img :src="user.PhotoURL || user.PhotoUrl" alt="User Photo" />
-                  </template>
-                  <template v-else>
-                    <span v-if="user.isAssignToTeam" class="material-symbols-outlined user-selector__group-icon">groups</span>
-                    <span v-else class="user-selector__initial" :style="initialStyle">
-                      {{ getInitial(user.name) }}
-                    </span>
-                  </template>
+          <div class="user-selector__current-group-items">
+            <div
+              v-for="user in filteredUsers"
+              :key="user.id !== null ? user.id : 'assign'"
+              class="user-selector__item"
+              :class="{ disabled: user.isEnabled === false }"
+              @click.stop="user.isEnabled === false || user.groupUsers?.length ? null : selectUser(user)"
+            >
+              <div class="avatar-outer">
+                <div class="avatar-middle">
+                  <div class="user-selector__avatar">
+                    <template v-if="user.PhotoURL || user.PhotoUrl">
+                      <img :src="user.PhotoURL || user.PhotoUrl" alt="User Photo" />
+                    </template>
+                    <template v-else>
+                      <span v-if="user.isAssignToTeam" class="material-symbols-outlined user-selector__group-icon">groups</span>
+                      <span v-else class="user-selector__initial" :style="initialStyle">
+                        {{ getInitial(user.name) }}
+                      </span>
+                    </template>
+                  </div>
                 </div>
               </div>
+              <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
+              <span
+                v-if="user.groupUsers?.length"
+                class="material-symbols-outlined user-selector__chevron"
+                @click.stop="openGroup(user)"
+                >chevron_right</span
+              >
             </div>
-            <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
-            <span
-              v-if="user.groupUsers?.length"
-              class="material-symbols-outlined user-selector__chevron"
-              @click.stop="openGroup(user)"
-              >chevron_right</span
-            >
           </div>
         </template>
 
@@ -865,6 +867,13 @@ export default {
   scrollbar-color: #bdbdbd transparent;
 }
 
+.user-selector__current-group-items {
+  max-height: 200px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+
 .user-selector__group-items::-webkit-scrollbar {
   width: 6px;
   background: transparent;
@@ -881,6 +890,26 @@ export default {
 }
 
 .user-selector__group-items::-webkit-scrollbar-button {
+  display: none;
+  height: 0;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+  border-radius: 12px;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar-thumb {
+  background: #bdbdbd;
+  border-radius: 12px;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar-button {
   display: none;
   height: 0;
 }


### PR DESCRIPTION
## Summary
- limit height of group member list with scroll support
- refresh grid data when assigning to team and expose refresh method

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af265bb3448330925aa59c5efe937b