### PR TITLE
feat: allow initial mentions selection

### DIFF
--- a/Project/InputMentions/ww-config.js
+++ b/Project/InputMentions/ww-config.js
@@ -61,6 +61,7 @@ export default {
                 'mentionAllowSpaces',
                 'mentionListLength',
                 'mentionList',
+                'initialMentions',
                 'mentionIdPath',
                 'mentionLabelPath',
                 'mentionHintPath'
@@ -337,6 +338,21 @@ export default {
                             },
                         },
                     },
+                },
+            },
+            defaultValue: [],
+            bindable: true,
+        },
+        initialMentions: {
+            section: 'settings',
+            label: {
+                en: 'Initial mentions',
+            },
+            hidden: content => !content.enableMention,
+            type: 'Array',
+            options: {
+                item: {
+                    type: 'Text',
                 },
             },
             defaultValue: [],


### PR DESCRIPTION
## Summary
- add bindable `initialMentions` property to configure starting mentions
- preselect mentions from provided IDs and display formatted tags

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0591058f0833099484bc3026dd2fa