### PR TITLE
Limpa anexos com DataSource inválido

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -369,13 +369,32 @@ export default {
 
     // Carrega anexos a partir da propriedade Data Source (gera signed URL)
     watch(
-      () => JSON.stringify(props.content.dataSource || []),
-      (json) => {
-        let data = [];
-        try { data = JSON.parse(json); } catch (_) {}
+      () => props.content.dataSource,
+      (ds) => {
+        if (!ds) {
+          files.value = [];
+          return;
+        }
+
+        let data = ds;
+
+        if (typeof data === "string") {
+          try {
+            data = JSON.parse(data);
+          } catch (_) {
+            files.value = [];
+            return;
+          }
+        }
+
+        if (!Array.isArray(data)) {
+          files.value = [];
+          return;
+        }
+
         loadFromDataSource(data);
       },
-      { immediate: true }
+      { immediate: true, deep: true }
     );
 
     function triggerFileInput() {


### PR DESCRIPTION
## Summary
- Evita carregar anexos quando o Data Source é nulo ou inválido
- Garante que a lista de arquivos fique vazia caso o Data Source não seja um array válido

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b05fa4f2108330a1c0439fff99c07d