### PR TITLE
Limpa anexos com DataSource inválido

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -369,13 +369,35 @@ export default {
 
     // Carrega anexos a partir da propriedade Data Source (gera signed URL)
     watch(
-      () => JSON.stringify(props.content.dataSource || []),
-      (json) => {
-        let data = [];
-        try { data = JSON.parse(json); } catch (_) {}
+      () => props.content.dataSource,
+      (ds) => {
+        if (!ds) {
+          dsLoadVersion++;
+          files.value = [];
+          return;
+        }
+
+        let data = ds;
+
+        if (typeof data === "string") {
+          try {
+            data = JSON.parse(data);
+          } catch (_) {
+            dsLoadVersion++;
+            files.value = [];
+            return;
+          }
+        }
+
+        if (!Array.isArray(data)) {
+          dsLoadVersion++;
+          files.value = [];
+          return;
+        }
+
         loadFromDataSource(data);
       },
-      { immediate: true }
+      { immediate: true, deep: true }
     );
 
     function triggerFileInput() {


### PR DESCRIPTION
## Summary
- Cancela carregamentos de anexos pendentes ao detectar Data Source nulo ou inválido
- Evita reaparecimento de anexos de registros anteriores

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b05fa4f2108330a1c0439fff99c07d