### PR TITLE
feat(TimeLine): emit deletion triggers

### DIFF
--- a/Project/TimeLine/src/wwElement.vue
+++ b/Project/TimeLine/src/wwElement.vue
@@ -1370,6 +1370,11 @@ export default {
           event: { value: { TicketCommentID } },
         });
 
+        emit("trigger-event", {
+          name: "timeline:deleted",
+          event: { value: { type: "comment", id: TicketCommentID } },
+        });
+
         cancelCmtDelete();
       } catch (e) {
         cmtError.value = e?.message || String(e);
@@ -1435,6 +1440,21 @@ export default {
 
         attCache.value = { ...attCache.value, [key]: { ...f, deleted: true } };
         if (attModalOpen.value) closeAttModal();
+
+        emit("trigger-event", {
+          name: "timeline:attachmentDeleted",
+          event: { value: { attachmentId: item?.PKTableModified ?? null } },
+        });
+        emit("trigger-event", {
+          name: "timeline:deleted",
+          event: {
+            value: {
+              type: "attachment",
+              id: item?.PKTableModified ?? null,
+              filename: f.file?.name ?? null,
+            },
+          },
+        });
       } catch (e) {
         console.warn("[TimeLine] Falha ao excluir anexo:", e);
       }

--- a/Project/TimeLine/ww-config.js
+++ b/Project/TimeLine/ww-config.js
@@ -318,5 +318,20 @@ export default {
       label: { en: "On marker click" },
       event: { value: null },
     },
+    {
+      name: "timeline:commentDeleted",
+      label: { en: "On comment deleted" },
+      event: { value: { TicketCommentID: null } },
+    },
+    {
+      name: "timeline:attachmentDeleted",
+      label: { en: "On attachment deleted" },
+      event: { value: { attachmentId: null } },
+    },
+    {
+      name: "timeline:deleted",
+      label: { en: "On deletion" },
+      event: { value: { type: null, id: null, filename: null } },
+    },
   ],
 };


### PR DESCRIPTION
## Summary
- emit timeline:deleted trigger for comment deletions
- emit timeline:attachmentDeleted and timeline:deleted for attachment deletions
- expose deletion events for workflow configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b8452d98833080ac37e5ddc486b3