### PR TITLE
feat(anexos): add remount component action

### DIFF
--- a/Project/Anexos/src/wwElement.vue
+++ b/Project/Anexos/src/wwElement.vue
@@ -243,9 +243,9 @@ export default {
     }
 
     // ---- Supabase ----
-    const sb = window?.wwLib?.wwPlugins?.supabase;
-    const supabase = sb?.instance || null; // pode ser null na 1ª render
-    const auth = window?.wwLib?.wwPlugins?.supabaseAuth?.publicInstance || null;
+    let sb = window?.wwLib?.wwPlugins?.supabase;
+    let supabase = sb?.instance || null; // pode ser null na 1ª render
+    let auth = window?.wwLib?.wwPlugins?.supabaseAuth?.publicInstance || null;
 
     // Helpers
     const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -438,6 +438,14 @@ export default {
       if (contextPollId) { clearInterval(contextPollId); contextPollId = null; }
       clearFiles();
     });
+
+    function remount() {
+      sb = window?.wwLib?.wwPlugins?.supabase;
+      supabase = sb?.instance || null;
+      auth = window?.wwLib?.wwPlugins?.supabaseAuth?.publicInstance || null;
+      dsLoadVersion++;
+      handleDataSource(props.content?.dataSource);
+    }
 
     function triggerFileInput() {
       if (fileInput.value) fileInput.value.click();
@@ -685,6 +693,7 @@ export default {
       getFileIcon,
       attachmentsInfo,
       popup, detailsOpen, closePopup, toggleDetails,
+      remount,
     };
   },
 };

--- a/Project/Anexos/ww-config.js
+++ b/Project/Anexos/ww-config.js
@@ -102,4 +102,7 @@ export default {
             },
         },
     ],
+    actions: [
+        { label: { en: 'Remount component' }, action: 'remount' },
+    ],
 };


### PR DESCRIPTION
## Summary
- add remount workflow action to Anexos component
- expose remount method in Anexos element to reload data source
- refresh Supabase plugin references during remount

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f2ee6afc8330af216828152b4c2b