### PR TITLE
feat: allow dynamic sort action in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/ww-config.js
+++ b/Project/GridViewDinamica/ww-config.js
@@ -152,17 +152,28 @@ export default {
     label: { en: 'Reset Filters' },
     args: []
   },
-  {
-    action: 'setFilters',
-    label: { en: 'Set Filters' },
-    args: [
-      {
-        name: 'filters',
-        type: 'object',
-        label: { en: 'Filters JSON' }
-      }
-    ]
-  },
+    {
+      action: 'setFilters',
+      label: { en: 'Set Filters' },
+      args: [
+        {
+          name: 'filters',
+          type: 'object',
+          label: { en: 'Filters JSON' }
+        }
+      ]
+    },
+    {
+      action: 'setSort',
+      label: { en: 'Set Sort' },
+      args: [
+        {
+          name: 'sort',
+          type: 'object',
+          label: { en: 'Sort JSON' }
+        }
+      ]
+    },
   ],
   properties: {
   headerTitle: {


### PR DESCRIPTION
## Summary
- add `setSort` action to GridViewDinamica configuration
- support setting grid sort model from action
- fallback when grid API lacks `setSortModel`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b81525a18483308a2ebf883112abf2