### PR TITLE
Reapply sort and filter when initial props update

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -17,7 +17,7 @@
 </template>
   
 <script>
-  import { shallowRef, watchEffect, computed, ref, onMounted, onUnmounted, watch, h } from "vue";
+  import { shallowRef, computed, ref, onMounted, onUnmounted, watch, h } from "vue";
   import { AgGridVue } from "ag-grid-vue3";
   import {
   AllCommunityModule,
@@ -760,18 +760,26 @@
     }
   };
   
-  watchEffect(() => {
-  if (!gridApi.value) return;
-  if (props.content.initialFilters) {
-  gridApi.value.setFilterModel(props.content.initialFilters);
-  }
-  if (props.content.initialSort) {
-  gridApi.value.applyColumnState({
-  state: props.content.initialSort || [],
-  defaultState: { sort: null },
-  });
-  }
-  });
+  watch(
+    [() => props.content.initialFilters, () => gridApi.value],
+    ([filters]) => {
+      if (!gridApi.value) return;
+      gridApi.value.setFilterModel(filters || null);
+    },
+    { deep: true, immediate: true }
+  );
+
+  watch(
+    [() => props.content.initialSort, () => gridApi.value],
+    ([sort]) => {
+      if (!gridApi.value) return;
+      gridApi.value.applyColumnState({
+        state: sort || [],
+        defaultState: { sort: null },
+      });
+    },
+    { deep: true, immediate: true }
+  );
   
   const onRowSelected = (event) => {
   const name = event.node.isSelected() ? "rowSelected" : "rowDeselected";


### PR DESCRIPTION
## Summary
- Reapply initial filters whenever `initialFilters` prop changes or grid reinitializes
- Reapply initial sorting whenever `initialSort` prop changes or grid reinitializes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b842b9da1c8330a32b1c0e6a6b81b7