### PR TITLE
Fix FormRender isEditing runtime check

### DIFF
--- a/Project/CADASTROSFormRender/Component/wwElement.vue
+++ b/Project/CADASTROSFormRender/Component/wwElement.vue
@@ -71,7 +71,7 @@ export default {
   setup(props) {
     
     const isEditing = computed(() => {
-      return props.wwEditorState.isEditing;
+      return props.wwEditorState?.isEditing || false;
     });
 
     const { value: formData, setValue: setFormData } = wwLib.wwVariable.useComponentVariable({

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -91,7 +91,7 @@ export default {
   setup(props, { emit }) {
     
     const isEditing = computed(() => {
-      return props.wwEditorState.isEditing;
+      return props.wwEditorState?.isEditing || false;
     });
 
     const { value: formData, setValue: setFormData } = wwLib.wwVariable.useComponentVariable({


### PR DESCRIPTION
## Summary
- handle undefined wwEditorState in FormRender components

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b89b4826488330b6cd4c7a272b7245