### PR TITLE
refactor: split responsible user filters

### DIFF
--- a/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
@@ -1,10 +1,11 @@
-export default class ListFilterRenderer {
+export default class ResponsibleUserFilterRenderer {
   constructor() {
     this.searchText = '';
     this.selectedValues = [];
     this.allValues = [];
     this.filteredValues = [];
     this.selectAll = false;
+    this.userInfo = {};
     this.formattedValues = [];
   }
 
@@ -103,6 +104,7 @@ export default class ListFilterRenderer {
 
     this.allValues = [];
     this.formattedValues = [];
+    this.userInfo = {};
     api.forEachNode(node => {
       if (node.data) {
         let value = this.getNestedValue(node.data, field);
@@ -131,7 +133,10 @@ export default class ListFilterRenderer {
         }
         if (value !== undefined && value !== null) {
           this.allValues.push(value);
-          this.formattedValues.push(formatted);
+          const name = node.data.ResponsibleUser || node.data.Username || node.data.UserName || '';
+          const photo = node.data.photoUrl || node.data.PhotoUrl || node.data.PhotoURL || node.data.UserPhoto || '';
+          this.userInfo[value] = { name, photo };
+          this.formattedValues.push(name || formatted);
         }
       }
     });
@@ -161,6 +166,9 @@ export default class ListFilterRenderer {
     });
     this.allValues = zipped.map(z => z.raw);
     this.formattedValues = zipped.map(z => z.formatted);
+    const newInfo = {};
+    this.allValues.forEach(v => { if (this.userInfo[v]) newInfo[v] = this.userInfo[v]; });
+    this.userInfo = newInfo;
     this.filteredValues = [...this.allValues];
   }
 
@@ -185,10 +193,20 @@ export default class ListFilterRenderer {
       const idx = this.allValues.indexOf(rawValue);
       const formattedValue = this.formattedValues[idx] || rawValue;
       const checked = this.selectedValues.includes(rawValue) ? 'checked' : '';
+      const info = this.userInfo[rawValue] || { name: formattedValue, photo: '' };
+      const name = info.name || formattedValue;
+      const photo = info.photo;
+      const initial = name ? name.trim().charAt(0).toUpperCase() : '';
+      const avatar = photo
+        ? `<img src="${photo}" alt="" />`
+        : `<span class="user-initial">${initial}</span>`;
       return `
         <label class="filter-item${this.selectedValues.includes(rawValue) ? ' selected' : ''}">
           <input type="checkbox" value="${rawValue}" ${checked} />
-          <span class="filter-label" title="">${formattedValue}</span>
+          <span class="user-option">
+            <span class="avatar-outer"><span class="avatar-middle"><span class="user-avatar">${avatar}</span></span></span>
+            <span class="filter-label">${name}</span>
+          </span>
         </label>
       `;
     }).join('');

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -37,6 +37,7 @@
   import FormatterCellRenderer from "./components/FormatterCellRenderer.vue";
   import UserCellRenderer from "./components/UserCellRenderer.vue";
   import ListFilterRenderer from "./components/ListFilterRenderer.js";
+  import ResponsibleUserFilterRenderer from "./components/ResponsibleUserFilterRenderer.js";
   import DateTimeCellEditor from "./components/DateTimeCellEditor.js";
   import FixedListCellEditor from "./components/FixedListCellEditor.js";
   import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
@@ -1132,6 +1133,7 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
 
         // Se o filtro for agListColumnFilter, usar o filtro customizado
         if (colCopy.filter === 'agListColumnFilter') {
+          const isResponsible = tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
           const result = {
             ...commonProperties,
             id: colCopy.id,
@@ -1139,10 +1141,8 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             headerName: colCopy.headerName,
             field: colCopy.field,
             sortable: colCopy.sortable,
-            filter: ListFilterRenderer,
-            cellRenderer: (tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID')
-              ? 'UserCellRenderer'
-              : 'FormatterCellRenderer',
+            filter: isResponsible ? ResponsibleUserFilterRenderer : ListFilterRenderer,
+            cellRenderer: isResponsible ? 'UserCellRenderer' : 'FormatterCellRenderer',
             cellRendererParams: {
               useCustomFormatter: colCopy.useCustomFormatter,
               formatter: colCopy.formatter,
@@ -1274,6 +1274,7 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                 ? colCopy.listOptions
                 : null;
 
+              const isResponsible = tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
               const result = {
                 ...commonProperties,
                 id: colCopy.id,
@@ -1281,8 +1282,8 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
                 headerName: colCopy.headerName,
                 field: colCopy.field,
                 sortable: colCopy.sortable,
-                filter: ListFilterRenderer,
-                cellRenderer: 'FormatterCellRenderer',
+                filter: isResponsible ? ResponsibleUserFilterRenderer : ListFilterRenderer,
+                cellRenderer: isResponsible ? 'UserCellRenderer' : 'FormatterCellRenderer',
                 cellRendererParams: {
                   useCustomFormatter: colCopy.useCustomFormatter,
                   formatter: colCopy.formatter,
@@ -1351,7 +1352,9 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             };
             // Filtro de lista dinâmico
             if (colCopy.filter === 'agListColumnFilter') {
-              result.filter = ListFilterRenderer;
+              result.filter = (tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID')
+                ? ResponsibleUserFilterRenderer
+                : ListFilterRenderer;
             }
             // Apply custom formatter if enabled
             if (colCopy.useCustomFormatter) {


### PR DESCRIPTION
## Summary
- add dedicated ResponsibleUserFilterRenderer for ResponsibleUserID columns
- simplify ListFilterRenderer for generic list fields
- choose filter based on column type in GridViewDinamica

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b994b4480c833097be93248add8482