### PR TITLE
Lazy load list editor options

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1197,12 +1197,13 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             const colOpts = this.columnOptions[fieldKey] || {};
             const cached = colOpts[key];
             if (cached) return cached;
-            this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
-
-              if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
-              this.columnOptions[fieldKey][key] = opts;
-              params.api?.refreshCells?.({ force: true });
-            });
+            if (tagControl === 'RESPONSIBLEUSERID') {
+              this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
+                if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
+                this.columnOptions[fieldKey][key] = opts;
+                params.api?.refreshCells?.({ columns: [fieldKey], force: true });
+              });
+            }
             return [];
           };
           const getDsOptionsAsync = params => {
@@ -1212,9 +1213,9 @@ const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontr
             const cached = colOpts[key];
             if (cached) return Promise.resolve(cached);
             return this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
-
               if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
               this.columnOptions[fieldKey][key] = opts;
+              params.api?.refreshCells?.({ columns: [fieldKey], force: true });
               return opts;
             });
           };


### PR DESCRIPTION
## Summary
- Load list editor options on demand for non-responsible fields
- Refresh grid after async option fetch to update display

## Testing
- `npm test` (fails: no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b9c671ee288330b70dd9f855d7fbf9