### PR TITLE
Fix formatted list editor options loading

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -1,6 +1,7 @@
 export default class FixedListCellEditor {
   init(params) {
     this.params = params;
+    console.log('FixedListCellEditor init params:', params);
     const colDef = params.colDef || {};
     this.rendererParams =
       typeof colDef.cellRendererParams === 'function'
@@ -20,6 +21,9 @@ export default class FixedListCellEditor {
     this.listEl = this.eGui.querySelector('.filter-list');
     this.closeBtn = this.eGui.querySelector('.editor-close');
 
+    // log API calls triggered while loading list options
+    this.restoreApiLogger = this.setupApiLogger();
+
 
     const tag =
       (params.colDef.TagControl ||
@@ -31,31 +35,107 @@ export default class FixedListCellEditor {
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
 
 
-    // Fixed list options
-    let optionsArr = [];
-    if (Array.isArray(params.options)) {
-      optionsArr = params.options;
+    // Fixed list options (supports promises)
+    const normalize = opt =>
+      typeof opt === 'object' ? opt : { value: opt, label: String(opt) };
+
+    const resolveOptions = arr => {
+      console.log('FixedListCellEditor resolved options:', arr);
+      this.options = (arr || []).map(normalize);
+      this.filteredOptions = [...this.options];
+      this.renderOptions();
+    };
+
+    let optionsPromise;
+    if (typeof params.options === 'function') {
+      console.log('FixedListCellEditor calling params.options function with', params);
+      try {
+        const result = params.options(params);
+        console.log('FixedListCellEditor params.options function result', result);
+        optionsPromise =
+          result && typeof result.then === 'function'
+            ? result
+            : Promise.resolve(result);
+      } catch (err) {
+        console.error('FixedListCellEditor params.options function error', err);
+        optionsPromise = Promise.resolve([]);
+      }
+    } else if (params.options && typeof params.options.then === 'function') {
+      console.log('FixedListCellEditor using params.options promise', params.options);
+      optionsPromise = params.options;
+    } else if (Array.isArray(params.options)) {
+      console.log('FixedListCellEditor using params.options array', params.options);
+      optionsPromise = Promise.resolve(params.options);
+    } else if (typeof params.colDef.options === 'function') {
+      console.log('FixedListCellEditor calling colDef.options function with', params);
+      try {
+        const result = params.colDef.options(params);
+        console.log('FixedListCellEditor colDef.options function result', result);
+        optionsPromise =
+          result && typeof result.then === 'function'
+            ? result
+            : Promise.resolve(result);
+      } catch (err) {
+        console.error('FixedListCellEditor colDef.options function error', err);
+        optionsPromise = Promise.resolve([]);
+      }
+    } else if (Array.isArray(params.colDef.options)) {
+      console.log('FixedListCellEditor using colDef.options', params.colDef.options);
+      optionsPromise = Promise.resolve(params.colDef.options);
     } else if (Array.isArray(params.colDef.listOptions)) {
-      optionsArr = params.colDef.listOptions;
+      console.log('FixedListCellEditor using colDef.listOptions array', params.colDef.listOptions);
+      optionsPromise = Promise.resolve(params.colDef.listOptions);
+    } else if (
+      typeof params.colDef.listOptions === 'function'
+    ) {
+      console.log('FixedListCellEditor calling colDef.listOptions function with', params);
+      try {
+        const result = params.colDef.listOptions(params);
+        console.log('FixedListCellEditor colDef.listOptions function result', result);
+        optionsPromise =
+          result && typeof result.then === 'function'
+            ? result
+            : Promise.resolve(result);
+      } catch (err) {
+        console.error('FixedListCellEditor colDef.listOptions function error', err);
+        optionsPromise = Promise.resolve([]);
+      }
     } else if (
       typeof params.colDef.listOptions === 'string' &&
       params.colDef.listOptions.trim() !== ''
     ) {
-      optionsArr = params.colDef.listOptions.split(',').map(o => o.trim());
+      console.log('FixedListCellEditor using colDef.listOptions string', params.colDef.listOptions);
+      optionsPromise = Promise.resolve(
+        params.colDef.listOptions.split(',').map(o => o.trim())
+      );
     } else if (
       params.colDef.dataSource &&
       typeof params.colDef.dataSource.list_options === 'string' &&
       params.colDef.dataSource.list_options.trim() !== ''
     ) {
-      optionsArr = params.colDef.dataSource.list_options
-        .split(',')
-        .map(o => o.trim());
+      console.log(
+        'FixedListCellEditor using params.colDef.dataSource.list_options',
+        params.colDef.dataSource.list_options
+      );
+      optionsPromise = Promise.resolve(
+        params.colDef.dataSource.list_options
+          .split(',')
+          .map(o => o.trim())
+      );
+    } else {
+      console.log('FixedListCellEditor no options source found');
+      optionsPromise = Promise.resolve([]);
     }
 
-    this.options = optionsArr.map(opt =>
-      typeof opt === 'object' ? opt : { value: opt, label: String(opt) }
-    );
-    this.filteredOptions = [...this.options];
+    optionsPromise
+      .then(res => {
+        console.log('FixedListCellEditor optionsPromise resolved', res);
+        resolveOptions(res);
+      })
+      .catch(err => {
+        console.error('FixedListCellEditor optionsPromise rejected', err);
+        resolveOptions([]);
+      });
 
     this.value = params.value;
 
@@ -72,8 +152,41 @@ export default class FixedListCellEditor {
         }
       });
     }
+  }
 
-    this.renderOptions();
+  setupApiLogger() {
+    const origFetch = window.fetch;
+    const origAxiosReq = window.axios && window.axios.request;
+    if (origFetch) {
+      window.fetch = (input, init = {}) => {
+        console.log('FixedListCellEditor fetch called with:', input, init);
+        if (init && init.body) {
+          try {
+            console.log('FixedListCellEditor fetch body:', init.body);
+          } catch (e) {
+            console.error('FixedListCellEditor fetch body log error', e);
+          }
+        }
+        return origFetch(input, init);
+      };
+    }
+    if (origAxiosReq) {
+      window.axios.request = function (config) {
+        console.log('FixedListCellEditor axios request config:', config);
+        if (config && config.data) {
+          try {
+            console.log('FixedListCellEditor axios request body:', config.data);
+          } catch (e) {
+            console.error('FixedListCellEditor axios body log error', e);
+          }
+        }
+        return origAxiosReq.apply(this, arguments);
+      };
+    }
+    return () => {
+      if (origFetch) window.fetch = origFetch;
+      if (origAxiosReq) window.axios.request = origAxiosReq;
+    };
   }
 
   filterOptions(text) {
@@ -200,7 +313,15 @@ export default class FixedListCellEditor {
     return this.value;
   }
 
-  destroy() { }
+  destroy() {
+    if (this.restoreApiLogger) {
+      try {
+        this.restoreApiLogger();
+      } finally {
+        this.restoreApiLogger = null;
+      }
+    }
+  }
 
   isPopup() {
     return true;


### PR DESCRIPTION
## Summary
- log cell editor params to inspect API input
- support option sources defined as functions and capture their results
- report resolved option arrays or errors when option promises settle
- wrap fetch/axios to log request URL and body while loading options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d3a58aec83308fb85e58ea2e7607