### PR TITLE
Group Responsible filters by type with avatars

### DIFF
--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -267,3 +267,15 @@
   cursor: pointer;
   line-height: 1;
 }
+
+/* Agrupamento em seções (Responsibles / Groups) */
+:is(.list-filter, .list-editor) .filter-section-title {
+  padding: 4px 0;
+  color: #444;
+  font-size: 13px;
+  font-weight: 400;
+}
+
+:is(.list-filter, .list-editor) .filter-section {
+  padding-bottom: 4px;
+}


### PR DESCRIPTION
## Summary
- Group ResponsibleUserID filter options into Responsibles and Groups
- Show user/group avatars inside filter and add section titles styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bac8323f448330b6e118570bcd6eae