### PR TITLE
feat: add auto-save toggle to form fields

### DIFF
--- a/Project/CADASTROSFormRender/Component/ww-config.js
+++ b/Project/CADASTROSFormRender/Component/ww-config.js
@@ -273,6 +273,22 @@ export default {
                 tooltip: 'Content above this height will scroll vertically'
             }
             /* wwEditor:end */
+        },
+        autoSave: {
+            label: { en: 'Auto save fields' },
+            type: 'boolean',
+            section: 'settings',
+            bindable: true,
+            defaultValue: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'Automatically persist field values when they change'
+            },
+            propertyHelp: {
+                tooltip: 'Disable to require manual saving of field values'
+            }
+            /* wwEditor:end */
         }
     },
     triggerEvents: [

--- a/Project/CADASTROSFormRender/Component/wwElement.vue
+++ b/Project/CADASTROSFormRender/Component/wwElement.vue
@@ -66,6 +66,10 @@ export default {
     ticketId: {
       type: String,
       required: false
+    },
+    autoSave: {
+      type: Boolean,
+      default: true
     }
   },
   setup(props) {
@@ -95,6 +99,11 @@ export default {
     const ticketId = computed(() => props.ticketId || props.content.ticketId);
     const companyId = computed(() => props.content.companyId);
     const language = computed(() => props.content.language);
+    const autoSave = computed(() => {
+      if (typeof props.autoSave === 'boolean') return props.autoSave;
+      if (typeof props.content.autoSave === 'boolean') return props.content.autoSave;
+      return true;
+    });
 
     const formHeightStyle = computed(() => {
       if (props.content.formHeight) {
@@ -278,7 +287,9 @@ export default {
         const field = section.fields.find(f => f.id === fieldId);
         if (field) {
           field.value = value;
-          updateFormState();
+          if (autoSave.value) {
+            updateFormState();
+          }
         }
       }
     };

--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -273,6 +273,22 @@ export default {
                 tooltip: 'Enable to disable editing of all form fields'
             }
             /* wwEditor:end */
+        },
+        autoSave: {
+            label: { en: 'Auto save fields' },
+            type: 'boolean',
+            section: 'settings',
+            bindable: true,
+            defaultValue: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'Automatically persist field values when they change'
+            },
+            propertyHelp: {
+                tooltip: 'Disable to require manual saving of field values'
+            }
+            /* wwEditor:end */
         }
     },
     triggerEvents: [

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -86,6 +86,10 @@ export default {
     readOnly: {
       type: Boolean,
       required: false
+    },
+    autoSave: {
+      type: Boolean,
+      default: true
     }
   },
   setup(props, { emit }) {
@@ -116,6 +120,11 @@ export default {
     const companyId = computed(() => props.content.companyId);
     const language = computed(() => props.content.language);
     const formReadOnly = computed(() => props.content.readOnly);
+    const autoSave = computed(() => {
+      if (typeof props.autoSave === 'boolean') return props.autoSave;
+      if (typeof props.content.autoSave === 'boolean') return props.content.autoSave;
+      return true;
+    });
 
     const loadFormData = () => {
       let formData = null;
@@ -309,7 +318,9 @@ export default {
         const field = section.fields.find(f => f.id === fieldId || f.field_id === fieldId || f.ID === fieldId);
         if (field) {
           field.value = value;
-          updateFormState();
+          if (autoSave.value) {
+            updateFormState();
+          }
         }
       }
     };


### PR DESCRIPTION
## Summary
- add `autoSave` prop to FormRender and CADASTROSFormRender components
- allow skipping automatic form state updates when `autoSave` is false
- expose `autoSave` option in ww-config for both components

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bae7c26b9c8330b9ebb8a16e6624ad