### PR TITLE
feat: disable alerts when auto save off

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <CustomAlert :message="error" :visible="!!error && showAlert" @close="showAlert = false" />
+  <CustomAlert v-if="autoSave" :message="error" :visible="!!error && showAlert" @close="showAlert = false" />
   <div class="field-component"
     :class="[`field-type-${field.fieldType.toLowerCase()}`, { 'is-mandatory': field.is_mandatory }]">
     <!-- Label do campo -->
@@ -206,6 +206,10 @@ export default {
     userId: {
       type: String,
       required: false
+    },
+    autoSave: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -431,7 +435,7 @@ export default {
       immediate: true
     },
     error(val) {
-      this.showAlert = !!val;
+      this.showAlert = this.autoSave && !!val;
     },
     localValue(newVal) {
       if (this.field.fieldType === 'FORMATED_TEXT' && this.$refs.rte && this.$refs.rte.innerHTML !== newVal) {
@@ -513,7 +517,9 @@ export default {
         if (isChanged) {
           this.localValue = value;
           this.$emit('update:value', value);
-          await this.saveFieldValueToApi(apiValue);
+          if (this.autoSave) {
+            await this.saveFieldValueToApi(apiValue);
+          }
           this.originalValue = value;
         }
       }

--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -20,6 +20,7 @@ class="action-icon-section"
             :ticket-id="ticketId"
             :options="getFieldOptions(field.id)"
             :user-id="userId"
+            :auto-save="autoSave"
             @update:value="value => updateFieldValue(field.id, value)"
           />
         </div>
@@ -77,6 +78,10 @@ export default {
     readOnly: {
       type: Boolean,
       default: false
+    },
+    autoSave: {
+      type: Boolean,
+      default: true
     }
   },
   emits: ['update:value'],

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -29,6 +29,7 @@
               :company-id="companyId"
               :language="language"
               :read-only="formReadOnly"
+              :auto-save="autoSave"
               @update-section="updateFormState"
               @edit-section="editSection"
               @edit-field="editFormField"


### PR DESCRIPTION
## Summary
- respect autoSave flag to avoid showing alerts on field changes
- skip API save when autoSave is disabled

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb39acca848330a03daed3cb0ba255