### PR TITLE
Fix autoSave propagation in FormRender

### DIFF
--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -30,7 +30,7 @@ class="action-icon-section"
 </template>
 
 <script>
-import { computed, ref, onMounted, onUnmounted } from 'vue';
+import { computed, ref, onMounted, onUnmounted, toRef } from 'vue';
 import FieldComponent from './FieldComponent.vue';
 
 export default {
@@ -95,6 +95,7 @@ export default {
     const error = ref({});
     const hasAddedListener = ref(false);
     const fieldValues = ref({});
+    const autoSave = toRef(props, 'autoSave');
 
     const toggleFields = () => {
       isExpanded.value = !isExpanded.value;
@@ -311,7 +312,8 @@ export default {
       loading,
       fieldValues,
       getFieldOptions,
-      fieldRows
+      fieldRows,
+      autoSave
     };
   }
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -418,7 +418,8 @@ export default {
       formReadOnly,
       isLoading,
       renderKey,
-      onFieldValueChange
+      onFieldValueChange,
+      autoSave
     };
   }
 };


### PR DESCRIPTION
## Summary
- expose computed autoSave to template in wwElement so forms respect Auto save fields setting
- forward autoSave through FormSection to FieldComponent

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bb3e5f525883308b12f6ff27c01bc7