### PR TITLE
Fix autoSave propagation in FormRender

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <CustomAlert v-if="autoSave" :message="error" :visible="!!error && showAlert" @close="showAlert = false" />
+  <CustomAlert v-if="autoSaveEnabled" :message="error" :visible="!!error && showAlert" @close="showAlert = false" />
   <div class="field-component"
     :class="[`field-type-${field.fieldType.toLowerCase()}`, { 'is-mandatory': field.is_mandatory }]">
     <!-- Label do campo -->
@@ -208,7 +208,7 @@ export default {
       required: false
     },
     autoSave: {
-      type: Boolean,
+      type: [Boolean, String],
       default: true
     }
   },
@@ -233,6 +233,12 @@ export default {
     }
   },
   computed: {
+    autoSaveEnabled() {
+      if (typeof this.autoSave === 'string') {
+        return this.autoSave.toLowerCase() === 'true';
+      }
+      return this.autoSave;
+    },
     listOptions() {
       // Se temos opções passadas via prop (da API), usa essas
       if (this.options && this.options.length > 0) {
@@ -435,7 +441,7 @@ export default {
       immediate: true
     },
     error(val) {
-      this.showAlert = this.autoSave && !!val;
+      this.showAlert = this.autoSaveEnabled && !!val;
     },
     localValue(newVal) {
       if (this.field.fieldType === 'FORMATED_TEXT' && this.$refs.rte && this.$refs.rte.innerHTML !== newVal) {
@@ -517,7 +523,7 @@ export default {
         if (isChanged) {
           this.localValue = value;
           this.$emit('update:value', value);
-          if (this.autoSave) {
+          if (this.autoSaveEnabled) {
             await this.saveFieldValueToApi(apiValue);
           }
           this.originalValue = value;

--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -80,8 +80,8 @@ export default {
       default: false
     },
     autoSave: {
-      type: Boolean,
-      default: true
+      type: [Boolean, String],
+      default: undefined
     }
   },
   emits: ['update:value'],
@@ -95,6 +95,12 @@ export default {
     const error = ref({});
     const hasAddedListener = ref(false);
     const fieldValues = ref({});
+
+    const autoSave = computed(() => {
+      if (typeof props.autoSave === 'string') return props.autoSave.toLowerCase() === 'true';
+      if (typeof props.autoSave === 'boolean') return props.autoSave;
+      return true;
+    });
 
     const toggleFields = () => {
       isExpanded.value = !isExpanded.value;
@@ -311,7 +317,8 @@ export default {
       loading,
       fieldValues,
       getFieldOptions,
-      fieldRows
+      fieldRows,
+      autoSave
     };
   }
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -89,8 +89,8 @@ export default {
       required: false
     },
     autoSave: {
-      type: Boolean,
-      default: true
+      type: [Boolean, String],
+      default: undefined
     }
   },
   setup(props, { emit }) {
@@ -121,9 +121,20 @@ export default {
     const companyId = computed(() => props.content.companyId);
     const language = computed(() => props.content.language);
     const formReadOnly = computed(() => props.content.readOnly);
+
+    const parseAutoSave = val => {
+      if (typeof val === 'boolean') return val;
+      if (typeof val === 'string') return val.toLowerCase() === 'true';
+      return undefined;
+    };
+
     const autoSave = computed(() => {
-      if (typeof props.autoSave === 'boolean') return props.autoSave;
-      if (typeof props.content.autoSave === 'boolean') return props.content.autoSave;
+      const propVal = parseAutoSave(props.autoSave);
+      if (propVal !== undefined) return propVal;
+
+      const contentVal = parseAutoSave(props.content.autoSave);
+      if (contentVal !== undefined) return contentVal;
+
       return true;
     });
 
@@ -418,7 +429,8 @@ export default {
       formReadOnly,
       isLoading,
       renderKey,
-      onFieldValueChange
+      onFieldValueChange,
+      autoSave
     };
   }
 };


### PR DESCRIPTION
## Summary
- parse Auto save fields setting as boolean in root form component
- normalize autoSave in FormSection and FieldComponent so false value is honored downstream

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bb3e5f525883308b12f6ff27c01bc7