### PR TITLE
fix: handle non-array row data in dynamic grid

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -422,7 +422,9 @@
 
   const loadAllColumnOptions = async () => {
     if (!props.content || !Array.isArray(props.content.columns)) return;
-    const rows = wwLib.wwUtils.getDataFromCollection(props.content.rowData) || [];
+    // Ensure rows is an array before iterating to avoid runtime errors
+    const rawRows = wwLib.wwUtils.getDataFromCollection(props.content.rowData);
+    const rows = Array.isArray(rawRows) ? rawRows : [];
     const result = {};
     await Promise.all(
       (props.content.columns || []).map(async (col) => {


### PR DESCRIPTION
## Summary
- prevent runtime error when row data isn't an array in GridViewDinamica

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7bf4f1288330a3ef2846bc1567a1