### PR TITLE
style: highlight category options

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -29,6 +29,7 @@ export default class FixedListCellEditor {
     const identifier = (params.colDef.FieldDB || '').toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    this.isCategoryField = tag === 'CATEGORYID';
 
 
     // Fixed list options
@@ -166,9 +167,9 @@ export default class FixedListCellEditor {
   renderOptions() {
     this.listEl.innerHTML = this.filteredOptions
       .map(opt => {
-        const formatted = this.formatOption(opt);
         const selected = opt.value == this.value ? ' selected' : '';
         if (this.isResponsibleUser) {
+          const formatted = this.formatOption(opt);
           const photo = opt.photo || opt.image || opt.img || '';
           const name = this.stripHtml(String(formatted));
           const initial = name ? name.trim().charAt(0).toUpperCase() : '';
@@ -184,6 +185,12 @@ export default class FixedListCellEditor {
             </div>`;
         }
 
+        if (this.isCategoryField) {
+          const label = this.stripHtml(String(opt.label != null ? opt.label : opt.value));
+          return `<div class="filter-item${selected} category-option" data-value="${opt.value}"><span class="filter-label">${label}</span></div>`;
+        }
+
+        const formatted = this.formatOption(opt);
         return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
       })
       .join('');

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -28,6 +28,7 @@ export default class ListCellEditor {
     const identifier = (params.colDef.FieldDB || '').toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    this.isCategoryField = tag === 'CATEGORYID';
 
     // Build option array (supports promises)
     const normalize = (opt) => {
@@ -176,10 +177,10 @@ export default class ListCellEditor {
   renderOptions() {
     this.listEl.innerHTML = this.filteredOptions
       .map(opt => {
-        const formatted = this.formatOption(opt);
         const selected = opt.value == this.value ? ' selected' : '';
-      
+
         if (this.isResponsibleUser) {
+          const formatted = this.formatOption(opt);
           const photo = opt.photo || opt.image || opt.img || '';
           const name = this.stripHtml(String(formatted));
           const initial = name ? name.trim().charAt(0).toUpperCase() : '';
@@ -194,7 +195,13 @@ export default class ListCellEditor {
               </span>
             </div>`;
         }
-      
+
+        if (this.isCategoryField) {
+          const label = this.stripHtml(String(opt.label != null ? opt.label : opt.value));
+          return `<div class="filter-item${selected} category-option" data-value="${opt.value}"><span class="filter-label">${label}</span></div>`;
+        }
+
+        const formatted = this.formatOption(opt);
         return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
       })
       .join('');

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -201,6 +201,18 @@
   font-family: Roboto, Arial, sans-serif;
 }
 
+:is(.list-filter, .list-editor) .filter-item.category-option .filter-label {
+  background: #c9edf9;
+  color: #303030;
+  border: 1px solid #c9edf9;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  height: 25px;
+  font-weight: 400;
+}
+
 /* Estilos para opções de usuário com avatar */
 :is(.list-filter, .list-editor) .user-option {
   display: flex;


### PR DESCRIPTION
## Summary
- style list editor options for CategoryID fields with blue background, dark text and rounded borders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc85a4543483309cdd0ac0c6804599