### PR TITLE
fix: style category editor options consistently

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -25,10 +25,19 @@ export default class FixedListCellEditor {
       (params.colDef.TagControl ||
         params.colDef.tagControl ||
         params.colDef.tagcontrol ||
-        '').toUpperCase();
-    const identifier = (params.colDef.FieldDB || '').toUpperCase();
+        '')
+        .toString()
+        .trim()
+        .toUpperCase();
+    const identifier = (params.colDef.FieldDB || '')
+      .toString()
+      .trim()
+      .toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    const categoryTags = ['CATEGORYID', 'SUBCATEGORYID', 'CATEGORYLEVEL3ID'];
+    this.isCategoryField =
+      categoryTags.includes(tag) || categoryTags.includes(identifier);
 
 
     // Fixed list options
@@ -166,9 +175,9 @@ export default class FixedListCellEditor {
   renderOptions() {
     this.listEl.innerHTML = this.filteredOptions
       .map(opt => {
-        const formatted = this.formatOption(opt);
         const selected = opt.value == this.value ? ' selected' : '';
         if (this.isResponsibleUser) {
+          const formatted = this.formatOption(opt);
           const photo = opt.photo || opt.image || opt.img || '';
           const name = this.stripHtml(String(formatted));
           const initial = name ? name.trim().charAt(0).toUpperCase() : '';
@@ -184,6 +193,12 @@ export default class FixedListCellEditor {
             </div>`;
         }
 
+        if (this.isCategoryField) {
+          const label = this.stripHtml(String(opt.label != null ? opt.label : opt.value));
+          return `<div class="filter-item${selected} category-option" data-value="${opt.value}"><span class="filter-label">${label}</span></div>`;
+        }
+
+        const formatted = this.formatOption(opt);
         return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
       })
       .join('');

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -24,10 +24,19 @@ export default class ListCellEditor {
       (params.colDef.TagControl ||
         params.colDef.tagControl ||
         params.colDef.tagcontrol ||
-        '').toUpperCase();
-    const identifier = (params.colDef.FieldDB || '').toUpperCase();
+        '')
+        .toString()
+        .trim()
+        .toUpperCase();
+    const identifier = (params.colDef.FieldDB || '')
+      .toString()
+      .trim()
+      .toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    const categoryTags = ['CATEGORYID', 'SUBCATEGORYID', 'CATEGORYLEVEL3ID'];
+    this.isCategoryField =
+      categoryTags.includes(tag) || categoryTags.includes(identifier);
 
     // Build option array (supports promises)
     const normalize = (opt) => {
@@ -176,10 +185,10 @@ export default class ListCellEditor {
   renderOptions() {
     this.listEl.innerHTML = this.filteredOptions
       .map(opt => {
-        const formatted = this.formatOption(opt);
         const selected = opt.value == this.value ? ' selected' : '';
-      
+
         if (this.isResponsibleUser) {
+          const formatted = this.formatOption(opt);
           const photo = opt.photo || opt.image || opt.img || '';
           const name = this.stripHtml(String(formatted));
           const initial = name ? name.trim().charAt(0).toUpperCase() : '';
@@ -194,7 +203,13 @@ export default class ListCellEditor {
               </span>
             </div>`;
         }
-      
+
+        if (this.isCategoryField) {
+          const label = this.stripHtml(String(opt.label != null ? opt.label : opt.value));
+          return `<div class="filter-item${selected} category-option" data-value="${opt.value}"><span class="filter-label">${label}</span></div>`;
+        }
+
+        const formatted = this.formatOption(opt);
         return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
       })
       .join('');

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -201,6 +201,23 @@
   font-family: Roboto, Arial, sans-serif;
 }
 
+:is(.list-filter, .list-editor) .filter-item.category-option .filter-label {
+  background: #c9edf9;
+  color: #303030;
+  border: 1px solid #c9edf9;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 12px;
+  height: 25px;
+  font-weight: 400;
+}
+
+:is(.list-filter, .list-editor) .filter-item.category-option:hover,
+:is(.list-filter, .list-editor) .filter-item.category-option.selected {
+  background: transparent;
+}
+
 /* Estilos para opções de usuário com avatar */
 :is(.list-filter, .list-editor) .user-option {
   display: flex;


### PR DESCRIPTION
## Summary
- detect CategoryID, SUBCATEGORYID, and CATEGORYLEVEL3ID fields and apply category-option class in list editors
- keep CategoryID-related options styled with blue pill background regardless of hover or selection

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68bc85a4543483309cdd0ac0c6804599