### PR TITLE
feat: add required property to DropdownUsers component

### DIFF
--- a/Project/DropdownUsers/src/wwElement.vue
+++ b/Project/DropdownUsers/src/wwElement.vue
@@ -27,10 +27,19 @@
         @user-selected="onUserSelected"
         @trigger-event="onTriggerEvent"
     />
+    <input
+        type="text"
+        :name="wwElementState.name"
+        :value="selectedUserId"
+        :required="content.required"
+        tabindex="-1"
+        class="fake-input"
+    />
 </template>
 
 <script>
 import UserSelector from './components/UserSelector.vue';
+import { computed } from 'vue';
 
 export default {
     components: {
@@ -43,6 +52,9 @@ export default {
         wwEditorState: { type: Object, required: true },
         /* wwEditor:end */
         uid: { type: String, required: true },
+    },
+    inject: {
+        useForm: { from: '_wwForm:useForm', default: null },
     },
     emits: ['update:content:effect', 'update:content', 'element-event', 'user-selected'],
     data() {
@@ -67,6 +79,15 @@ export default {
                     this.selectedUserId = val;
                 }
             );
+            if (this.useForm) {
+                const fieldName = computed(() => this.wwElementState.name);
+                const validation = computed(() => ({ required: this.content.required }));
+                this.useForm(
+                    value,
+                    { fieldName, validation, initialValue: '' },
+                    { elementState: this.wwElementState, emit: this.$emit, sidepanelFormPath: 'form', setValue }
+                );
+            }
         }
     },
     mounted() {
@@ -95,3 +116,19 @@ export default {
     },
 };
 </script>
+
+<style>
+.fake-input {
+    background: rgba(0, 0, 0, 0);
+    border: 0;
+    bottom: -1px;
+    font-size: 0;
+    height: 1px;
+    left: 0;
+    outline: none;
+    padding: 0;
+    position: absolute;
+    right: 0;
+    width: 100%;
+}
+</style>

--- a/Project/DropdownUsers/ww-config.js
+++ b/Project/DropdownUsers/ww-config.js
@@ -172,6 +172,13 @@ export default {
             bindable: true,
             description: 'Maximum width for the selector button (e.g., 150px, 10em, 100%)',
         },
+        required: {
+            label: { en: 'Required' },
+            type: 'OnOff',
+            defaultValue: false,
+            bindable: true,
+            section: 'settings',
+        },
         TableToSave: {
             label: { en: 'Table to Save' },
             type: 'text',


### PR DESCRIPTION
## Summary
- allow DropdownUsers to be marked as required in forms
- ensure required validation shows by styling hidden input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcca2084bc8330872100739aa3defc