### PR TITLE
Use CustomDatePicker for dateString fields

### DIFF
--- a/Project/GridViewDinamica/src/components/CustomDatePicker.vue
+++ b/Project/GridViewDinamica/src/components/CustomDatePicker.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="dp-wrapper" ref="dpWrapper">
     <input
+      ref="dpInput"
       class="dp-input"
       type="text"
       :value="displayDate"
@@ -66,7 +67,7 @@ export default {
     showTime: { type: Boolean, default: false }
   },
   emits: ['update:modelValue'],
-  setup(props, { emit }) {
+  setup(props, { emit, expose }) {
     const translateText = (t) => t;
     const ww = window.wwLib?.wwVariable;
     const lang = ww?.getValue('aa44dc4c-476b-45e9-a094-16687e063342') || navigator.language;
@@ -279,6 +280,8 @@ export default {
       window.removeEventListener('scroll', updatePopoverPosition, true);
       window.removeEventListener('resize', updatePopoverPosition, true);
     });
+
+    expose({ openDp });
 
     const displayDate = computed(() => {
       if (!selectedDate.value) return '';

--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
@@ -72,7 +72,7 @@ export default class DateTimeCellEditor {
   afterGuiAttached() {
     const picker = this.vm?.$refs?.picker;
     if (picker && typeof picker.openDp === 'function') {
-      picker.openDp();
+      setTimeout(() => picker.openDp(), 0);
     }
   }
 
@@ -95,7 +95,7 @@ export default class DateTimeCellEditor {
   }
 
   isPopup() {
-    return false;
+    return true;
   }
 }
 

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1268,7 +1268,7 @@
                 options: getDsOptions(params),
               });
             }
-            if (tagControl === 'DATE' || colCopy.cellDataType === 'date') {
+            if (tagControl === 'DATE' || colCopy.cellDataType === 'date' || colCopy.cellDataType === 'dateString') {
               result.filter = 'agDateColumnFilter';
               if (colCopy.editable) {
                 result.cellEditor = DateTimeCellEditor;


### PR DESCRIPTION
## Summary
- ensure GridViewDinamica date editors expose the CustomDatePicker popup when clicked
- make CustomDatePicker's open method accessible and focus its input

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beb5c0bba88330b38298a8ddbafa20