### PR TITLE
Fix date picker opening in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
@@ -25,7 +25,6 @@ export default class DateTimeCellEditor {
           modelValue: this.value,
           'onUpdate:modelValue': v => (this.value = v),
           showTime: self.showTime,
-          autoOpen: true,
         });
       },
     });
@@ -68,6 +67,13 @@ export default class DateTimeCellEditor {
 
   getGui() {
     return this.eGui;
+  }
+
+  afterGuiAttached() {
+    const picker = this.vm?.$refs?.picker;
+    if (picker && typeof picker.openDp === 'function') {
+      setTimeout(() => picker.openDp(), 0);
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- ensure date fields open calendar by attaching afterGuiAttached hook in DateTimeCellEditor

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bec9c5d5348330862b239bbe092924