### PR TITLE
Fix date picker opening in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/components/CustomDatePicker.vue
+++ b/Project/GridViewDinamica/src/components/CustomDatePicker.vue
@@ -209,11 +209,11 @@ export default {
       if (!wrap) return;
       const rect = wrap.getBoundingClientRect();
       const left = Math.round(rect.left);
-      const bottom = Math.round(window.innerHeight - rect.top + 4);
+      const top = Math.round(rect.bottom + 4);
       dpPopStyle.value = {
         position: 'fixed',
         left: `${left}px`,
-        bottom: `${bottom}px`,
+        top: `${top}px`,
         minWidth: `${Math.max(rect.width, 230)}px`,
         zIndex: 2147483647
       };

--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
@@ -25,7 +25,6 @@ export default class DateTimeCellEditor {
           modelValue: this.value,
           'onUpdate:modelValue': v => (this.value = v),
           showTime: self.showTime,
-          autoOpen: true,
         });
       },
     });
@@ -68,6 +67,13 @@ export default class DateTimeCellEditor {
 
   getGui() {
     return this.eGui;
+  }
+
+  afterGuiAttached() {
+    const picker = this.vm?.$refs?.picker;
+    if (picker && typeof picker.openDp === 'function') {
+      setTimeout(() => picker.openDp(), 0);
+    }
   }
 
 


### PR DESCRIPTION
## Summary
- ensure date fields open calendar by attaching afterGuiAttached hook in DateTimeCellEditor
- position CustomDatePicker popover relative to input using top/left

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bec9c5d5348330862b239bbe092924