### PR TITLE
Align date filters with editor inputs

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeFilter.js
+++ b/Project/GridViewDinamica/src/components/DateTimeFilter.js
@@ -21,8 +21,8 @@ export default class DateTimeFilter {
     this.eGui.style.display = 'flex';
     this.eGui.style.gap = '4px';
     this.eGui.innerHTML = `
-      <input type="date" class="from-date" style="flex:1;" lang="${this.lang}" />
-      <input type="date" class="to-date" style="flex:1;" lang="${this.lang}" />
+      <input type="datetime-local" class="from-date" style="flex:1;" lang="${this.lang}" />
+      <input type="datetime-local" class="to-date" style="flex:1;" lang="${this.lang}" />
 
     `;
     this.fromInput = this.eGui.querySelector('.from-date');
@@ -30,6 +30,23 @@ export default class DateTimeFilter {
     const listener = () => this.params.filterChangedCallback();
     this.fromInput.addEventListener('input', listener);
     this.toInput.addEventListener('input', listener);
+  }
+
+  toDateTimeLocal(value) {
+    try {
+      let v = value;
+      if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?([\+\-]\d{2})?$/.test(v)) {
+        v = v.replace(' ', 'T');
+        if (/([\+\-]\d{2})(\d{2})?$/.test(v)) v = v.replace(/([\+\-]\d{2})(\d{2})?$/, '$1:$2');
+        if (/([\+\-]\d{2})$/.test(v)) v = v.replace(/([\+\-]\d{2})$/, '$1:00');
+      }
+      const d = new Date(v);
+      if (!isNaN(d.getTime())) {
+        const pad = n => n.toString().padStart(2, '0');
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+      }
+    } catch (e) {}
+    return value;
   }
 
 
@@ -59,8 +76,8 @@ export default class DateTimeFilter {
   }
 
   setModel(model) {
-    this.fromInput.value = model?.from || '';
-    this.toInput.value = model?.to || '';
+    this.fromInput.value = model?.from ? this.toDateTimeLocal(model.from) : '';
+    this.toInput.value = model?.to ? this.toDateTimeLocal(model.to) : '';
   }
 
   getGui() {

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -38,6 +38,7 @@
   import UserCellRenderer from "./components/UserCellRenderer.vue";
   import ListFilterRenderer from "./components/ListFilterRenderer.js";
   import ResponsibleUserFilterRenderer from "./components/ResponsibleUserFilterRenderer.js";
+  import DateTimeFilter from "./components/DateTimeFilter.js";
   import DateTimeCellEditor from "./components/DateTimeCellEditor.js";
   import FixedListCellEditor from "./components/FixedListCellEditor.js";
   import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
@@ -1270,7 +1271,7 @@
               });
             }
             if (tagControl === 'DATE' || colCopy.cellDataType === 'date' || colCopy.cellDataType === 'dateString') {
-              result.filter = 'agDateColumnFilter';
+              result.filter = DateTimeFilter;
               if (colCopy.editable) {
                 result.cellEditor = DateTimeCellEditor;
               }
@@ -1290,7 +1291,7 @@
               delete result.valueParser;
             }
             if (tagControl === 'DEADLINE') {
-              result.filter = 'agDateColumnFilter';
+              result.filter = DateTimeFilter;
               // Remove default date configuration applied above
               delete result.cellDataType;
               if (colCopy.editable) {


### PR DESCRIPTION
## Summary
- Replace date filter inputs with `datetime-local` to match cell editor behavior
- Apply `DateTimeFilter` to DATE and DEADLINE columns in dynamic grid

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed9339aa4833094c3cee5cea38cbf