### PR TITLE
feat: improve date filtering with native options

### DIFF
--- a/Project/GridViewDinamica/src/components/CustomDatePicker.vue
+++ b/Project/GridViewDinamica/src/components/CustomDatePicker.vue
@@ -10,7 +10,7 @@
       @pointerdown.stop.prevent="!disabled && openDp($event)"
       @mousedown.stop.prevent="!disabled && openDp($event)"
       @click.stop.prevent="!disabled && openDp($event)"
-      @focus="!disabled && openDp($event)"   
+      @focus="!disabled && autoOpen && openDp($event)"
       aria-haspopup="dialog"
       :aria-expanded="dpOpen ? 'true' : 'false'"
     />

--- a/Project/GridViewDinamica/src/components/DateTimeFilter.js
+++ b/Project/GridViewDinamica/src/components/DateTimeFilter.js
@@ -8,6 +8,9 @@ export default class DateFilterInput {
     this.showTime = !!(params.filterParams && params.filterParams.showTime);
 
     this.eGui = document.createElement('div');
+    this.eGui.style.width = '100%';
+    // allow the filter option dropdown to retain its width
+    this.eGui.style.minWidth = '0';
 
     const self = this;
     this.app = createApp({
@@ -35,7 +38,9 @@ export default class DateFilterInput {
 
   toValue(date) {
     if (!date) return '';
-    const d = date instanceof Date ? date : new Date(date);
+    const d = date instanceof Date
+      ? date
+      : new Date(String(date).includes('T') ? date : `${date}T00:00`);
     if (isNaN(d.getTime())) return '';
     const pad = n => n.toString().padStart(2, '0');
     if (this.showTime) {
@@ -57,8 +62,8 @@ export default class DateFilterInput {
   getDate() {
     const v = this.vm?.value;
     if (!v) return null;
-    const d = new Date(v);
-    return isNaN(d.getTime()) ? null : d;
+    const parsed = v.includes('T') ? new Date(v) : new Date(`${v}T00:00`);
+    return isNaN(parsed.getTime()) ? null : parsed;
   }
 
   setDate(date) {

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -38,7 +38,7 @@
   import UserCellRenderer from "./components/UserCellRenderer.vue";
   import ListFilterRenderer from "./components/ListFilterRenderer.js";
   import ResponsibleUserFilterRenderer from "./components/ResponsibleUserFilterRenderer.js";
-  import DateTimeFilter from "./components/DateTimeFilter.js";
+  import DateFilterInput from "./components/DateTimeFilter.js";
   import DateTimeCellEditor from "./components/DateTimeCellEditor.js";
   import FixedListCellEditor from "./components/FixedListCellEditor.js";
   import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
@@ -765,6 +765,7 @@
     DateTimeCellEditor,
     ResponsibleUserCellEditor,
     ResponsibleUserCellRenderer,
+    agDateInput: DateFilterInput,
   };
   /* wwEditor:end */
   
@@ -838,23 +839,40 @@
             if (typeof v === 'string' && v.length > 0) lang = v;
           }
         } catch (e) {}
+        let base;
         switch (lang) {
           case 'pt-BR':
           case 'pt':
-            return AG_GRID_LOCALE_PT;
+            base = AG_GRID_LOCALE_PT;
+            break;
           case 'fr':
           case 'fr-FR':
-            return AG_GRID_LOCALE_FR;
+            base = AG_GRID_LOCALE_FR;
+            break;
           case 'de':
           case 'de-DE':
-            return AG_GRID_LOCALE_DE;
+            base = AG_GRID_LOCALE_DE;
+            break;
           case 'es':
           case 'es-ES':
-            return AG_GRID_LOCALE_ES;
+            base = AG_GRID_LOCALE_ES;
+            break;
           case 'en-US':
           default:
-            return AG_GRID_LOCALE_EN;
+            base = AG_GRID_LOCALE_EN;
         }
+        const overrides = {
+          'pt-BR': { equals: 'Igual', greaterThan: 'Depois', lessThan: 'Antes', inRange: 'Entre' },
+          'pt': { equals: 'Igual', greaterThan: 'Depois', lessThan: 'Antes', inRange: 'Entre' },
+          'fr': { equals: 'Égal', greaterThan: 'Après', lessThan: 'Avant', inRange: 'Entre' },
+          'fr-FR': { equals: 'Égal', greaterThan: 'Après', lessThan: 'Avant', inRange: 'Entre' },
+          'de': { equals: 'Gleich', greaterThan: 'Nach', lessThan: 'Vor', inRange: 'Zwischen' },
+          'de-DE': { equals: 'Gleich', greaterThan: 'Nach', lessThan: 'Vor', inRange: 'Zwischen' },
+          'es': { equals: 'Igual', greaterThan: 'Después', lessThan: 'Antes', inRange: 'Entre' },
+          'es-ES': { equals: 'Igual', greaterThan: 'Después', lessThan: 'Antes', inRange: 'Entre' },
+          default: { equals: 'Equals', greaterThan: 'After', lessThan: 'Before', inRange: 'Between' },
+        };
+        return { ...base, ...(overrides[lang] || overrides.default) };
       }),
       /* wwEditor:start */
       createElement,
@@ -1271,7 +1289,19 @@
               });
             }
             if (tagControl === 'DATE' || colCopy.cellDataType === 'date' || colCopy.cellDataType === 'dateString') {
-              result.filter = DateTimeFilter;
+              const comparator = (filterDate, cellValue) => {
+                if (!cellValue) return -1;
+                const cellDate = new Date(cellValue);
+                if (isNaN(cellDate.getTime())) return -1;
+                const cellOnlyDate = new Date(cellDate.getFullYear(), cellDate.getMonth(), cellDate.getDate());
+                return cellOnlyDate.getTime() - filterDate.getTime();
+              };
+              result.filter = 'agDateColumnFilter';
+              result.filterParams = {
+                comparator,
+                filterOptions: ['equals', 'greaterThan', 'lessThan', 'inRange'],
+                suppressAndOrCondition: true,
+              };
               if (colCopy.editable) {
                 result.cellEditor = DateTimeCellEditor;
               }
@@ -1291,7 +1321,19 @@
               delete result.valueParser;
             }
             if (tagControl === 'DEADLINE') {
-              result.filter = DateTimeFilter;
+              const comparator = (filterDate, cellValue) => {
+                if (!cellValue) return -1;
+                const cellDate = new Date(cellValue);
+                if (isNaN(cellDate.getTime())) return -1;
+                return cellDate.getTime() - filterDate.getTime();
+              };
+              result.filter = 'agDateColumnFilter';
+              result.filterParams = {
+                comparator,
+                filterOptions: ['equals', 'greaterThan', 'lessThan', 'inRange'],
+                suppressAndOrCondition: true,
+                showTime: true,
+              };
               // Remove default date configuration applied above
               delete result.cellDataType;
               if (colCopy.editable) {
@@ -2228,6 +2270,16 @@ forceClearSelection() {
   :deep(.ag-header-cell.ag-header-cell-filtered .ag-header-icon) {
     color: rgb(105, 157, 140) !important;
     filter: drop-shadow(0 0 2px rgb(105, 157, 140));
+  }
+
+  // Ensure the date filter's option dropdown has enough space
+  :deep(.ag-filter-select) {
+    min-width: 120px;
+  }
+
+  // Prevent the option popup from collapsing to a thin line
+  :deep(.ag-picker-options) {
+    min-width: 120px;
   }
 
   // Fonte da paginação igual à das linhas da grid


### PR DESCRIPTION
## Summary
- use AG Grid's date filter with options equals, after, before or between
- keep CustomDatePicker as the date input and enable time when needed
- rename option labels to better match native filters
- register CustomDatePicker so date filters no longer use native inputs
- open the custom picker on focus only when requested to avoid runaway updates
- parse dates in the filter using local time to prevent values from drifting
- ensure the filter's option list fully opens by giving the select and popup a minimum width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee1fa18908330a1efc3d51d88594b