### PR TITLE
fix: handle non-array data and destroyed grid

### DIFF
--- a/Project/GridViewDinamica/src/components/ListFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ListFilterRenderer.js
@@ -137,6 +137,10 @@ export default class ListFilterRenderer {
 
     this.allValues = [];
     this.formattedValues = [];
+    // ``api`` can be undefined or the grid may already be destroyed when the
+    // filter component remains mounted after navigation. Guard against calling
+    // AG Grid APIs in those cases to avoid runtime errors.
+    if (!api || (api.isDestroyed && api.isDestroyed())) return;
     api.forEachNode(node => {
       if (!node.data) return;
       const rawValue = this.getNestedValue(node.data, field);

--- a/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
@@ -177,6 +177,10 @@ export default class ResponsibleUserFilterRenderer {
     });
 
     const field = this.params.column.getColDef().field || this.params.column.getColId();
+    // Guard against calling AG Grid APIs when the grid has already been
+    // destroyed which may happen if the filter component lives longer than the
+    // grid instance.
+    if (!api || (api.isDestroyed && api.isDestroyed())) return;
     api.forEachNode(node => {
       const data = node.data || {};
       const userId = this.getNestedValue(data, field);

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -278,6 +278,13 @@
   const gridApi = shallowRef(null);
   const columnApi = shallowRef(null);
   const agGridRef = ref(null);
+
+  // Utility to verify that the underlying grid instance is still alive. After
+  // publishing the project some callbacks could be triggered while the grid is
+  // already destroyed which leads AG Grid to throw errors such as
+  // `forEachNode() cannot be called as the grid has been destroyed`.
+  const isGridAlive = () =>
+    gridApi.value && !(gridApi.value.isDestroyed && gridApi.value.isDestroyed());
   const { value: selectedRows, setValue: setSelectedRows } =
   wwLib.wwVariable.useComponentVariable({
   uid: props.uid,
@@ -457,13 +464,25 @@
   };
 
   const loadAllColumnOptions = async () => {
-    if (!props.content || !Array.isArray(props.content.columns)) return;
+    if (!props.content) return;
+
+    // ``columns`` might be provided as an object when the project is
+    // published. Convert to an array to safely iterate over it.
+    const colsSrc = props.content.columns;
+    const columnsArr = Array.isArray(colsSrc) ? colsSrc : Object.values(colsSrc || {});
+    if (!columnsArr.length) return;
+
     // Ensure rows is an array before iterating to avoid runtime errors
     const rawRows = wwLib.wwUtils.getDataFromCollection(props.content.rowData);
-    const rows = Array.isArray(rawRows) ? rawRows : [];
+    const rows = Array.isArray(rawRows)
+      ? rawRows
+      : rawRows && typeof rawRows === 'object'
+        ? Object.values(rawRows)
+        : [];
+
     const result = {};
     await Promise.all(
-      (props.content.columns || []).map(async (col) => {
+      columnsArr.map(async (col) => {
         const colId = col.id || col.field;
         result[colId] = {};
         await Promise.all(
@@ -652,8 +671,8 @@
   
   // Função para forçar a coluna de seleção a ser a primeira
   const forceSelectionColumnFirst = () => {
-    if (!gridApi.value) return;
-    
+    if (!isGridAlive()) return;
+
     try {
       // Tentar reposicionar usando API do AG-Grid
       const columnState = gridApi.value.getColumnState();
@@ -687,19 +706,19 @@
         });
       }
     } catch (error) {
-      
+
     }
-    
+
     // Fallback: reposicionamento direto no DOM
     setTimeout(() => {
-      forceSelectionColumnFirstDOM();
+      if (isGridAlive()) forceSelectionColumnFirstDOM();
     }, 100);
   };
-  
+
   // Função para reposicionar a coluna de seleção diretamente no DOM
   const forceSelectionColumnFirstDOM = () => {
-    if (!gridApi.value) return;
-    
+    if (!isGridAlive()) return;
+
     try {
       const gridElement = agGridRef.value?.$el;
       if (!gridElement) return;
@@ -724,7 +743,7 @@
         }
       });
     } catch (error) {
-      
+
     }
   };
   
@@ -920,7 +939,11 @@
     computed: {
     rowData() {
       const data = wwLib.wwUtils.getDataFromCollection(this.content.rowData);
-      return Array.isArray(data) ? data ?? [] : [];
+      // Some collections might come as objects after publish. Ensure we always
+      // work with an array to avoid ``.map`` runtime errors in production.
+      if (Array.isArray(data)) return data ?? [];
+      if (data && typeof data === 'object') return Object.values(data);
+      return [];
     },
     defaultColDef() {
       return {
@@ -1649,17 +1672,17 @@
   },
   methods: {
   deselectAllRows() {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.deselectAll();
     }
   },
   resetFilters() {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.setFilterModel(null);
     }
   },
   setFilters(filters) {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.setFilterModel(filters || null);
     }
   },
@@ -1701,7 +1724,7 @@
           event.data.PhotoUrl = '';
         }
       }
-      if (this.gridApi && event.node) {
+      if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed()) && event.node) {
         this.gridApi.refreshCells({
           rowNodes: [event.node],
           columns: [fieldKey],
@@ -1716,7 +1739,7 @@
       const v = event.newValue;
       event.node.setDataValue(fieldKey, v);
 
-      if (this.gridApi) {
+      if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
         this.gridApi.refreshCells({
           rowNodes: [event.node],
           columns: [fieldKey],
@@ -1855,14 +1878,14 @@
 },
 clearSelection() {
   // Limpar seleção usando a API do AG-Grid
-  if (this.gridApi) {
+  if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
     this.gridApi.deselectAll();
   }
   // Limpar a variável selectedRows
   this.setSelectedRows([]);
   // Forçar atualização visual
   this.$nextTick(() => {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.deselectAll();
     }
   });
@@ -1882,7 +1905,7 @@ forceClearSelection() {
     this.setSelectedRows([]);
     
     // Forçar AG-Grid a desmarcar
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.deselectAll();
     }
   }
@@ -1904,7 +1927,10 @@ forceClearSelection() {
       }
       // Checar configuração de draggable
       const field = colDef.field;
-      const columnConfig = this.content.columns.find(col => col.field === field);
+      const colsArr = Array.isArray(this.content.columns)
+        ? this.content.columns
+        : Object.values(this.content.columns || {});
+      const columnConfig = colsArr.find(col => col.field === field);
       if (columnConfig && columnConfig.draggable === false) {
         return false;
       }
@@ -1922,7 +1948,9 @@ forceClearSelection() {
     columnDefs: {
       async handler() {
         if (this.wwEditorState?.boundProps?.columns) return;
-        this.gridApi.resetColumnState();
+        if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
+          this.gridApi.resetColumnState();
+        }
 
         if (this.wwEditorState.isACopy) return;
 
@@ -1944,7 +1972,7 @@ forceClearSelection() {
     // Watch for changes in rowSelection to reconfigure selection column
     'content.rowSelection': {
       handler(newValue, oldValue) {
-        if (newValue !== oldValue && this.gridApi) {
+        if (newValue !== oldValue && this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
           this.$nextTick(() => {
             if (newValue === 'multiple' && !this.content.disableCheckboxes) {
               setTimeout(() => {
@@ -1962,10 +1990,10 @@ forceClearSelection() {
     // Watch selectedRows to sync visual state when cleared
     selectedRows: {
       handler(newValue) {
-        if (this.gridApi && Array.isArray(newValue) && newValue.length === 0) {
+        if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed()) && Array.isArray(newValue) && newValue.length === 0) {
           // Clear via AG-Grid API
           setTimeout(() => {
-            if (this.gridApi) {
+            if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
               this.gridApi.deselectAll();
             }
           }, 100);
@@ -1995,7 +2023,7 @@ forceClearSelection() {
     // Reaplica a ordenação atual quando o datasource muda
     'content.rowData': {
       handler() {
-        if (this.gridApi) {
+        if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
           // Reaplica o sortModel atual se existir
           try {
             const currentSort = this.gridApi.getSortModel?.() || [];
@@ -2017,7 +2045,7 @@ forceClearSelection() {
     },
     'content.selectAllRows'(newValue) {
       if (newValue === null) return;
-      if (this.gridApi) {
+      if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
         if (newValue === 'S') {
           this.gridApi.selectAll();
         } else if (newValue === 'N') {


### PR DESCRIPTION
## Summary
- ensure GridViewDinamica handles collection data delivered as objects after publishing
- guard AG Grid API calls when the grid has been destroyed
- protect list and user filters from calling `forEachNode` on a dead grid

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2697c1548330879b5f2d5d2dbec2