### PR TITLE
Fix list editors not loading options in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -41,27 +41,7 @@ export default class FixedListCellEditor {
 
 
 
-    // Fixed list options
-    let optionsArr = [];
-    if (Array.isArray(params.options)) {
-      optionsArr = params.options;
-    } else if (Array.isArray(params.colDef.listOptions)) {
-      optionsArr = params.colDef.listOptions;
-    } else if (
-      typeof params.colDef.listOptions === 'string' &&
-      params.colDef.listOptions.trim() !== ''
-    ) {
-      optionsArr = params.colDef.listOptions.split(',').map(o => o.trim());
-    } else if (
-      params.colDef.dataSource &&
-      typeof params.colDef.dataSource.list_options === 'string' &&
-      params.colDef.dataSource.list_options.trim() !== ''
-    ) {
-      optionsArr = params.colDef.dataSource.list_options
-        .split(',')
-        .map(o => o.trim());
-    }
-
+    // Fixed list options (supports options from renderer params)
     const normalize = (opt) => {
       if (typeof opt === 'object') {
         const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
@@ -75,8 +55,47 @@ export default class FixedListCellEditor {
       }
       return { value: opt, label: String(opt) };
     };
-    this.options = optionsArr.map(normalize);
-    this.filteredOptions = [...this.options];
+
+    const resolveOptions = (arr) => {
+      let list;
+      if (Array.isArray(arr)) list = arr;
+      else if (arr && typeof arr === 'object') list = Object.values(arr);
+      else list = [];
+      this.options = list.map(normalize);
+      this.filteredOptions = [...this.options];
+      this.renderOptions();
+    };
+
+    let optionsPromise;
+    const rendererOpts = this.rendererParams && this.rendererParams.options;
+    if (rendererOpts && typeof rendererOpts.then === 'function') {
+      optionsPromise = rendererOpts;
+    } else if (Array.isArray(rendererOpts)) {
+      optionsPromise = Promise.resolve(rendererOpts);
+    } else if (Array.isArray(params.options)) {
+      optionsPromise = Promise.resolve(params.options);
+    } else if (Array.isArray(params.colDef.listOptions)) {
+      optionsPromise = Promise.resolve(params.colDef.listOptions);
+    } else if (
+      typeof params.colDef.listOptions === 'string' &&
+      params.colDef.listOptions.trim() !== ''
+    ) {
+      optionsPromise = Promise.resolve(
+        params.colDef.listOptions.split(',').map(o => o.trim())
+      );
+    } else if (
+      params.colDef.dataSource &&
+      typeof params.colDef.dataSource.list_options === 'string' &&
+      params.colDef.dataSource.list_options.trim() !== ''
+    ) {
+      optionsPromise = Promise.resolve(
+        params.colDef.dataSource.list_options.split(',').map(o => o.trim())
+      );
+    } else {
+      optionsPromise = Promise.resolve([]);
+    }
+
+    optionsPromise.then(resolveOptions).catch(() => resolveOptions([]));
 
     this.value = params.value;
 
@@ -106,8 +125,6 @@ export default class FixedListCellEditor {
       }
     };
     document.addEventListener('mousedown', this.handleOutsideClick);
-
-    this.renderOptions();
   }
 
   filterOptions(text) {

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -55,13 +55,22 @@ export default class ListCellEditor {
     };
 
     const resolveOptions = (arr) => {
-      this.options = (arr || []).map(normalize);
+      let list;
+      if (Array.isArray(arr)) list = arr;
+      else if (arr && typeof arr === 'object') list = Object.values(arr);
+      else list = [];
+      this.options = list.map(normalize);
       this.filteredOptions = [...this.options];
       this.renderOptions();
     };
 
     let optionsPromise;
-    if (params.options && typeof params.options.then === 'function') {
+    const rendererOpts = this.rendererParams && this.rendererParams.options;
+    if (rendererOpts && typeof rendererOpts.then === 'function') {
+      optionsPromise = rendererOpts;
+    } else if (Array.isArray(rendererOpts)) {
+      optionsPromise = Promise.resolve(rendererOpts);
+    } else if (params.options && typeof params.options.then === 'function') {
       optionsPromise = params.options;
     } else if (Array.isArray(params.options)) {
       optionsPromise = Promise.resolve(params.options);
@@ -88,7 +97,7 @@ export default class ListCellEditor {
       optionsPromise = Promise.resolve([]);
     }
 
-    optionsPromise.then(resolveOptions);
+    optionsPromise.then(resolveOptions).catch(() => resolveOptions([]));
 
     this.value = params.value;
 

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
@@ -44,7 +44,11 @@ export default class ResponsibleUserCellEditor {
       return { value: opt, label: String(opt) };
     };
     const resolveOptions = (opts) => {
-      const arr = (opts || []).map(normalize);
+      let list;
+      if (Array.isArray(opts)) list = opts;
+      else if (opts && typeof opts === 'object') list = Object.values(opts);
+      else list = [];
+      const arr = list.map(normalize);
       this.options = arr;
       this.filteredRoot = [...arr];
       this.applyRootFilter();
@@ -52,7 +56,12 @@ export default class ResponsibleUserCellEditor {
     };
 
     let optionsPromise;
-    if (params.options && typeof params.options.then === 'function') {
+    const rendererOpts = this.rendererParams && this.rendererParams.options;
+    if (rendererOpts && typeof rendererOpts.then === 'function') {
+      optionsPromise = rendererOpts;
+    } else if (Array.isArray(rendererOpts)) {
+      optionsPromise = Promise.resolve(rendererOpts);
+    } else if (params.options && typeof params.options.then === 'function') {
       optionsPromise = params.options;
     } else if (Array.isArray(params.options)) {
       optionsPromise = Promise.resolve(params.options);
@@ -68,7 +77,7 @@ export default class ResponsibleUserCellEditor {
 
     this.options = [];
     this.filteredRoot = [];
-    optionsPromise.then(resolveOptions);
+    optionsPromise.then(resolveOptions).catch(() => resolveOptions([]));
 
     // DOM
     this.eGui = document.createElement('div');

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
@@ -37,7 +37,11 @@ export default {
     };
 
     const mapOptions = list => {
-      const arr = Array.isArray(list) ? list : [];
+      const arr = Array.isArray(list)
+        ? list
+        : list && typeof list === 'object'
+          ? Object.values(list)
+          : [];
       const hasNested = arr.some(it => Array.isArray(getProp(it, 'groupUsers')) && getProp(it, 'groupUsers').length);
       if (hasNested) {
         return arr.map(item => {
@@ -79,8 +83,14 @@ export default {
 
 
     const loadOptions = async () => {
-      if (props.params.options && props.params.options.length) {
-        options.value = mapOptions(props.params.options);
+      const initial = props.params.options;
+      const initialArr = Array.isArray(initial)
+        ? initial
+        : initial && typeof initial === 'object'
+          ? Object.values(initial)
+          : [];
+      if (initialArr.length) {
+        options.value = mapOptions(initialArr);
         return;
       }
       try {


### PR DESCRIPTION
## Summary
- ensure list editors resolve options from cell renderer parameters
- support renderer-based options for fixed list and responsible user editors
- convert non-array option sources into arrays for published builds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c06323d3388330b51f20a85ed8138c