### PR TITLE
feat: add debug logs for grid editors

### DIFF
--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -61,6 +61,11 @@ export default class ListCellEditor {
       else list = [];
       this.options = list.map(normalize);
       this.filteredOptions = [...this.options];
+      if (this.options.length === 0) {
+        console.warn('[ListCellEditor] resolved zero options from', arr);
+      } else {
+        console.log('[ListCellEditor] resolved options', this.options);
+      }
       this.renderOptions();
     };
 
@@ -97,7 +102,12 @@ export default class ListCellEditor {
       optionsPromise = Promise.resolve([]);
     }
 
-    optionsPromise.then(resolveOptions).catch(() => resolveOptions([]));
+    optionsPromise
+      .then(resolveOptions)
+      .catch((err) => {
+        console.error('[ListCellEditor] failed to load options', err);
+        resolveOptions([]);
+      });
 
     this.value = params.value;
 

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
@@ -51,6 +51,11 @@ export default class ResponsibleUserCellEditor {
       const arr = list.map(normalize);
       this.options = arr;
       this.filteredRoot = [...arr];
+      if (arr.length === 0) {
+        console.warn('[ResponsibleUserCellEditor] resolved zero options from', opts);
+      } else {
+        console.log('[ResponsibleUserCellEditor] resolved options', this.options);
+      }
       this.applyRootFilter();
       this.render();
     };
@@ -77,7 +82,12 @@ export default class ResponsibleUserCellEditor {
 
     this.options = [];
     this.filteredRoot = [];
-    optionsPromise.then(resolveOptions).catch(() => resolveOptions([]));
+    optionsPromise
+      .then(resolveOptions)
+      .catch((err) => {
+        console.error('[ResponsibleUserCellEditor] failed to load options', err);
+        resolveOptions([]);
+      });
 
     // DOM
     this.eGui = document.createElement('div');

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -597,6 +597,10 @@
       const onGridReady = (params) => {
         gridApi.value = params.api;
         columnApi.value = params.columnApi;
+        console.log('[GridViewDinamica] onGridReady', {
+          rows: params.api?.getDisplayedRowCount?.(),
+          cols: params.api?.getColumnDefs?.()?.length,
+        });
 
         // Limpeza antecipada quando a grid está prestes a ser destruída
         addGridListener(params.api, 'gridPreDestroyed', () => {
@@ -611,10 +615,13 @@
             headerName: col.getColDef().headerName,
             cellRenderer: col.getColDef().cellRenderer
           }));
+          console.log('[GridViewDinamica] columns', allCols);
         } else if (typeof params.api.getColumnDefs === 'function') {
           const colDefs = params.api.getColumnDefs();
+          console.log('[GridViewDinamica] columnDefs', colDefs);
         } else if (typeof params.api.getColumnState === 'function') {
           const colState = params.api.getColumnState();
+          console.log('[GridViewDinamica] columnState', colState);
         }
 
         updateColumnsPosition();
@@ -886,6 +893,9 @@
       }
 
       const onFirstDataRendered = () => {
+        console.log('[GridViewDinamica] firstDataRendered', {
+          rows: gridApi.value?.getDisplayedRowCount?.(),
+        });
         updateColumnsPosition();
         updateColumnsSort();
 


### PR DESCRIPTION
## Summary
- add debug logs for grid readiness and column details
- add option loading logs to list-based cell editors
- warn when list-based editors resolve no options

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c06f7ff7308330a27f8327232f7aeb