### PR TITLE
Ensure AG Grid styles load in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -30,6 +30,8 @@
     ModuleRegistry,
     themeQuartz,
   } from "ag-grid-community";
+  import "ag-grid-community/styles/ag-grid.css";
+  import "ag-grid-community/styles/ag-theme-quartz.css";
   import {
     AG_GRID_LOCALE_EN,
     AG_GRID_LOCALE_FR,

--- a/Project/GridViewDinamica/ww-config.js
+++ b/Project/GridViewDinamica/ww-config.js
@@ -1,4 +1,10 @@
 export default {
+  files: {
+    css: [
+      'https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css',
+      'https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-quartz.css'
+    ]
+  },
   editor: {
   label: {
   en: "Datagrid",


### PR DESCRIPTION
## Summary
- Load AG Grid base and theme styles through `files` in GridViewDinamica config
- Import AG Grid CSS directly in GridViewDinamica component to fix unstyled editors after publish

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c157ba6edc8330a2ebe4d922fe7bea