### PR TITLE
fix: handle non-array data and destroyed grid

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.js
@@ -4,7 +4,12 @@ import CustomDatePicker from './CustomDatePicker.vue';
 export default class DateTimeCellEditor {
   init(params) {
     this.params = params;
-    const tag = (params.colDef?.TagControl || params.colDef?.tagControl || '').toUpperCase();
+    const tag = (
+      params.colDef?.context?.TagControl ||
+      params.colDef?.TagControl ||
+      params.colDef?.tagControl ||
+      ''
+    ).toUpperCase();
     this.showTime = tag === 'DEADLINE';
 
     this.eGui = document.createElement('div');

--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -22,17 +22,19 @@ export default class FixedListCellEditor {
 
 
     const tag =
-      (params.colDef.TagControl ||
+      (params.colDef.context?.TagControl ||
+        params.colDef.TagControl ||
         params.colDef.tagControl ||
         params.colDef.tagcontrol ||
         '')
         .toString()
         .trim()
         .toUpperCase();
-    const identifier = (params.colDef.FieldDB || '')
-      .toString()
-      .trim()
-      .toUpperCase();
+    const identifier =
+      (params.colDef.context?.FieldDB || params.colDef.FieldDB || '')
+        .toString()
+        .trim()
+        .toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
     const categoryTags = ['CATEGORYID', 'SUBCATEGORYID', 'CATEGORYLEVEL3ID'];
@@ -176,7 +178,7 @@ export default class FixedListCellEditor {
         const styled = this.getRoundedSpanColor(
           value,
           params.styleArray,
-          colDef.FieldDB
+          colDef.context?.FieldDB || colDef.FieldDB
         );
         if (styled) return styled;
       }

--- a/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
@@ -84,11 +84,21 @@ export default {
   },
   computed: {
     isCategoryField() {
-      const tag = (this.params.colDef?.TagControl || this.params.colDef?.tagControl || this.params.colDef?.tagcontrol || '')
+      const tag = (
+        this.params.colDef?.context?.TagControl ||
+        this.params.colDef?.TagControl ||
+        this.params.colDef?.tagControl ||
+        this.params.colDef?.tagcontrol ||
+        ''
+      )
         .toString()
         .trim()
         .toUpperCase();
-      const identifier = (this.params.colDef?.FieldDB || '')
+      const identifier = (
+        this.params.colDef?.context?.FieldDB ||
+        this.params.colDef?.FieldDB ||
+        ''
+      )
         .toString()
         .trim()
         .toUpperCase();

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -21,17 +21,19 @@ export default class ListCellEditor {
     this.closeBtn = this.eGui.querySelector('.editor-close');
 
     const tag =
-      (params.colDef.TagControl ||
+      (params.colDef.context?.TagControl ||
+        params.colDef.TagControl ||
         params.colDef.tagControl ||
         params.colDef.tagcontrol ||
         '')
         .toString()
         .trim()
         .toUpperCase();
-    const identifier = (params.colDef.FieldDB || '')
-      .toString()
-      .trim()
-      .toUpperCase();
+    const identifier =
+      (params.colDef.context?.FieldDB || params.colDef.FieldDB || '')
+        .toString()
+        .trim()
+        .toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
     const categoryTags = ['CATEGORYID', 'SUBCATEGORYID', 'CATEGORYLEVEL3ID'];
@@ -186,7 +188,7 @@ export default class ListCellEditor {
         const styled = this.getRoundedSpanColor(
           value,
           params.styleArray,
-          colDef.FieldDB
+          colDef.context?.FieldDB || colDef.FieldDB
         );
         if (styled) return styled;
       }

--- a/Project/GridViewDinamica/src/components/ListFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ListFilterRenderer.js
@@ -11,17 +11,19 @@ export default class ListFilterRenderer {
   init(params) {
     this.params = params;
     const tag =
-      (params.colDef.TagControl ||
+      (params.colDef.context?.TagControl ||
+        params.colDef.TagControl ||
         params.colDef.tagControl ||
         params.colDef.tagcontrol ||
         '')
         .toString()
         .trim()
         .toUpperCase();
-    const identifier = (params.colDef.FieldDB || '')
-      .toString()
-      .trim()
-      .toUpperCase();
+    const identifier =
+      (params.colDef.context?.FieldDB || params.colDef.FieldDB || '')
+        .toString()
+        .trim()
+        .toUpperCase();
     const categoryTags = ['CATEGORYID', 'SUBCATEGORYID', 'CATEGORYLEVEL3ID'];
     this.isCategoryField =
       categoryTags.includes(tag) || categoryTags.includes(identifier);
@@ -137,6 +139,10 @@ export default class ListFilterRenderer {
 
     this.allValues = [];
     this.formattedValues = [];
+    // ``api`` can be undefined or the grid may already be destroyed when the
+    // filter component remains mounted after navigation. Guard against calling
+    // AG Grid APIs in those cases to avoid runtime errors.
+    if (!api || (api.isDestroyed && api.isDestroyed())) return;
     api.forEachNode(node => {
       if (!node.data) return;
       const rawValue = this.getNestedValue(node.data, field);
@@ -185,7 +191,11 @@ export default class ListFilterRenderer {
             this.dateFormatter
           );
         } else if (rendererParams.useStyleArray && Array.isArray(rendererParams.styleArray)) {
-          const styled = this.getRoundedSpanColor(display, rendererParams.styleArray, colDef.FieldDB);
+          const styled = this.getRoundedSpanColor(
+            display,
+            rendererParams.styleArray,
+            colDef.context?.FieldDB || colDef.FieldDB
+          );
           if (styled) formatted = styled;
         }
       } catch (e) {

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
@@ -19,8 +19,14 @@ export default class ResponsibleUserCellEditor {
     this.searchPlaceholder = 'Search user or group...';
 
     const tag =
-      (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toUpperCase();
-    const identifier = (colDef.FieldDB || '').toUpperCase();
+      (
+        colDef.context?.TagControl ||
+        colDef.TagControl ||
+        colDef.tagControl ||
+        colDef.tagcontrol ||
+        ''
+      ).toUpperCase();
+    const identifier = (colDef.context?.FieldDB || colDef.FieldDB || '').toUpperCase();
     this.isResponsibleUser = tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
 
     // Normalização das opções (mantém chaves extras intactas)
@@ -268,7 +274,11 @@ export default class ResponsibleUserCellEditor {
         );
         return fn(value, {}, colDef, this.getRoundedSpanColor.bind(this), this.dateFormatter.bind(this));
       } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
-        const styled = this.getRoundedSpanColor(value, params.styleArray, colDef.FieldDB);
+        const styled = this.getRoundedSpanColor(
+          value,
+          params.styleArray,
+          colDef.context?.FieldDB || colDef.FieldDB
+        );
         if (styled) return styled;
       }
     } catch (e) {

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellRenderer.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellRenderer.js
@@ -26,8 +26,14 @@ export default class ResponsibleUserCellRenderer {
     return this.params?.colDef || {};
   }
   isResponsibleCol() {
-    const tag = (this.colDef.TagControl || this.colDef.tagControl || this.colDef.tagcontrol || '').toUpperCase();
-    const fieldDb = (this.colDef.FieldDB || '').toUpperCase();
+    const tag = (
+      this.colDef.context?.TagControl ||
+      this.colDef.TagControl ||
+      this.colDef.tagControl ||
+      this.colDef.tagcontrol ||
+      ''
+    ).toUpperCase();
+    const fieldDb = (this.colDef.context?.FieldDB || this.colDef.FieldDB || '').toUpperCase();
     const field = (this.colDef.field || '').toUpperCase();
     return tag === 'RESPONSIBLEUSERID' || fieldDb === 'RESPONSIBLEUSERID' || field === 'RESPONSIBLEUSERID';
   }

--- a/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
@@ -177,6 +177,10 @@ export default class ResponsibleUserFilterRenderer {
     });
 
     const field = this.params.column.getColDef().field || this.params.column.getColId();
+    // Guard against calling AG Grid APIs when the grid has already been
+    // destroyed which may happen if the filter component lives longer than the
+    // grid instance.
+    if (!api || (api.isDestroyed && api.isDestroyed())) return;
     api.forEachNode(node => {
       const data = node.data || {};
       const userId = this.getNestedValue(data, field);

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -94,17 +94,19 @@
       this.value = params.value;
 
       const tag =
-        (params.colDef.TagControl ||
+        (params.colDef.context?.TagControl ||
+          params.colDef.TagControl ||
           params.colDef.tagControl ||
           params.colDef.tagcontrol ||
           '')
           .toString()
           .trim()
           .toUpperCase();
-      const identifier = (params.colDef.FieldDB || '')
-        .toString()
-        .trim()
-        .toUpperCase();
+      const identifier =
+        (params.colDef.context?.FieldDB || params.colDef.FieldDB || '')
+          .toString()
+          .trim()
+          .toUpperCase();
       const categoryTags = ['CATEGORYID', 'SUBCATEGORYID', 'CATEGORYLEVEL3ID'];
       this.isCategoryField =
         categoryTags.includes(tag) || categoryTags.includes(identifier);
@@ -200,7 +202,7 @@
           const styled = this.getRoundedSpanColor(
             value,
             params.styleArray,
-            colDef.FieldDB
+            colDef.context?.FieldDB || colDef.FieldDB
           );
           if (styled) return styled;
         }
@@ -274,10 +276,23 @@
   emits: ["trigger-event", "update:content:effect"],
   setup(props, ctx) {
   const { resolveMappingFormula } = wwLib.wwFormula.useFormula();
-  
+
   const gridApi = shallowRef(null);
   const columnApi = shallowRef(null);
   const agGridRef = ref(null);
+
+  // Ensure row ID generation does not rely on component instance context
+  const getRowId = (params) =>
+    resolveMappingFormula(props.content.idFormula, params.data);
+
+  // Utility to verify that the underlying grid instance is still alive. After
+  // publishing the project some callbacks could be triggered while the grid is
+  // already destroyed which leads AG Grid to throw errors such as
+  // `forEachNode() cannot be called as the grid has been destroyed`.
+  const isGridAlive = () =>
+    gridApi.value && !(gridApi.value.isDestroyed && gridApi.value.isDestroyed());
+  const getColumnsArray = (cols) =>
+    Array.isArray(cols) ? cols : Object.values(cols || {});
   const { value: selectedRows, setValue: setSelectedRows } =
   wwLib.wwVariable.useComponentVariable({
   uid: props.uid,
@@ -457,13 +472,24 @@
   };
 
   const loadAllColumnOptions = async () => {
-    if (!props.content || !Array.isArray(props.content.columns)) return;
+    if (!props.content) return;
+
+    // ``columns`` might be provided as an object when the project is
+    // published. Convert to an array to safely iterate over it.
+    const columnsArr = getColumnsArray(props.content.columns);
+    if (!columnsArr.length) return;
+
     // Ensure rows is an array before iterating to avoid runtime errors
     const rawRows = wwLib.wwUtils.getDataFromCollection(props.content.rowData);
-    const rows = Array.isArray(rawRows) ? rawRows : [];
+    const rows = Array.isArray(rawRows)
+      ? rawRows
+      : rawRows && typeof rawRows === 'object'
+        ? Object.values(rawRows)
+        : [];
+
     const result = {};
     await Promise.all(
-      (props.content.columns || []).map(async (col) => {
+      columnsArr.map(async (col) => {
         const colId = col.id || col.field;
         result[colId] = {};
         await Promise.all(
@@ -608,9 +634,9 @@
 
     // Descobrir colunas DEADLINE
     let deadlineColumns = [];
-    // Timer para atualizar células DEADLINE
-    if (props.content && props.content.columns && Array.isArray(props.content.columns)) {
-      deadlineColumns = props.content.columns
+    const colsForDeadline = getColumnsArray(props.content?.columns);
+    if (colsForDeadline.length) {
+      deadlineColumns = colsForDeadline
         .filter(col => {
           const tc = col.TagControl || col.tagControl || col.tagcontrol;
           return tc && tc.toUpperCase() === 'DEADLINE';
@@ -622,7 +648,7 @@
     if (deadlineColumns.length) {
       deadlineTimer = setInterval(() => {
         window.gridDeadlineNow = new Date();
-        if (gridApi.value) {
+        if (isGridAlive()) {
           gridApi.value.refreshCells({ columns: deadlineColumns, force: true });
         }
       }, 1000);
@@ -636,8 +662,9 @@
     const pinnedLeft = [];
     const pinnedRight = [];
     const others = [];
+    const contentCols = getColumnsArray(props.content?.columns);
     state.forEach(col => {
-      const original = props.content && props.content.columns ? props.content.columns.find(c => c.id === col.colId || c.field === col.colId) : null;
+      const original = contentCols.find(c => c.id === col.colId || c.field === col.colId) || null;
       if (original && original.pinned === 'left') {
         pinnedLeft.push({ ...col, pinned: 'left' });
       } else if (original && original.pinned === 'right') {
@@ -652,8 +679,8 @@
   
   // Função para forçar a coluna de seleção a ser a primeira
   const forceSelectionColumnFirst = () => {
-    if (!gridApi.value) return;
-    
+    if (!isGridAlive()) return;
+
     try {
       // Tentar reposicionar usando API do AG-Grid
       const columnState = gridApi.value.getColumnState();
@@ -672,7 +699,7 @@
         columnState.unshift(selectionColumn);
         
         // Restaurar pinning das outras colunas
-        const originalColumns = props.content && props.content.columns ? props.content.columns : [];
+        const originalColumns = getColumnsArray(props.content?.columns);
         columnState.forEach(colState => {
           const originalCol = originalColumns.find(col => col.id === colState.colId);
           if (originalCol && originalCol.pinned === 'left' && colState.colId !== 'ag-Grid-SelectionColumn') {
@@ -687,19 +714,19 @@
         });
       }
     } catch (error) {
-      
+
     }
-    
+
     // Fallback: reposicionamento direto no DOM
     setTimeout(() => {
-      forceSelectionColumnFirstDOM();
+      if (isGridAlive()) forceSelectionColumnFirstDOM();
     }, 100);
   };
-  
+
   // Função para reposicionar a coluna de seleção diretamente no DOM
   const forceSelectionColumnFirstDOM = () => {
-    if (!gridApi.value) return;
-    
+    if (!isGridAlive()) return;
+
     try {
       const gridElement = agGridRef.value?.$el;
       if (!gridElement) return;
@@ -724,7 +751,7 @@
         }
       });
     } catch (error) {
-      
+
     }
   };
   
@@ -866,6 +893,7 @@
       forceSelectionColumnFirst,
       forceSelectionColumnFirstDOM,
       columnOptions,
+      getRowId,
       localeText: computed(() => {
         let lang = 'en-US';
         try {
@@ -920,7 +948,11 @@
     computed: {
     rowData() {
       const data = wwLib.wwUtils.getDataFromCollection(this.content.rowData);
-      return Array.isArray(data) ? data ?? [] : [];
+      // Some collections might come as objects after publish. Ensure we always
+      // work with an array to avoid ``.map`` runtime errors in production.
+      if (Array.isArray(data)) return data ?? [];
+      if (data && typeof data === 'object') return Object.values(data);
+      return [];
     },
     defaultColDef() {
       return {
@@ -942,11 +974,15 @@
       return columns;
     },
     columnDefs() {
-      if (!this.content || !this.content.columns || !Array.isArray(this.content.columns)) {
+      if (!this.content || !this.content.columns) {
         return [];
       }
 
-      const orderedColumns = [...this.content.columns].sort((a, b) => {
+      const colsSrc = this.content.columns;
+      const columnsArray = Array.isArray(colsSrc) ? colsSrc : Object.values(colsSrc);
+      if (!columnsArray.length) return [];
+
+      const orderedColumns = [...columnsArray].sort((a, b) => {
         const aPos = a.PositionInGrid ?? a.positionInGrid ?? a.PositionField ?? 0;
         const bPos = b.PositionInGrid ?? b.positionInGrid ?? b.PositionField ?? 0;
         return aPos - bPos;
@@ -985,6 +1021,12 @@
         const maxWidth = toNumber(colCopy.maxWidth) || undefined;
         const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontrol || '').toUpperCase();
         const identifier = (colCopy.FieldDB || '').toUpperCase();
+        const context = {
+          ...(colCopy.context || {}),
+          FieldDB: colCopy.FieldDB,
+          TagControl: tagControl,
+          id: colCopy.id,
+        };
         const commonProperties = {
           minWidth,
           ...(width ? { width } : {}),
@@ -993,15 +1035,15 @@
           pinned: colCopy.pinned === "none" ? false : colCopy.pinned,
           hide: !!colCopy.hide,
           editable: !!colCopy.editable, // <-- garantir editable
-          FieldDB: colCopy.FieldDB, // <-- garantir FieldDB no colDef
-          TagControl: tagControl,
+          context,
           ...(colCopy.pinned === 'left' ? { lockPinned: true, lockPosition: true } : {}),
         };
 
-        const fieldKey = colCopy.id || colCopy.field;
+        const colId = colCopy.id || colCopy.field;
+        const fieldKey = colCopy.field || colCopy.id;
         const getDsOptions = params => {
           const ticketId = params.data?.TicketID;
-          const colOpts = this.columnOptions[fieldKey] || {};
+          const colOpts = this.columnOptions?.[colId] || {};
           return colOpts[ticketId] || [];
         };
 
@@ -1011,10 +1053,9 @@
             tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
           const result = {
             ...commonProperties,
-            id: colCopy.id,
-            colId: colCopy.id,
+            colId,
             headerName: colCopy.headerName,
-            field: colCopy.field,
+            field: fieldKey,
             sortable: colCopy.sortable,
             filter: isResponsible
               ? ResponsibleUserFilterRenderer
@@ -1110,8 +1151,7 @@
           case "action": {
             return {
               ...commonProperties,
-              id: colCopy.id,
-              colId: colCopy.id,
+              colId,
               headerName: colCopy.headerName,
               cellRenderer: "ActionCellRenderer",
               cellRendererParams: {
@@ -1127,10 +1167,9 @@
           case "custom":
             return {
               ...commonProperties,
-              id: colCopy.id,
-              colId: colCopy.id,
+              colId,
               headerName: colCopy.headerName,
-              field: colCopy.field,
+              field: fieldKey,
               cellRenderer: "WewebCellRenderer",
               cellRendererParams: {
                 containerId: colCopy.containerId,
@@ -1141,10 +1180,9 @@
           case "image": {
             return {
               ...commonProperties,
-              id: colCopy.id,
-              colId: colCopy.id,
+              colId,
               headerName: colCopy.headerName,
-              field: colCopy.field,
+              field: fieldKey,
               cellRenderer: "ImageCellRenderer",
               cellRendererParams: {
                 width: colCopy.imageWidth,
@@ -1156,7 +1194,7 @@
             {
               const getDsOptions = params => {
                 const ticketId = params.data?.TicketID;
-                const colOpts = this.columnOptions[fieldKey] || {};
+                const colOpts = this.columnOptions?.[colId] || {};
                 return colOpts[ticketId] || [];
               };
 
@@ -1171,10 +1209,9 @@
 
               const result = {
                 ...commonProperties,
-                id: colCopy.id,
-                colId: colCopy.id,
+                colId,
                 headerName: colCopy.headerName,
-                field: colCopy.field,
+                field: fieldKey,
                 sortable: colCopy.sortable,
                 filter: isResponsible
                   ? ResponsibleUserFilterRenderer
@@ -1244,10 +1281,9 @@
           default: {
             const result = {
               ...commonProperties,
-              id: colCopy.id,
-              colId: colCopy.id,
+              colId,
               headerName: colCopy.headerName,
-              field: colCopy.field,
+              field: fieldKey,
               sortable: colCopy.sortable,
               filter: colCopy.filter === 'agListColumnFilter' ? 'agSetColumnFilter' : colCopy.filter,
             };
@@ -1649,22 +1685,19 @@
   },
   methods: {
   deselectAllRows() {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.deselectAll();
     }
   },
   resetFilters() {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.setFilterModel(null);
     }
   },
   setFilters(filters) {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.setFilterModel(filters || null);
     }
-  },
-  getRowId(params) {
-  return this.resolveMappingFormula(this.content.idFormula, params.data);
   },
   onActionTrigger(event) {
   if (!event) return;
@@ -1682,11 +1715,18 @@
   },
   onCellValueChanged(event) {
   const colDef = event.column.getColDef ? event.column.getColDef() : {};
-  const tag = (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toUpperCase();
-  const identifier = (colDef.FieldDB || '').toUpperCase();
-  const fieldKey = colDef.colId || colDef.field;
+  const tag = (
+    colDef.context?.TagControl ||
+    colDef.TagControl ||
+    colDef.tagControl ||
+    colDef.tagcontrol ||
+    ''
+  ).toUpperCase();
+  const identifier = (colDef.context?.FieldDB || colDef.FieldDB || '').toUpperCase();
+  const colId = colDef.colId || colDef.field;
+  const fieldKey = colDef.field || colDef.colId;
   if (tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') {
-    const colOpts = this.columnOptions[fieldKey] || {};
+    const colOpts = this.columnOptions?.[colId] || {};
     const ticketId = event.data?.TicketID;
     const opts = ticketId != null ? colOpts[ticketId] || [] : [];
     const match = opts.find(o => String(o.value) === String(event.newValue));
@@ -1701,7 +1741,7 @@
           event.data.PhotoUrl = '';
         }
       }
-      if (this.gridApi && event.node) {
+      if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed()) && event.node) {
         this.gridApi.refreshCells({
           rowNodes: [event.node],
           columns: [fieldKey],
@@ -1716,7 +1756,7 @@
       const v = event.newValue;
       event.node.setDataValue(fieldKey, v);
 
-      if (this.gridApi) {
+      if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
         this.gridApi.refreshCells({
           rowNodes: [event.node],
           columns: [fieldKey],
@@ -1742,12 +1782,15 @@
   // Identifica a coluna clicada
   const colId = event.column?.getColId?.();
   let fieldDB = null;
-  if (colId) {
-    const colConfig = this.content.columns.find(col => col.id === colId || col.field === colId);
-    if (colConfig) {
-      fieldDB = colConfig.FieldDB;
+    if (colId) {
+      const colsArr = Array.isArray(this.content.columns)
+        ? this.content.columns
+        : Object.values(this.content.columns || {});
+      const colConfig = colsArr.find(col => col.id === colId || col.field === colId);
+      if (colConfig) {
+        fieldDB = colConfig.FieldDB;
+      }
     }
-  }
 
   this.$emit("trigger-event", {
     name: "rowClicked",
@@ -1762,12 +1805,15 @@
 },
   onCellClicked(event) {
   const colId = event.column?.getColId?.();
-  
+
 
   let fieldDB = null;
   let fieldID = null;
   if (colId) {
-    const colConfig = this.content.columns.find(col =>
+    const colsArr = Array.isArray(this.content.columns)
+      ? this.content.columns
+      : Object.values(this.content.columns || {});
+    const colConfig = colsArr.find(col =>
       col.id == colId || col.field == colId || col.colId == colId
     );
     if (colConfig) {
@@ -1855,14 +1901,14 @@
 },
 clearSelection() {
   // Limpar seleção usando a API do AG-Grid
-  if (this.gridApi) {
+  if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
     this.gridApi.deselectAll();
   }
   // Limpar a variável selectedRows
   this.setSelectedRows([]);
   // Forçar atualização visual
   this.$nextTick(() => {
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.deselectAll();
     }
   });
@@ -1882,7 +1928,7 @@ forceClearSelection() {
     this.setSelectedRows([]);
     
     // Forçar AG-Grid a desmarcar
-    if (this.gridApi) {
+    if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
       this.gridApi.deselectAll();
     }
   }
@@ -1904,7 +1950,10 @@ forceClearSelection() {
       }
       // Checar configuração de draggable
       const field = colDef.field;
-      const columnConfig = this.content.columns.find(col => col.field === field);
+      const colsArr = Array.isArray(this.content.columns)
+        ? this.content.columns
+        : Object.values(this.content.columns || {});
+      const columnConfig = colsArr.find(col => col.field === field);
       if (columnConfig && columnConfig.draggable === false) {
         return false;
       }
@@ -1922,16 +1971,21 @@ forceClearSelection() {
     columnDefs: {
       async handler() {
         if (this.wwEditorState?.boundProps?.columns) return;
-        this.gridApi.resetColumnState();
+        if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
+          this.gridApi.resetColumnState();
+        }
 
         if (this.wwEditorState.isACopy) return;
 
         // We assume there will only be one custom column each time
-        const columnIndex = (this.content.columns || []).findIndex(
-          (col) => col.cellDataType === "custom" && !col.containerId
-        );
-        if (columnIndex === -1) return;
-        const newColumns = [...this.content.columns];
+          const colsArr = Array.isArray(this.content.columns)
+            ? this.content.columns
+            : Object.values(this.content.columns || {});
+          const columnIndex = colsArr.findIndex(
+            (col) => col.cellDataType === "custom" && !col.containerId
+          );
+          if (columnIndex === -1) return;
+          const newColumns = [...colsArr];
         let column = { ...newColumns[columnIndex] };
         column.containerId = await this.createElement("ww-flexbox", {
           _state: { name: `Cell ${column.headerName || column.field}` },
@@ -1944,7 +1998,7 @@ forceClearSelection() {
     // Watch for changes in rowSelection to reconfigure selection column
     'content.rowSelection': {
       handler(newValue, oldValue) {
-        if (newValue !== oldValue && this.gridApi) {
+        if (newValue !== oldValue && this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
           this.$nextTick(() => {
             if (newValue === 'multiple' && !this.content.disableCheckboxes) {
               setTimeout(() => {
@@ -1962,10 +2016,10 @@ forceClearSelection() {
     // Watch selectedRows to sync visual state when cleared
     selectedRows: {
       handler(newValue) {
-        if (this.gridApi && Array.isArray(newValue) && newValue.length === 0) {
+        if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed()) && Array.isArray(newValue) && newValue.length === 0) {
           // Clear via AG-Grid API
           setTimeout(() => {
-            if (this.gridApi) {
+            if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
               this.gridApi.deselectAll();
             }
           }, 100);
@@ -1995,7 +2049,7 @@ forceClearSelection() {
     // Reaplica a ordenação atual quando o datasource muda
     'content.rowData': {
       handler() {
-        if (this.gridApi) {
+        if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
           // Reaplica o sortModel atual se existir
           try {
             const currentSort = this.gridApi.getSortModel?.() || [];
@@ -2017,7 +2071,7 @@ forceClearSelection() {
     },
     'content.selectAllRows'(newValue) {
       if (newValue === null) return;
-      if (this.gridApi) {
+      if (this.gridApi && !(this.gridApi.isDestroyed && this.gridApi.isDestroyed())) {
         if (newValue === 'S') {
           this.gridApi.selectAll();
         } else if (newValue === 'N') {


### PR DESCRIPTION
## Summary
- ensure GridViewDinamica handles collection data delivered as objects after publishing
- guard AG Grid API calls when the grid has been destroyed
- protect list and user filters from calling `forEachNode` on a dead grid
- bind row id formula resolver to avoid `this` context loss
- store `FieldDB`, `TagControl`, and `id` under `colDef.context` and update editors/renderers accordingly
- derive column `field` from `field` or `id` and guard option lookups with optional chaining
- normalize column definitions provided as objects so grids render after publishing
- refresh deadline cells only when the grid instance is alive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2697c1548330879b5f2d5d2dbec2