### PR TITLE
Cache column list options and pass ticket only for status field

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -302,9 +302,8 @@
   function usesTicketId(col) {
     const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
     const identifier = (col.FieldDB || '').toUpperCase();
-    if (tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') return false;
-    return col?.dataSource?.useTicketId === true;
-    }
+    return tag === 'STATUSID' || identifier === 'STATUSID';
+  }
   function getOptionsCacheKey(col, ticketId) {
     return usesTicketId(col) && ticketId != null ? String(ticketId) : GLOBAL_OPTIONS_KEY;
   }


### PR DESCRIPTION
## Summary
- Fetch status editor options per row using p_ticketid
- Cache API list options per column for other editors

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d0ec0e2483309e9e761aae7e8d66