### PR TITLE
Use CustomDatePicker for date and deadline fields

### DIFF
--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -11,12 +11,21 @@
     <!-- Campos de entrada baseados no tipo -->
     <div class="field-input-container">
       <!-- DATE -->
-      <input
+      <CustomDatePicker
         v-if="field.fieldType === 'DATE'"
-        type="date"
-        :value="field.value"
+        :model-value="field.value"
         :disabled="field.is_readonly"
-        @input="updateValue"
+        @update:modelValue="val => updateValue({ target: { value: val } })"
+        class="field-input date-input"
+      />
+
+      <!-- DEADLINE -->
+      <CustomDatePicker
+        v-else-if="field.fieldType === 'DEADLINE'"
+        :model-value="field.value"
+        :disabled="field.is_readonly"
+        :show-time="true"
+        @update:modelValue="val => updateValue({ target: { value: val } })"
         class="field-input date-input"
       />
 
@@ -114,8 +123,11 @@
 </template>
 
 <script>
+import CustomDatePicker from '../../../CustomDatePicker/CustomDatePicker.vue';
+
 export default {
   name: 'FieldComponent',
+  components: { CustomDatePicker },
   props: {
     field: {
       type: Object,
@@ -147,6 +159,7 @@ export default {
       // Validação específica por tipo de campo
       switch (this.field.fieldType) {
         case 'DATE':
+        case 'DEADLINE':
           this.validateDate(value);
           break;
         case 'DECIMAL':

--- a/Project/FormBuilderCadastros/Component/components/FieldComponent.vue
+++ b/Project/FormBuilderCadastros/Component/components/FieldComponent.vue
@@ -11,12 +11,21 @@
     <!-- Campos de entrada baseados no tipo -->
     <div class="field-input-container">
       <!-- DATE -->
-      <input
+      <CustomDatePicker
         v-if="field.fieldType === 'DATE'"
-        type="date"
-        :value="field.value"
+        :model-value="field.value"
         :disabled="field.is_readonly"
-        @input="updateValue"
+        @update:modelValue="val => updateValue({ target: { value: val } })"
+        class="field-input date-input"
+      />
+
+      <!-- DEADLINE -->
+      <CustomDatePicker
+        v-else-if="field.fieldType === 'DEADLINE'"
+        :model-value="field.value"
+        :disabled="field.is_readonly"
+        :show-time="true"
+        @update:modelValue="val => updateValue({ target: { value: val } })"
         class="field-input date-input"
       />
 
@@ -114,8 +123,11 @@
 </template>
 
 <script>
+import CustomDatePicker from '../../../CustomDatePicker/CustomDatePicker.vue';
+
 export default {
   name: 'FieldComponent',
+  components: { CustomDatePicker },
   props: {
     field: {
       type: Object,
@@ -147,6 +159,7 @@ export default {
       // Validação específica por tipo de campo
       switch (this.field.fieldType) {
         case 'DATE':
+        case 'DEADLINE':
           this.validateDate(value);
           break;
         case 'DECIMAL':


### PR DESCRIPTION
## Summary
- switch Date/Deadline inputs in form builders to use `CustomDatePicker`
- allow deadlines to edit time and share date validation

## Testing
- `npm test` (FormBuilder/Component) *(fails: Missing script "test")*
- `npm test` (FormBuilderCadastros/Component) *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c1d41c1a30833083f6cca87c2fa247