### PR TITLE
style: highlight category fields in dynamic grid

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -33,6 +33,8 @@ export default class FixedListCellEditor {
     const identifier = (params.colDef.FieldDB || '').toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+    this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
 
 
     // Fixed list options (supports promises)
@@ -266,6 +268,9 @@ export default class FixedListCellEditor {
 
   formatOption(opt) {
     const value = opt.label != null ? opt.label : opt.value;
+    if (this.isCategoryField) {
+      return `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+    }
     const colDef = this.params.colDef || {};
     const params = this.rendererParams || {};
     try {

--- a/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
@@ -87,6 +87,12 @@ export default {
           );
           if (match) displayValue = match.label;
         }
+        const tag = (this.params.colDef?.TagControl || this.params.colDef?.tagControl || this.params.colDef?.tagcontrol || '').toString().toUpperCase();
+        const identifier = (this.params.colDef?.FieldDB || '').toString().toUpperCase();
+        const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+        if (categoryTags.includes(tag) || categoryTags.includes(identifier)) {
+          return `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${displayValue}</span>`;
+        }
         // DEADLINE: barra proporcional
         if (this.params.colDef?.TagControl === 'DEADLINE' || this.params.colDef?.tagControl === 'DEADLINE') {
           const value = this.params.value;

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -28,6 +28,8 @@ export default class ListCellEditor {
     const identifier = (params.colDef.FieldDB || '').toUpperCase();
     this.isResponsibleUser =
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+    this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
 
     // Build option array (supports promises)
     const normalize = (opt) => {
@@ -140,6 +142,9 @@ export default class ListCellEditor {
 
   formatOption(opt) {
     const value = opt.label != null ? opt.label : opt.value;
+    if (this.isCategoryField) {
+      return `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+    }
     const colDef = this.params.colDef || {};
     const params = this.rendererParams || {};
     try {

--- a/Project/GridViewDinamica/src/components/ListFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ListFilterRenderer.js
@@ -100,6 +100,11 @@ export default class ListFilterRenderer {
     const colDef = column.getColDef();
     const field = colDef.field || column.getColId();
 
+    const tag = (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toString().toUpperCase();
+    const identifier = (colDef.FieldDB || '').toString().toUpperCase();
+    const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+    this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+
     const normalize = (opt) => {
       if (typeof opt === 'object') {
         const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
@@ -147,7 +152,9 @@ export default class ListFilterRenderer {
       // Aplica formatter ou style array conforme editor
       let formatted = display;
       try {
-        if (rendererParams.useCustomFormatter && typeof rendererParams.formatter === 'string') {
+        if (this.isCategoryField) {
+          formatted = `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${display}</span>`;
+        } else if (rendererParams.useCustomFormatter && typeof rendererParams.formatter === 'string') {
           const formatterFn = new Function(
             'value',
             'row',

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -63,6 +63,11 @@
       this.listEl = this.eGui.querySelector('.filter-list');
       this.closeBtn = this.eGui.querySelector('.editor-close');
 
+      const tag = (params.colDef.TagControl || params.colDef.tagControl || params.colDef.tagcontrol || '').toString().toUpperCase();
+      const identifier = (params.colDef.FieldDB || '').toString().toUpperCase();
+      const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+      this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+
       // Build option array (supports promises)
       const normalize = opt =>
         typeof opt === 'object' ? opt : { value: opt, label: String(opt) };
@@ -158,6 +163,9 @@
     }
     formatOption(opt) {
       const value = opt.label != null ? opt.label : opt.value;
+      if (this.isCategoryField) {
+        return `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+      }
       const colDef = this.params.colDef || {};
       const params = this.rendererParams || {};
       try {


### PR DESCRIPTION
## Summary
- style CategoryID, SubCategoryID and CategoryLevel3ID cells with gray text, light blue background and rounded borders
- apply same styling to list editors
- ensure filters render category values with the new style

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f966f1dc8330a0be9ec1365426fa