### PR TITLE
feat: add custom date filter options

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeFilter.js
+++ b/Project/GridViewDinamica/src/components/DateTimeFilter.js
@@ -1,6 +1,6 @@
 
 import { createApp, h } from 'vue';
-import CustomDatePicker from './CustomDatePicker.vue';
+import DateTimeCellEditor from './DateTimeCellEditor.vue';
 
 export default class DateFilterInput {
   init(params) {
@@ -21,14 +21,16 @@ export default class DateFilterInput {
         };
       },
       render() {
-        return h(CustomDatePicker, {
+        return h(DateTimeCellEditor, {
           modelValue: this.value,
+          params,
+          showTime: self.showTime,
+          autoOpen: false,
+          disabled: this.disabled,
           'onUpdate:modelValue': v => {
             this.value = v;
             params.onDateChanged();
           },
-          showTime: self.showTime,
-          disabled: this.disabled,
         });
       },
     });
@@ -60,14 +62,16 @@ export default class DateFilterInput {
   }
 
   getDate() {
-    const v = this.vm?.value;
+    const v = this.vm ? this.vm.value : null;
     if (!v) return null;
     const parsed = v.includes('T') ? new Date(v) : new Date(`${v}T00:00`);
     return isNaN(parsed.getTime()) ? null : parsed;
   }
 
   setDate(date) {
-    this.vm.value = this.toValue(date);
+    if (this.vm) {
+      this.vm.value = this.toValue(date);
+    }
   }
 
   setDisabled(disabled) {

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -38,6 +38,7 @@
   import ListFilterRenderer from "./components/ListFilterRenderer.js";
   import ResponsibleUserFilterRenderer from "./components/ResponsibleUserFilterRenderer.js";
   import DateTimeCellEditor from "./components/DateTimeCellEditor.vue";
+  import DateTimeFilter from "./components/DateTimeFilter.js";
   import FixedListCellEditor from "./components/FixedListCellEditor.js";
   import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
   // Editor customizado inline para listas
@@ -1120,6 +1121,7 @@ setTimeout(() => {
         FixedListCellEditor,
         ResponsibleUserCellEditor,
         DateTimeCellEditor,
+        DateTimeFilter,
       },
     };
   },
@@ -1531,9 +1533,35 @@ setTimeout(() => {
             }
             // Use DateTimeCellEditor for editable date fields and deadlines
             if (colCopy.cellDataType === 'dateString' || tagControl === 'DEADLINE') {
-
+              const showTime = tagControl === 'DEADLINE';
               result.filter = 'agDateColumnFilter';
-              if (tagControl !== 'DEADLINE') {
+              result.filterParams = {
+                filterOptions: ['equals', 'greaterThan', 'lessThan', 'inRange'],
+                defaultOption: 'equals',
+                suppressAndOrCondition: true,
+                buttons: ['reset', 'apply'],
+                dateComponent: DateTimeFilter,
+                showTime,
+                comparator: (filterDate, cellValue) => {
+                  if (!cellValue) return -1;
+                  const cellDate = new Date(cellValue);
+                  if (isNaN(cellDate)) return -1;
+                  if (!showTime) {
+                    const cellNoTime = new Date(
+                      cellDate.getFullYear(),
+                      cellDate.getMonth(),
+                      cellDate.getDate()
+                    );
+                    if (cellNoTime < filterDate) return -1;
+                    if (cellNoTime > filterDate) return 1;
+                    return 0;
+                  }
+                  if (cellDate < filterDate) return -1;
+                  if (cellDate > filterDate) return 1;
+                  return 0;
+                }
+              };
+              if (!showTime) {
                 result.cellDataType = 'dateString';
               } else {
                 delete result.cellDataType;


### PR DESCRIPTION
## Summary
- enhance GridViewDinamica date filters with native-like options (equals, after, before, between)
- wire custom DateTimeFilter component based on DateTimeCellEditor for consistent date inputs
- fix compilation by registering DateTimeFilter and removing optional chaining

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fed662dc83308c07e9aef8b1d81e