### PR TITLE
feat(combo): add user avatar option

### DIFF
--- a/Project/ComboAgrupador/src/wwElement_Option.vue
+++ b/Project/ComboAgrupador/src/wwElement_Option.vue
@@ -21,10 +21,32 @@
                 @change.stop="toggle"
                 @click.stop
             />
-            <span :style="optionTextStyles">{{ data.label }}</span>
+            <div class="user-option-content">
+                <template v-if="isUsersCombo">
+                    <div class="user-option-avatar" v-if="!isGroupOption">
+                        <img v-if="avatarUrl" :src="avatarUrl" alt="User avatar" />
+                        <span v-else>{{ avatarInitial }}</span>
+                    </div>
+                    <div class="user-option-avatar" v-else>
+                        <span class="material-symbols-outlined">groups</span>
+                    </div>
+                </template>
+                <span :style="optionTextStyles">{{ data.label }}</span>
+            </div>
         </label>
         <template v-else>
-            <span :style="optionTextStyles">{{ data.label }}</span>
+            <div class="user-option-content">
+                <template v-if="isUsersCombo">
+                    <div class="user-option-avatar" v-if="!isGroupOption">
+                        <img v-if="avatarUrl" :src="avatarUrl" alt="User avatar" />
+                        <span v-else>{{ avatarInitial }}</span>
+                    </div>
+                    <div class="user-option-avatar" v-else>
+                        <span class="material-symbols-outlined">groups</span>
+                    </div>
+                </template>
+                <span :style="optionTextStyles">{{ data.label }}</span>
+            </div>
             <div v-if="data.isSelected" v-html="optionIcon" :style="optionIconStyle" aria-hidden="true"></div>
         </template>
     </div>
@@ -201,6 +223,21 @@ export default {
                 : Array.isArray(selectValue.value) && selectValue.value.some(v => areValuesEqual(v, value.value))
         );
 
+        const isUsersCombo = computed(() => props.content.isUsers || false);
+        const avatarUrl = computed(
+            () =>
+                props.localData?.photoUrl || props.localData?.PhotoURL || props.localData?.PhotoUrl
+        );
+        const isGroupOption = computed(() => {
+            const d = props.localData || {};
+            return (
+                (Array.isArray(d.groupUsers) && d.groupUsers.length > 0) ||
+                String(d.type || '').toLowerCase() === 'group' ||
+                d.isAssignToTeam
+            );
+        });
+        const avatarInitial = computed(() => (label.value || '').trim().charAt(0).toUpperCase());
+
         const { optionId, handleKeyDown, focusFromOptionId } = useAccessibility({
             emit,
             optionElement,
@@ -354,6 +391,10 @@ export default {
             selectType,
             toggle,
             isSelected,
+            isUsersCombo,
+            avatarUrl,
+            avatarInitial,
+            isGroupOption,
         };
     },
 };
@@ -383,5 +424,31 @@ export default {
     display: flex;
     align-items: center;
     gap: 0.5em;
+}
+
+.user-option-content {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+}
+
+.user-option-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background-color: #F3F4F6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 500;
+    color: #6B7280;
+    overflow: hidden;
+}
+
+.user-option-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 </style>

--- a/Project/ComboAgrupador/src/wwElement_Trigger.vue
+++ b/Project/ComboAgrupador/src/wwElement_Trigger.vue
@@ -2,7 +2,20 @@
     <div class="ww-input-select__trigger">
         <!-- SINGLE SELECT -->
         <div v-if="isSingleSelect" :style="triggerStyle">
-            <span v-if="isOptionSelected" :style="selectedValueStyle">{{ selectedLabel }}</span>
+            <template v-if="isOptionSelected">
+                <div class="user-option-content">
+                    <template v-if="isUsersCombo">
+                        <div class="user-option-avatar" v-if="!selectedIsGroup">
+                            <img v-if="selectedAvatarUrl" :src="selectedAvatarUrl" alt="User avatar" />
+                            <span v-else>{{ selectedInitial }}</span>
+                        </div>
+                        <div class="user-option-avatar" v-else>
+                            <span class="material-symbols-outlined">groups</span>
+                        </div>
+                    </template>
+                    <span :style="selectedValueStyle">{{ selectedLabel }}</span>
+                </div>
+            </template>
             <span v-else :style="placeholderStyle">{{ data.placeholder }}</span>
             <div v-html="chipIcon" :style="triggerIconStyle" aria-hidden="true"></div>
         </div>
@@ -75,6 +88,25 @@ export default {
                 !!localContext.value?.data?.select?.active?.details?.label ||
                 localContext.value?.data?.select?.active?.details?.length > 0
         );
+        const isUsersCombo = computed(() => props.content.isUsers || false);
+        const selectedOptionData = computed(
+            () => localContext.value?.data?.select?.active?.details?.data || {}
+        );
+        const selectedAvatarUrl = computed(
+            () =>
+                selectedOptionData.value?.photoUrl ||
+                selectedOptionData.value?.PhotoURL ||
+                selectedOptionData.value?.PhotoUrl
+        );
+        const selectedIsGroup = computed(() => {
+            const d = selectedOptionData.value || {};
+            return (
+                (Array.isArray(d.groupUsers) && d.groupUsers.length > 0) ||
+                String(d.type || '').toLowerCase() === 'group' ||
+                d.isAssignToTeam
+            );
+        });
+        const selectedInitial = computed(() => (selectedLabel.value || '').trim().charAt(0).toUpperCase());
         const isOpen = computed(() => localContext.value?.data?.select?.utils?.isOpen);
         const data = ref({
             placeholder,
@@ -312,6 +344,10 @@ export default {
             setChipRef,
             visibleChipCount,
             hiddenChipCount,
+            isUsersCombo,
+            selectedAvatarUrl,
+            selectedIsGroup,
+            selectedInitial,
         };
     },
 };
@@ -346,5 +382,31 @@ export default {
 
 .ww-select-trigger {
     width: 100%;
+}
+
+.user-option-content {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+}
+
+.user-option-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background-color: #F3F4F6;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 500;
+    color: #6B7280;
+    overflow: hidden;
+}
+
+.user-option-avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
 }
 </style>

--- a/Project/ComboAgrupador/ww-config.js
+++ b/Project/ComboAgrupador/ww-config.js
@@ -145,6 +145,7 @@ export default {
             'mappingValue',
             'mappingDisabled',
             'groupBy',
+            'isUsers',
             'optionBgColorField',
             'optionFontColorField',
             'initValueSingle',
@@ -868,6 +869,12 @@ export default {
                 tooltip:
                     'This should be disabled in some edge cases like in popups, datagrid, etc. A boolean value: \n\n`true` or `false`',
             },
+            section: 'settings',
+        },
+        isUsers: {
+            label: { en: 'Users combo' },
+            type: 'OnOff',
+            defaultValue: false,
             section: 'settings',
         },
         optionProperties: {


### PR DESCRIPTION
## Summary
- add `isUsers` setting to ComboAgrupador
- show user avatars or group icons next to labels when `isUsers` is true

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3f8dadfcc83309c0dafe024e7bada