### PR TITLE
feat: add search icon and separators to ComboAgrupador

### DIFF
--- a/Project/ComboAgrupador/src/wwElement_OptionList.vue
+++ b/Project/ComboAgrupador/src/wwElement_OptionList.vue
@@ -16,6 +16,7 @@
             >
                 <wwLayoutItemContext :key="index" is-repeat :index="index" :data="item">
                     <template v-if="item.__type === 'group'">
+                        <div class="ww-select-separator"></div>
                         <div class="ww-select-group" :style="{ padding: content.optionPadding }">
                             <span style="font-size:16px"
                                 class="material-symbols-outlined ww-select-group-icon"
@@ -378,6 +379,10 @@ export default {
 
 <style>
 @import 'vue-virtual-scroller/dist/vue-virtual-scroller.css';
+
+.ww-select-separator {
+    border-top: 1px solid #e0e0e0;
+}
 
 .ww-select-group-label {
     display: flex;

--- a/Project/ComboAgrupador/src/wwElement_Search.vue
+++ b/Project/ComboAgrupador/src/wwElement_Search.vue
@@ -1,14 +1,17 @@
 <template>
-    <input
-        ref="searchElementRef"
-        name="select-search"
-        :style="[searchStyles]"
-        :class="['ww-select-search']"
-        @input="handleInputChange"
-        @focus="handleSearchFocus"
-        @blur="handleSearchBlur"
-        :placeholder="searchPlaceholder"
-    />
+    <div class="ww-select-search-wrapper">
+        <span class="material-symbols-outlined ww-select-search-icon">search</span>
+        <input
+            ref="searchElementRef"
+            name="select-search"
+            :style="[searchStyles]"
+            :class="['ww-select-search']"
+            @input="handleInputChange"
+            @focus="handleSearchFocus"
+            @blur="handleSearchBlur"
+            :placeholder="searchPlaceholder"
+        />
+    </div>
 </template>
 
 <script>
@@ -65,6 +68,7 @@ export default {
                 height: props.content.searchHeight,
                 'border-radius': props.content.searchBorderRadius,
                 padding: props.content.searchPadding,
+                'padding-left': '30px',
                 margin: props.content.searchMargin,
                 'background-color': props.content.searchBgColor,
                 'font-family': props.content.searchFontFamily,
@@ -122,6 +126,20 @@ export default {
 </script>
 
 <style scoped lang="scss">
+.ww-select-search-wrapper {
+    position: relative;
+}
+
+.ww-select-search-icon {
+    position: absolute;
+    left: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 20px;
+    color: #9e9e9e;
+    pointer-events: none;
+}
+
 .ww-select-search {
     &::placeholder {
         color: var(--placeholder-color);

--- a/Project/ComboAgrupador/src/wwElement_Select.vue
+++ b/Project/ComboAgrupador/src/wwElement_Select.vue
@@ -41,6 +41,8 @@
                     <div :style="[dropdownStyles]">
                         <SelectDropdown :content="content" :wwEditorState="wwEditorState">
                             <SelectSearch v-if="showSearch" :content="content" :wwEditorState="wwEditorState" />
+                            <div class="ww-select-close" @click="closeDropdown">x</div>
+                            <div class="ww-select-separator"></div>
                             <!-- List mode -->
                             <SelectOptionList :content="content" :wwEditorState="wwEditorState" />
                         </SelectDropdown>
@@ -1017,6 +1019,12 @@ export default {
 
 <style lang="scss" scoped>
 // dropdown width is
+
+.ww-select-close {
+    text-align: right;
+    padding: 4px 8px;
+    cursor: pointer;
+}
 
 .ww-select {
     position: relative;


### PR DESCRIPTION
## Summary
- add close button and separators to dropdown blocks
- show search icon inside search field

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ff2e03e88330991d73df77966dd3