### PR TITLE
feat: add group checkbox toggle

### DIFF
--- a/Project/ComboAgrupador/ww-config.js
+++ b/Project/ComboAgrupador/ww-config.js
@@ -146,6 +146,7 @@ export default {
             'mappingDisabled',
             'groupBy',
             'isUsers',
+            'showGroupCheckbox',
             'optionBgColorField',
             'optionFontColorField',
             'initValueSingle',
@@ -875,6 +876,12 @@ export default {
             label: { en: 'Users combo' },
             type: 'OnOff',
             defaultValue: false,
+            section: 'settings',
+        },
+        showGroupCheckbox: {
+            label: { en: 'Show group checkbox' },
+            type: 'OnOff',
+            defaultValue: true,
             section: 'settings',
         },
         optionProperties: {


### PR DESCRIPTION
## Summary
- add showGroupCheckbox option to ComboAgrupador
- hide checkbox and collapse icon when disabled
- avoid displaying group header for User group

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c40e0a856c83308932c01acdffe69c