### PR TITLE
Ensure required fields show red border

### DIFF
--- a/Project/FormRender/Component/components/CustomDatePicker.vue
+++ b/Project/FormRender/Component/components/CustomDatePicker.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="dp-wrapper" ref="dpWrapper">
     <input
-      class="dp-input"
+      :class="['dp-input', { error }]"
       type="text"
       :value="displayDate"
       readonly
@@ -63,7 +63,8 @@ export default {
   props: {
     modelValue: { type: String, default: '' },
     disabled: { type: Boolean, default: false },
-    showTime: { type: Boolean, default: false }
+    showTime: { type: Boolean, default: false },
+    error: { type: Boolean, default: false }
   },
   emits: ['update:modelValue'],
   setup(props, { emit }) {
@@ -306,7 +307,8 @@ export default {
       timePart,
       onTimeInput,
       showTime: props.showTime,
-      disabled: props.disabled
+      disabled: props.disabled,
+      error: props.error
     };
   }
 };
@@ -334,6 +336,11 @@ export default {
   font-size: 13px;
   border: 1px solid #ccc; /* borda fina e cinza escura */
   border-radius: 4px;
+}
+
+.dp-input.error {
+  border-color: #ff0000;
+  box-shadow: 0 0 0 1px #ff0000;
 }
 
 .dp-icon {

--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -11,7 +11,12 @@
     <!-- Campos de entrada baseados no tipo -->
     <div class="field-input-container">
       <template v-if="field.fieldType === 'DATE'">
-        <CustomDatePicker v-model="localValue" :disabled="field.is_readonly" @update:modelValue="onDateChange" />
+        <CustomDatePicker
+          v-model="localValue"
+          :disabled="field.is_readonly"
+          @update:modelValue="onDateChange"
+          :error="error && field.is_mandatory"
+        />
       </template>
       <template v-else-if="field.fieldType === 'DEADLINE'">
         <div style="position:relative;">
@@ -89,7 +94,7 @@
       <template
         v-else-if="field.fieldType === 'SIMPLE_LIST' || field.fieldType === 'CONTROLLED_LIST' || field.fieldType === 'LIST'">
         <div class="custom-dropdown-wrapper" :class="{ 'readonly-field': field.is_readonly }">
-          <div class="custom-dropdown-selected" :class="{ 'open': dropdownOpen, 'readonly-field': field.is_readonly }"
+          <div class="custom-dropdown-selected" :class="{ open: dropdownOpen, 'readonly-field': field.is_readonly, error: error && field.is_mandatory }"
             @click="onDropdownClick" tabindex="0" @keydown.enter.prevent="!field.is_readonly && toggleDropdown()">
             <span v-if="selectedOption" @click.stop="onDropdownClick" style="pointer-events:auto">{{ selectedOption.label }}</span>
             <span class="material-symbols-outlined dropdown-arrow" @click.stop="onDropdownClick" style="pointer-events:auto">expand_more</span>
@@ -1136,6 +1141,11 @@ export default {
   .custom-dropdown-selected.open {
     border-color: #699d8c;
     box-shadow: 0 2px 8px rgba(105, 157, 140, 0.08);
+  }
+
+  .custom-dropdown-selected.error {
+    border-color: #ff0000;
+    box-shadow: 0 0 0 1px #ff0000;
   }
 
   .custom-dropdown-selected.readonly-field {


### PR DESCRIPTION
## Summary
- Show validation error styling on dropdowns and date picker
- Add error prop to custom date picker component

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: weweb not found)


------
https://chatgpt.com/codex/tasks/task_e_68c4d03427a883308e87f3979428f66b