### PR TITLE
Use FormatterCellRenderer for dateTime cells

### DIFF
--- a/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
@@ -109,8 +109,12 @@ export default {
         const rawValue = this.params.value;
         let displayValue = rawValue;
 
-if (this.params.colDef?.TagControl === 'DATETIME' || this.params.colDef?.tagControl === 'DATETIME')
-return dateTimeFormater(rawValue, "");
+if (
+  this.params.colDef?.TagControl === 'DATETIME' ||
+  this.params.colDef?.tagControl === 'DATETIME' ||
+  this.params.colDef?.cellDataType === 'dateTime'
+)
+  return dateTimeFormater(rawValue, "");
 
         if (Array.isArray(this.params.options)) {
           const match = this.params.options.find(

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1162,11 +1162,9 @@ setTimeout(() => {
           delete colCopy.useStyleArray;
         }
         if (colCopy.cellDataType === 'dateTime') {
-          colCopy.cellRenderer = FormatterCellRenderer;
           delete colCopy.useCustomFormatter;
           delete colCopy.formatter;
           delete colCopy.valueFormatter;
-          delete colCopy.cellRenderer;
           delete colCopy.cellRendererFramework;
         }
         if (colCopy.FieldDB === 'StatusID') {
@@ -1533,8 +1531,10 @@ setTimeout(() => {
               if (tagControl !== 'DEADLINE' && colCopy.cellDataType !== 'dateTime') {
                 result.cellDataType = 'dateString';
               } else {
-                if(colCopy.cellDataType === 'dateTime')
-                  result.TagControl = "DATETIME";
+                if (colCopy.cellDataType === 'dateTime') {
+                  result.TagControl = 'DATETIME';
+                  result.cellRenderer = 'FormatterCellRenderer';
+                }
                 delete result.cellDataType;
               }
 


### PR DESCRIPTION
## Summary
- render dateTime columns with FormatterCellRenderer
- format dateTime values using dateTimeFormater

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c54d9d3f708330b87a6e928a2c0fc9