### PR TITLE
Fix date editor initial value in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
@@ -153,9 +153,17 @@ export default {
       selectedDate.value = String(v);
     }
 
-    watch(() => props.modelValue ?? (props.params && props.params.value), v => {
-      applyValue(v);
-    }, { immediate: true });
+    watch(
+      () => {
+        const mv = props.modelValue;
+        const pv = props.params && props.params.value;
+        return mv !== undefined && mv !== null && mv !== '' ? mv : pv;
+      },
+      v => {
+        applyValue(v);
+      },
+      { immediate: true }
+    );
 
     const dpMonth = ref(0);
     const dpYear  = ref(0);


### PR DESCRIPTION
## Summary
- ensure date/deadline editor starts with existing value instead of blank

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5723ae07083308b29b68d75bab979