### PR TITLE
Fix date editor initial value in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
@@ -152,10 +152,20 @@ export default {
       }
       selectedDate.value = String(v);
     }
+    // defina o valor inicial de forma síncrona para evitar campo vazio ao montar
+    const initVal = props.modelValue ?? (props.params && props.params.value);
+    applyValue(initVal);
 
-    watch(() => props.modelValue ?? (props.params && props.params.value), v => {
-      applyValue(v);
-    }, { immediate: true });
+    watch(
+      () => {
+        const mv = props.modelValue;
+        const pv = props.params && props.params.value;
+        return mv !== undefined && mv !== null && mv !== '' ? mv : pv;
+      },
+      v => {
+        applyValue(v);
+      }
+    );
 
     const dpMonth = ref(0);
     const dpYear  = ref(0);


### PR DESCRIPTION
## Summary
- set initial date/deadline value synchronously to avoid empty field warnings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5723ae07083308b29b68d75bab979