### PR TITLE
Fix date editor validation in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
@@ -110,6 +110,8 @@ export default {
     const timePart = ref('00:00');
     const originalValue = ref('');
     const anchorPoint = ref(null);
+    // evita validação imediata ao entrar em edição
+    const readyToEmit = ref(false);
 
     function toYMD(date) {
       const y = date.getFullYear();
@@ -152,10 +154,25 @@ export default {
       }
       selectedDate.value = String(v);
     }
+    // defina o valor inicial de forma síncrona para evitar campo vazio ao montar
+    const initVal =
+      props.modelValue !== undefined &&
+      props.modelValue !== null &&
+      props.modelValue !== ''
+        ? props.modelValue
+        : (props.params && props.params.value);
+    applyValue(initVal);
 
-    watch(() => props.modelValue ?? (props.params && props.params.value), v => {
-      applyValue(v);
-    }, { immediate: true });
+    watch(
+      () => {
+        const mv = props.modelValue;
+        const pv = props.params && props.params.value;
+        return mv !== undefined && mv !== null && mv !== '' ? mv : pv;
+      },
+      v => {
+        applyValue(v);
+      }
+    );
 
     const dpMonth = ref(0);
     const dpYear  = ref(0);
@@ -213,33 +230,41 @@ export default {
     });
 
     function emitValue(){
-      if(!selectedDate.value){ emit('update:modelValue', ''); return; }
-      if(!isShowTime.value){
-        emit('update:modelValue', selectedDate.value);
-        return;
+      if(!readyToEmit.value) return;
+
+      let newVal = '';
+      if(selectedDate.value){
+        if(!isShowTime.value){
+          newVal = selectedDate.value;
+        } else {
+          const orig = originalValue.value || '';
+          if(/t/i.test(orig)){
+            newVal = `${selectedDate.value}T${timePart.value}`;
+          } else {
+            const baseDate = new Date(`${selectedDate.value}T${timePart.value}`);
+            const mm = String(baseDate.getMonth() + 1).padStart(2,'0');
+            const dd = String(baseDate.getDate()).padStart(2,'0');
+            const yyyy = baseDate.getFullYear();
+            const min = String(baseDate.getMinutes()).padStart(2,'0');
+            if(/am|pm/i.test(orig)){
+              let hh = baseDate.getHours();
+              const ampm = hh >= 12 ? 'PM' : 'AM';
+              hh = hh % 12; if(hh === 0) hh = 12;
+              const hh12 = String(hh).padStart(2,'0');
+              newVal = `${mm}/${dd}/${yyyy} ${hh12}:${min} ${ampm}`;
+            } else if(orig.includes('/')){
+              const hh = String(baseDate.getHours()).padStart(2,'0');
+              newVal = `${mm}/${dd}/${yyyy} ${hh}:${min}`;
+            } else {
+              newVal = `${selectedDate.value} ${timePart.value}`;
+            }
+          }
+        }
       }
-      const orig = originalValue.value || '';
-      if(/t/i.test(orig)){
-        emit('update:modelValue', `${selectedDate.value}T${timePart.value}`);
-        return;
-      }
-      const baseDate = new Date(`${selectedDate.value}T${timePart.value}`);
-      const mm = String(baseDate.getMonth() + 1).padStart(2,'0');
-      const dd = String(baseDate.getDate()).padStart(2,'0');
-      const yyyy = baseDate.getFullYear();
-      const min = String(baseDate.getMinutes()).padStart(2,'0');
-      if(/am|pm/i.test(orig)){
-        let hh = baseDate.getHours();
-        const ampm = hh >= 12 ? 'PM' : 'AM';
-        hh = hh % 12; if(hh === 0) hh = 12;
-        const hh12 = String(hh).padStart(2,'0');
-        emit('update:modelValue', `${mm}/${dd}/${yyyy} ${hh12}:${min} ${ampm}`);
-      } else if(orig.includes('/')){
-        const hh = String(baseDate.getHours()).padStart(2,'0');
-        emit('update:modelValue', `${mm}/${dd}/${yyyy} ${hh}:${min}`);
-      } else {
-        emit('update:modelValue', `${selectedDate.value} ${timePart.value}`);
-      }
+
+      if(newVal === originalValue.value) return;
+      emit('update:modelValue', newVal);
+      originalValue.value = newVal;
     }
 
     function finalizeEditing(){
@@ -342,6 +367,7 @@ export default {
       if(!d.inMonth) return;
       // Apenas seleciona o dia e mantém o calendário aberto
       selectedDate.value = d.dateStr;
+      readyToEmit.value = true;
       emitValue();
     }
     function onPickToday(){
@@ -351,6 +377,7 @@ export default {
         const p = n=>String(n).padStart(2,'0');
         timePart.value = `${p(now.getHours())}:${p(now.getMinutes())}`;
       }
+      readyToEmit.value = true;
       emitValue();
       closeDp();
       finalizeEditing(); // Today => finaliza
@@ -358,17 +385,20 @@ export default {
     function onClear(){
       selectedDate.value = '';
       if(isShowTime.value) timePart.value = '00:00';
-      emit('update:modelValue','');
+      readyToEmit.value = true;
+      emitValue();
       closeDp();
       finalizeEditing(); // Clear => finaliza
     }
     function onApply(){
+      readyToEmit.value = true;
       emitValue();
       closeDp();
       finalizeEditing(); // Select => finaliza
     }
     function onTimeInput(e){
       timePart.value = e.target.value;
+      readyToEmit.value = true;
       emitValue();
     }
 
@@ -394,8 +424,7 @@ export default {
         } catch (e) {}
       },
       getValue(){
-        if(!selectedDate.value) return '';
-        return isShowTime.value ? (selectedDate.value + 'T' + timePart.value) : selectedDate.value;
+        return originalValue.value || '';
       },
       isPopup(){ return true; },
       isCancelBeforeStart(){ return false; },


### PR DESCRIPTION
## Summary
- only emit model updates when the user actually changes the date/time
- reuse change-detection on clear to skip mandatory popup when untouched
- return last committed value if no edits were made

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5723ae07083308b29b68d75bab979