### PR TITLE
fix(grid-view): prefill deadline editor value

### DIFF
--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
@@ -161,14 +161,27 @@ export default {
       props.modelValue !== null &&
       props.modelValue !== ''
         ? props.modelValue
-        : (props.params && props.params.value);
+        : (
+            props.params &&
+            (props.params.value !== undefined && props.params.value !== null
+              ? props.params.value
+              : props.params.colDef && props.params.data
+                ? props.params.data[props.params.colDef.field]
+                : undefined)
+          );
     applyValue(initVal);
 
 
     watch(
       () => {
         const mv = props.modelValue;
-        const pv = props.params && props.params.value;
+        const p = props.params || {};
+        const pv =
+          p.value !== undefined && p.value !== null
+            ? p.value
+            : p.colDef && p.data
+              ? p.data[p.colDef.field]
+              : undefined;
         return mv !== undefined && mv !== null && mv !== '' ? mv : pv;
       },
       v => {


### PR DESCRIPTION
## Summary
- ensure DateTimeCellEditor uses cell data when params.value is missing so Deadline editing starts with current value

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c58d75991c833088ae86728fc4f57a