### PR TITLE
fix: ensure uniform grid row borders

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -2358,6 +2358,12 @@ forceClearSelection() {
       border: none !important;
     }
 
+    :deep(.ag-row.ag-row-even),
+    :deep(.ag-row.ag-row-odd) {
+      border-top: none !important;
+      border-bottom: none !important;
+    }
+
     :deep(.ag-row:last-child .ag-cell) {
       border-bottom: none !important;
     }


### PR DESCRIPTION
## Summary
- remove extra borders on alternating rows in GridViewDinamica to keep 1px lines

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ea800bd083308cb79bd831f2106a