### PR TITLE
feat: add deadline filter to grid

### DIFF
--- a/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
@@ -1,0 +1,297 @@
+import { createApp } from 'vue';
+import CustomDatePicker from '../../../CustomDatePicker/CustomDatePicker.vue';
+
+export default class DeadlineFilterRenderer {
+  constructor() {
+    this.selected = null;
+    this.customFrom = '';
+    this.customTo = '';
+    this.customMode = 'equals';
+    this.searchText = '';
+    this.fromPickerApp = null;
+    this.toPickerApp = null;
+    this.options = [
+      { label: 'Today', value: 'today' },
+      { label: 'Yesterday', value: 'yesterday' },
+      { label: 'This week', value: 'this_week' },
+      { label: 'This month', value: 'this_month' },
+      { label: 'Last 30 days', value: 'last_30_days' },
+      { label: 'Customize', value: 'custom' },
+      { label: 'Clear', value: 'clear' },
+    ];
+  }
+
+  init(params) {
+    this.params = params;
+    this.filteredOptions = [...this.options];
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'list-filter deadline-filter';
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" placeholder="Search..." class="search-input" />
+        <span class="search-icon">
+          <i class="material-symbols-outlined-search">search</i>
+        </span>
+      </div>
+      <div class="filter-list"></div>
+    `;
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.listEl = this.eGui.querySelector('.filter-list');
+    this.searchInput.addEventListener('input', e => {
+      this.searchText = e.target.value.toLowerCase();
+      this.filteredOptions = this.options.filter(o =>
+        o.label.toLowerCase().includes(this.searchText)
+      );
+      this.render();
+    });
+    this.render();
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  render() {
+    this.destroyCustomPickers();
+    this.listEl.innerHTML = this.filteredOptions
+      .map(opt => {
+        const selected = this.selected === opt.value ? ' selected' : '';
+        const custom = opt.value === 'custom' ? ' custom' : '';
+        return `<div class="filter-item${selected}${custom}" data-value="${opt.value}">
+          <span class="filter-label">${opt.label}</span>
+          ${opt.value === 'custom' ? '<span class="arrow-icon">arrow_forward_ios</span>' : ''}
+        </div>`;
+      })
+      .join('');
+    this.listEl.querySelectorAll('.filter-item').forEach(el => {
+      el.addEventListener('click', () => {
+        const value = el.getAttribute('data-value');
+        if (value === 'custom') {
+          this.selected = value;
+          this.showCustomInputs();
+          return;
+        }
+        if (value === 'clear') {
+          this.selected = null;
+          this.customFrom = '';
+          this.customTo = '';
+          this.customMode = 'equals';
+          this.params.filterChangedCallback();
+          this.render();
+          this.closePopup();
+          return;
+        }
+        this.selected = value;
+        this.params.filterChangedCallback();
+        this.render();
+        this.closePopup();
+      });
+    });
+  }
+
+  showCustomInputs() {
+    this.destroyCustomPickers();
+    this.listEl.innerHTML = `
+      <div class="custom-header">
+        <span class="back-icon material-symbols-outlined">arrow_back_ios</span>
+        <span class="custom-title">Customize</span>
+      </div>
+      <select class="custom-select">
+        <option value="equals">Equals</option>
+        <option value="before">Before</option>
+        <option value="after">After</option>
+        <option value="between">Between</option>
+      </select>
+      <div class="custom-range"></div>
+      <button type="button" class="apply-btn">Apply</button>
+    `;
+    const backBtn = this.listEl.querySelector('.back-icon');
+    backBtn.addEventListener('click', () => this.render());
+    const select = this.listEl.querySelector('.custom-select');
+    select.value = this.customMode;
+    select.addEventListener('change', e => {
+      this.customMode = e.target.value;
+      this.updateCustomRange();
+    });
+    this.customRangeEl = this.listEl.querySelector('.custom-range');
+    this.updateCustomRange();
+    const applyBtn = this.listEl.querySelector('.apply-btn');
+    applyBtn.addEventListener('click', () => {
+      if (this.customMode === 'equals') this.customTo = this.customFrom;
+      if (this.customMode === 'before') this.customFrom = '';
+      if (this.customMode === 'after') this.customTo = '';
+      this.params.filterChangedCallback();
+    });
+  }
+
+  updateCustomRange() {
+    this.destroyCustomPickers();
+    let rangeHtml = '';
+    switch (this.customMode) {
+      case 'before':
+        rangeHtml = `<div class="to-date"></div>`;
+        break;
+      case 'after':
+        rangeHtml = `<div class="from-date"></div>`;
+        break;
+      case 'between':
+        rangeHtml = `<div class="from-date"></div><div class="to-date"></div>`;
+        break;
+      case 'equals':
+      default:
+        rangeHtml = `<div class="from-date"></div>`;
+    }
+    this.customRangeEl.innerHTML = rangeHtml;
+    this.customRangeEl.className = 'custom-range' + (this.customMode === 'between' ? ' between-mode' : '');
+    const fromContainer = this.customRangeEl.querySelector('.from-date');
+    const toContainer = this.customRangeEl.querySelector('.to-date');
+    if (fromContainer) {
+      this.fromPickerApp = createApp(CustomDatePicker, {
+        modelValue: this.customFrom,
+        'onUpdate:modelValue': val => {
+          this.customFrom = val;
+        },
+      });
+      this.fromPickerApp.mount(fromContainer);
+    }
+    if (toContainer) {
+      this.toPickerApp = createApp(CustomDatePicker, {
+        modelValue: this.customTo,
+        'onUpdate:modelValue': val => {
+          this.customTo = val;
+        },
+      });
+      this.toPickerApp.mount(toContainer);
+    }
+  }
+
+  getSelectedRange() {
+    const now = window.gridDeadlineNow instanceof Date ? new Date(window.gridDeadlineNow) : new Date();
+    const startOfDay = d => new Date(d.getFullYear(), d.getMonth(), d.getDate());
+    const endOfDay = d => new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+    const todayStart = startOfDay(now);
+    switch (this.selected) {
+      case 'today':
+        return { from: todayStart, to: endOfDay(todayStart) };
+      case 'yesterday': {
+        const y = new Date(todayStart);
+        y.setDate(y.getDate() - 1);
+        return { from: y, to: endOfDay(y) };
+      }
+      case 'this_week': {
+        const day = todayStart.getDay();
+        const diff = day === 0 ? -6 : 1 - day; // week starts Monday
+        const start = new Date(todayStart);
+        start.setDate(start.getDate() + diff);
+        const end = new Date(start);
+        end.setDate(start.getDate() + 6);
+        return { from: start, to: endOfDay(end) };
+      }
+      case 'this_month': {
+        const start = new Date(now.getFullYear(), now.getMonth(), 1);
+        const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+        return { from: start, to: endOfDay(end) };
+      }
+      case 'last_30_days': {
+        const start = new Date(todayStart);
+        start.setDate(start.getDate() - 29);
+        return { from: start, to: endOfDay(todayStart) };
+      }
+      case 'custom': {
+        let from = this.customFrom ? startOfDay(new Date(this.customFrom)) : null;
+        let to = this.customTo ? endOfDay(new Date(this.customTo)) : null;
+        switch (this.customMode) {
+          case 'equals':
+            if (!from) return null;
+            to = endOfDay(new Date(this.customFrom));
+            break;
+          case 'before':
+            if (!to) return null;
+            from = null;
+            break;
+          case 'after':
+            if (!from) return null;
+            to = null;
+            break;
+          case 'between':
+            if (!from && !to) return null;
+            break;
+        }
+        return { from, to };
+      }
+      default:
+        return null;
+    }
+  }
+
+  doesFilterPass(params) {
+    const value = params.data ? params.data[this.params.colDef.field] : undefined;
+    if (!value) return false;
+    const dateValue = new Date(value);
+    if (isNaN(dateValue.getTime())) return false;
+    const range = this.getSelectedRange();
+    if (!range) return true;
+    const { from, to } = range;
+    if (from && dateValue < from) return false;
+    if (to && dateValue > to) return false;
+    return true;
+  }
+
+  isFilterActive() {
+    return !!this.getSelectedRange();
+  }
+
+  getModel() {
+    const range = this.getSelectedRange();
+    if (!range) return null;
+    const { from, to } = range;
+    return {
+      option: this.selected,
+      from: from ? from.toISOString() : null,
+      to: to ? to.toISOString() : null,
+      mode: this.customMode,
+    };
+  }
+
+  setModel(model) {
+    if (!model) {
+      this.selected = null;
+      this.customFrom = '';
+      this.customTo = '';
+      this.render();
+      return;
+    }
+    this.selected = model.option;
+    this.customFrom = model.from ? model.from.slice(0, 10) : '';
+    this.customTo = model.to ? model.to.slice(0, 10) : '';
+    this.customMode = model.mode || 'equals';
+    this.render();
+  }
+
+  afterGuiAttached(params) {
+    this.hidePopup = params?.hidePopup;
+  }
+
+  destroy() {
+    this.destroyCustomPickers();
+  }
+
+  closePopup() {
+    if (typeof this.hidePopup === 'function') {
+      this.hidePopup();
+    } else if (this.params?.api?.hidePopupMenu) {
+      this.params.api.hidePopupMenu();
+    }
+  }
+
+  destroyCustomPickers() {
+    if (this.fromPickerApp) {
+      this.fromPickerApp.unmount();
+      this.fromPickerApp = null;
+    }
+    if (this.toPickerApp) {
+      this.toPickerApp.unmount();
+      this.toPickerApp = null;
+    }
+  }
+}

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -207,6 +207,106 @@
   font-family: Roboto, Arial, sans-serif;
 }
 
+/* Specific styles for Deadline filter */
+.deadline-filter {
+  max-width: none;
+  max-height: none;
+  overflow: visible;
+}
+
+.deadline-filter .field-search {
+  padding-bottom: 12px;
+  margin-bottom: 12px;
+  border-bottom: 1px solid #ccc;
+}
+
+.deadline-filter .filter-list {
+  max-height: none;
+  overflow: visible;
+}
+
+.deadline-filter .filter-item {
+  width: 100%;
+  padding: 12px 0;
+  margin-bottom: 8px;
+}
+
+.deadline-filter .filter-item.custom {
+  border-top: 1px solid #ccc;
+  margin-top: 12px;
+  padding-top: 12px;
+}
+
+.deadline-filter .filter-item.custom .arrow-icon {
+  margin-left: auto;
+  font-family: 'Material Symbols Outlined';
+  font-size: 16px;
+  line-height: 1;
+  color: #999;
+  flex-shrink: 0;
+}
+
+.deadline-filter .custom-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.deadline-filter .custom-header .back-icon {
+  font-family: 'Material Symbols Outlined';
+  font-size: 16px;
+  cursor: pointer;
+  margin-right: 8px;
+}
+
+.deadline-filter .custom-header .custom-title {
+  margin-left: auto;
+  font-size: 13px;
+}
+
+.deadline-filter .custom-select {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 6px 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: Roboto, Arial, sans-serif;
+  background: #fff;
+  color: #444;
+  box-sizing: border-box;
+}
+
+.deadline-filter .custom-range {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.deadline-filter .custom-range.between-mode {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.deadline-filter .custom-range .dp-wrapper {
+  flex: 1;
+}
+
+.deadline-filter .apply-btn {
+  padding: 6px 12px;
+  border: none;
+  background: #5e6a75;
+  color: #fff;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 13px;
+}
+
+.deadline-filter .apply-btn:hover {
+  background: #4b5560;
+}
+
 /* Estilos para opções de usuário com avatar */
 :is(.list-filter, .list-editor) .user-option {
   display: flex;

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -37,6 +37,7 @@
   import UserCellRenderer from "./components/UserCellRenderer.vue";
   import ListFilterRenderer from "./components/ListFilterRenderer.js";
   import ResponsibleUserFilterRenderer from "./components/ResponsibleUserFilterRenderer.js";
+  import DeadlineFilterRenderer from "./components/DeadlineFilterRenderer.js";
   import DateTimeCellEditor from "./components/DateTimeCellEditor.vue";
   import FixedListCellEditor from "./components/FixedListCellEditor.js";
   import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
@@ -1527,7 +1528,11 @@ setTimeout(() => {
 
             if (colCopy.cellDataType === 'dateString' || colCopy.cellDataType === 'dateTime' || tagControl === 'DEADLINE') {
 
-              result.filter = 'agDateColumnFilter';
+              if (tagControl === 'DEADLINE') {
+                result.filter = DeadlineFilterRenderer;
+              } else {
+                result.filter = 'agDateColumnFilter';
+              }
               if (tagControl !== 'DEADLINE' && colCopy.cellDataType !== 'dateTime') {
                 result.cellDataType = 'dateString';
               } else {


### PR DESCRIPTION
## Summary
- add clear option to deadline filter and reset logic
- stack "between" date inputs vertically with dedicated styles
- close popup when selecting preset deadlines
- use custom date picker components for custom date range inputs

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c7f823b00883309bd923ec5c8428a5