### PR TITLE
Ajusta comportamento do filtro de data

### DIFF
--- a/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
@@ -685,6 +685,7 @@ export default class DeadlineFilterRenderer {
 
     this.eGui = null;
     this.listEl = null;
+    this.searchWrapper = null;
     this.filteredOptions = [...this.options];
 
     this._Vue =
@@ -712,11 +713,13 @@ export default class DeadlineFilterRenderer {
     this.eGui.className = "list-filter deadline-filter";
     this.eGui.innerHTML = `
       <div class="field-search">
+        <span class="search-icon material-symbols-outlined">search</span>
         <input type="text" placeholder="Search..." class="search-input" />
       </div>
       <div class="filter-list"></div>
     `;
 
+    this.searchWrapper = this.eGui.querySelector(".field-search");
     const searchInput = this.eGui.querySelector(".search-input");
     this.listEl = this.eGui.querySelector(".filter-list");
 
@@ -731,6 +734,12 @@ export default class DeadlineFilterRenderer {
     this.render();
   }
 
+  _setSearchVisibility(show = true) {
+    if (!this.searchWrapper) return;
+    this.searchWrapper.style.display = show ? "" : "none";
+    this.searchWrapper.setAttribute("aria-hidden", show ? "false" : "true");
+  }
+
   getGui() { return this.eGui; }
   afterGuiAttached(params) { this.hidePopup = params?.hidePopup; }
   destroy() { this._unmountPickers(); }
@@ -741,6 +750,7 @@ export default class DeadlineFilterRenderer {
 
   render() {
     this._unmountPickers();
+    this._setSearchVisibility(true);
 
     this.listEl.innerHTML = this.filteredOptions
       .map((opt) => {
@@ -781,6 +791,7 @@ export default class DeadlineFilterRenderer {
 
   showCustomInputs() {
     this._unmountPickers();
+    this._setSearchVisibility(false);
 
     this.listEl.innerHTML = `
       <div class="custom-header">

--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -12,8 +12,8 @@ export default class FixedListCellEditor {
     this.eGui.innerHTML = `
       <span class="editor-close">&times;</span>
       <div class="field-search">
+        <span class="search-icon material-symbols-outlined">search</span>
         <input type="text" class="search-input" placeholder="Search..." />
-        <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
       </div>
       <div class="filter-list"></div>
     `;

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -11,8 +11,8 @@ export default class ListCellEditor {
     this.eGui.innerHTML = `
       <span class="editor-close">&times;</span>
       <div class="field-search">
+        <span class="search-icon material-symbols-outlined">search</span>
         <input type="text" class="search-input" placeholder="Search..." />
-        <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
       </div>
       <div class="filter-list"></div>
     `;

--- a/Project/GridViewDinamica/src/components/ListFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ListFilterRenderer.js
@@ -19,10 +19,8 @@ export default class ListFilterRenderer {
     this.eGui.className = 'list-filter';
     this.eGui.innerHTML = `
       <div class="field-search">
+        <span class="search-icon material-symbols-outlined">search</span>
         <input type="text" placeholder="Search..." class="search-input" />
-        <span class="search-icon">
-          <i class="material-symbols-outlined-search">search</i>
-        </span>
       </div>
       <div class="select-all-row">
         <label>

--- a/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserFilterRenderer.js
@@ -23,10 +23,8 @@ export default class ResponsibleUserFilterRenderer {
     this.eGui.className = 'list-filter';
     this.eGui.innerHTML = `
       <div class="field-search">
+        <span class="search-icon material-symbols-outlined">search</span>
         <input type="text" placeholder="Search..." class="search-input" />
-        <span class="search-icon">
-          <i class="material-symbols-outlined-search">search</i>
-        </span>
       </div>
       <div class="select-all-row">
         <label>

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -63,9 +63,9 @@
 
 :is(.list-filter, .list-editor) .search-input {
   width: 100%;
-  padding: 7px 36px 7px 13px;
+  padding: 8px 42px 8px 16px;
   border: 1px solid #ddd;
-  border-radius: 20px;
+  border-radius: 9999px;
   font-size: 13px;
   font-family: Roboto, Arial, sans-serif;
   outline: none;
@@ -82,8 +82,8 @@
 
 :is(.list-filter, .list-editor) .search-icon {
   position: absolute;
-  right: 12px;
-  top: 16px;
+  right: 16px;
+  top: 50%;
   transform: translateY(-50%);
   color: #999;
   width: 20px;
@@ -94,9 +94,9 @@
   justify-content: center;
 }
 
-:is(.list-filter, .list-editor) .search-icon i.material-symbols-outlined-search {
+:is(.list-filter, .list-editor) .search-icon.material-symbols-outlined {
   font-family: 'Material Symbols Outlined';
-  font-size: 19px;
+  font-size: 20px;
   font-style: normal;
   font-weight: normal;
   line-height: 1;
@@ -348,7 +348,12 @@
 
 .list-filter.deadline-filter { min-width: 280px; }
 .field-search { position: relative; margin-bottom: 8px; }
-.field-search .search-input { width: 100%; padding: 8px 10px; border: 1px solid #e5e7eb; border-radius: 8px; }
+.field-search .search-input {
+  width: 100%;
+  padding: 8px 42px 8px 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 9999px;
+}
 .filter-list { display: flex; flex-direction: column; gap: 4px; max-height: 320px; overflow: auto; }
 .filter-item { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px; border-radius: 8px; cursor: pointer; }
 .filter-item:hover { background: #f3f4f6; }

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -55,8 +55,8 @@
       this.eGui.innerHTML = `
         <span class="editor-close">&times;</span>
         <div class="field-search">
+          <span class="search-icon material-symbols-outlined">search</span>
           <input type="text" class="search-input" placeholder="Search..." />
-          <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
         </div>
         <div class="filter-list"></div>
       `;


### PR DESCRIPTION
## Summary
- oculta o campo de busca ao abrir a personalização dos filtros de data/deadline e o exibe novamente ao retornar à lista de opções
- atualiza a marcação dos filtros e editores de lista para usar o ícone material symbols e combina com o novo estilo
- ajusta o CSS do campo de busca para bordas mais arredondadas e espaçamento do ícone de busca

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c892856e608330b811e82a2504452a