### PR TITLE
Oculta busca ao customizar filtro DeadLine

### DIFF
--- a/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
@@ -685,6 +685,7 @@ export default class DeadlineFilterRenderer {
 
     this.eGui = null;
     this.listEl = null;
+    this.searchContainer = null;
     this.filteredOptions = [...this.options];
 
     this._Vue =
@@ -701,6 +702,7 @@ export default class DeadlineFilterRenderer {
     this.toApp = null;
   }
   _closeAndNotify() {
+    this._setSearchVisibility(true);
     this.params?.filterChangedCallback?.();
     this.closePopup();
   }
@@ -718,6 +720,7 @@ export default class DeadlineFilterRenderer {
     `;
 
     const searchInput = this.eGui.querySelector(".search-input");
+    this.searchContainer = this.eGui.querySelector(".field-search");
     this.listEl = this.eGui.querySelector(".filter-list");
 
     searchInput.addEventListener("input", (e) => {
@@ -739,7 +742,13 @@ export default class DeadlineFilterRenderer {
     else if (this.params?.api?.hidePopupMenu) this.params.api.hidePopupMenu();
   }
 
+  _setSearchVisibility(show) {
+    if (!this.searchContainer) return;
+    this.searchContainer.style.display = show ? "" : "none";
+  }
+
   render() {
+    this._setSearchVisibility(true);
     this._unmountPickers();
 
     this.listEl.innerHTML = this.filteredOptions
@@ -780,6 +789,7 @@ export default class DeadlineFilterRenderer {
   }
 
   showCustomInputs() {
+    this._setSearchVisibility(false);
     this._unmountPickers();
 
     this.listEl.innerHTML = `


### PR DESCRIPTION
## Summary
- oculta o campo de busca quando o usuário entra na personalização do filtro DeadLine
- volta a exibir o campo de busca ao retornar para a lista ou ao fechar o filtro

## Testing
- não foram executados testes automatizados; nenhum script foi fornecido

------
https://chatgpt.com/codex/tasks/task_e_68c89689545883308604b4032a147372