### PR TITLE
Ensure GridViewDinamica list edits keep displaying labels

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -49,6 +49,53 @@ export default class FixedListCellEditor {
       this.renderOptions();
     };
 
+    this.getColumnFieldKey = () => {
+      if (!this.params) return null;
+      const col = this.params.column;
+      if (col && typeof col.getColId === 'function') {
+        const id = col.getColId();
+        if (id) return id;
+      }
+      return this.params.colDef?.field || this.params.colDef?.colId || null;
+    };
+
+    this.extractOptionLabel = value => {
+      if (!this.options || !this.options.length) return undefined;
+      const match = this.options.find(opt => String(opt.value) === String(value));
+      if (!match) return undefined;
+      const label =
+        match.label ??
+        match.name ??
+        match.text ??
+        match.descricao ??
+        match.description ??
+        match.Valor ??
+        match.value;
+      return label != null ? label : undefined;
+    };
+
+    this.updateDisplayLabel = (value, { refresh = true } = {}) => {
+      const fieldKey = this.getColumnFieldKey();
+      const rowData = this.params?.node?.data;
+      if (!fieldKey || !rowData) return;
+      const labelField = `${fieldKey}__displayLabel`;
+      const label = this.extractOptionLabel(value);
+      if (label != null) {
+        rowData[labelField] = String(label);
+      } else if (value != null && value !== '') {
+        rowData[labelField] = String(value);
+      } else {
+        delete rowData[labelField];
+      }
+      if (refresh && this.params.api && this.params.node) {
+        this.params.api.refreshCells({
+          rowNodes: [this.params.node],
+          columns: [fieldKey],
+          force: true,
+        });
+      }
+    };
+
     let optionsPromise;
     if (typeof params.options === 'function') {
       console.log('FixedListCellEditor calling params.options function with', params);
@@ -330,7 +377,9 @@ export default class FixedListCellEditor {
       .join('');
     this.listEl.querySelectorAll('.filter-item').forEach(el => {
       el.addEventListener('click', () => {
-        this.value = el.getAttribute('data-value');
+        const selectedValue = el.getAttribute('data-value');
+        this.value = selectedValue;
+        this.updateDisplayLabel(selectedValue, { refresh: false });
         if (this.params.api && this.params.api.stopEditing) {
           this.params.api.stopEditing();
         } else if (this.params.stopEditing) {
@@ -349,6 +398,7 @@ export default class FixedListCellEditor {
   }
 
   getValue() {
+    this.updateDisplayLabel(this.value);
     return this.value;
   }
 

--- a/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
@@ -110,6 +110,14 @@ export default {
         const rawValue = this.params.value;
         let displayValue = rawValue;
 
+        const fieldKey = this.params.colDef?.colId || this.params.colDef?.field;
+        if (fieldKey && this.params.data) {
+          const storedLabel = this.params.data[`${fieldKey}__displayLabel`];
+          if (storedLabel !== undefined && storedLabel !== null) {
+            displayValue = storedLabel;
+          }
+        }
+
 if (
   this.params.colDef?.TagControl === 'DATETIME' ||
   this.params.colDef?.tagControl === 'DATETIME' ||

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -199,6 +199,50 @@
       }
       return value;
     }
+    getColumnFieldKey() {
+      if (!this.params) return null;
+      const col = this.params.column;
+      if (col && typeof col.getColId === 'function') {
+        const id = col.getColId();
+        if (id) return id;
+      }
+      return this.params.colDef?.field || this.params.colDef?.colId || null;
+    }
+    extractOptionLabel(value) {
+      if (!this.options || !this.options.length) return undefined;
+      const match = this.options.find(opt => String(opt.value) === String(value));
+      if (!match) return undefined;
+      const label =
+        match.label ??
+        match.name ??
+        match.text ??
+        match.descricao ??
+        match.description ??
+        match.Valor ??
+        match.value;
+      return label != null ? label : undefined;
+    }
+    updateDisplayLabel(value, { refresh = true } = {}) {
+      const fieldKey = this.getColumnFieldKey();
+      const rowData = this.params?.node?.data;
+      if (!fieldKey || !rowData) return;
+      const labelField = `${fieldKey}__displayLabel`;
+      const label = this.extractOptionLabel(value);
+      if (label != null) {
+        rowData[labelField] = String(label);
+      } else if (value != null && value !== '') {
+        rowData[labelField] = String(value);
+      } else {
+        delete rowData[labelField];
+      }
+      if (refresh && this.params.api && this.params.node) {
+        this.params.api.refreshCells({
+          rowNodes: [this.params.node],
+          columns: [fieldKey],
+          force: true,
+        });
+      }
+    }
     renderOptions() {
       this.listEl.innerHTML = this.filteredOptions
         .map(opt => {
@@ -209,7 +253,9 @@
         .join('');
       this.listEl.querySelectorAll('.filter-item').forEach(el => {
         el.addEventListener('click', () => {
-          this.value = el.getAttribute('data-value');
+          const selectedValue = el.getAttribute('data-value');
+          this.value = selectedValue;
+          this.updateDisplayLabel(selectedValue, { refresh: false });
           if (this.params.api && this.params.api.stopEditing) {
             this.params.api.stopEditing();
           } else if (this.params.stopEditing) {
@@ -220,7 +266,10 @@
     }
     getGui() { return this.eGui; }
     afterGuiAttached() { if (this.searchInput) this.searchInput.focus(); }
-    getValue() { return this.value; }
+    getValue() {
+      this.updateDisplayLabel(this.value);
+      return this.value;
+    }
     destroy() {}
     isPopup() { return true; }
   }


### PR DESCRIPTION
## Summary
- persist the selected option label on the row data when list cells are edited
- update the list cell renderers to prefer the stored label so values stay readable after resorting or filtering
- align both dynamic and fixed list editors with the new label persistence helper

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8985e0b60833088eb8642f865b103