### PR TITLE
Keep Deadline filter popup open when selecting custom dates

### DIFF
--- a/Project/GridViewDinamica/src/components/CustomDatePicker.vue
+++ b/Project/GridViewDinamica/src/components/CustomDatePicker.vue
@@ -30,6 +30,8 @@
       class="datepicker-pop"
       :style="dpPopStyle"
       ref="dpPopRef"
+      role="dialog"
+      aria-modal="true"
     >
       <div class="dp-header">
         <button type="button" class="dp-nav" @click="prevMonth">&lt;</button>

--- a/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
@@ -580,6 +580,8 @@ const CustomDatePicker = (() => {
                 {
                   class: "datepicker-pop",
                   ref: dpPopRef,
+                  role: "dialog",
+                  "aria-modal": "true",
                   style: {
                     ...stylePopupBase,
                     left: `${dpPopPos.value.left}px`,


### PR DESCRIPTION
## Summary
- ensure the deadline filter's custom date picker popup exposes dialog semantics so the global outside-click handler keeps the filter open while interacting with the calendar
- align the shared CustomDatePicker component with the same dialog attributes for consistency

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c93ad65aa08330b26d9f5df484b7a5