### PR TITLE
Expand cadastros drop surface for empty sections

### DIFF
--- a/Project/FormBuilderCadastros/Component/components/FormSection.vue
+++ b/Project/FormBuilderCadastros/Component/components/FormSection.vue
@@ -1,34 +1,52 @@
 <template> 
 
-<div 
-class="form-section" 
-:class="{ 'is-empty': !section.fields.length, 'expanded': isExpanded }" 
+<div
+class="form-section"
+:class="{ 'is-empty': !section.fields.length, 'expanded': isExpanded }"
 :data-section-id="section.id"
 ref="sectionRef"
 >
 
-<div 
-class="sortable-container grid-layout" 
-:data-section-id="section.id"
-:id="`sortable-${section.id}`"
-ref="sortableContainer"
-v-show="isExpanded"
->
-<DraggableField
-v-for="field in sectionFields"
-:key="field.id || field.field_id"
-:field="field"
-:show-properties="true"
-:show-actions="true"
-:is-editing="isEditing"
-:show-field-component="true"
-:is-in-form-section="true"
-:class="draggableField"
-@click="selectField(field)"
-@edit-field="$emit('edit-field', field)"
-@remove-field="$emit('remove-field', field, section.id)"
-/>
-</div>
+  <div
+    class="section-header section-header--metadata"
+    aria-hidden="true"
+  >
+    <h4
+      class="section-title"
+      :data-section-id="section.id"
+    >
+      {{ sectionTitle }}
+    </h4>
+  </div>
+
+  <div
+    class="sortable-container grid-layout"
+    :data-section-id="section.id"
+    :id="`sortable-${section.id}`"
+    ref="sortableContainer"
+    v-show="isExpanded"
+  >
+    <div
+      v-if="!sectionFields.length"
+      class="empty-drop-target"
+      :data-section-id="section.id"
+    ></div>
+
+    <DraggableField
+      v-for="field in sectionFields"
+      :key="field.id || field.field_id"
+      :field="field"
+      :show-properties="true"
+      :show-actions="true"
+      :is-editing="isEditing"
+      :show-field-component="true"
+      :is-in-form-section="true"
+      :class="draggableField"
+      @click="selectField(field)"
+      @edit-field="$emit('edit-field', field)"
+      @remove-field="$emit('remove-field', field, section.id)"
+    />
+  </div>
 </div>
 </template>
 
@@ -516,6 +534,10 @@ background-color: #f0f0f0;
 border: 1px solid #ddd;
 }
 
+.section-header--metadata {
+display: none;
+}
+
 .section-actions {
 display: none;
 gap: 5px;
@@ -548,11 +570,15 @@ opacity: 1;
 }
 
 .sortable-container {
-min-height: 50px;
-border: 1px dashed #ccc;
-border-radius: 4px;
-padding: 10px;
-background-color: surface;
+  min-height: 50px;
+  border: 1px dashed #ccc;
+  border-radius: 4px;
+  padding: 16px;
+  background-color: surface;
+}
+
+.form-section.is-empty .sortable-container {
+  min-height: 120px;
 }
 
 .grid-layout {
@@ -616,12 +642,13 @@ border:0px;
 }
 
 .empty-drop-target {
-grid-column: 1 / -1;
-min-height: 40px;
-border: 1px dashed #ccc;
-border-radius: 4px;
-margin-top: 10px;
-background-color: rgba(0, 0, 0, 0.02);
+  grid-column: 1 / -1;
+  min-height: 80px;
+  border: 1px dashed #ccc;
+  border-radius: 4px;
+  margin-top: 10px;
+  background-color: rgba(0, 0, 0, 0.02);
+  pointer-events: none;
 }
 
 i.material-symbols-outlined {


### PR DESCRIPTION
## Summary
- add an empty drop target placeholder so cadastros sections expose a larger drop area when they have no fields yet
- increase the sortable container padding and minimum height to keep the drop surface comfortable, matching the working builder component

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8a91f827c8330bf92bcc51bdc8acf