### PR TITLE
Fix grid row border consistency

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -2400,7 +2400,7 @@ forceClearSelection() {
 
     :deep(.ag-cell) {
       border: none !important;
-      border-bottom: 1px solid #888 !important;
+      border-bottom: 1px solid var(--ag-border-color, #888) !important;
     }
 
     :deep(.ag-row) {
@@ -2413,8 +2413,9 @@ forceClearSelection() {
       border-bottom: none !important;
     }
 
+    :deep(.ag-row.ag-row-last .ag-cell),
     :deep(.ag-row:last-child .ag-cell) {
-      border-bottom: none !important;
+      border-bottom: 1px solid var(--ag-border-color, #888) !important;
     }
 
     // Inputs de edição compactos e centralizados (ajuste agressivo)


### PR DESCRIPTION
## Summary
- ensure grid cells use the theme border color so row separators stay consistent
- restore the bottom border on the last rendered row to avoid gaps after filtering or sorting

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9492df2fc83308fe3413fad51c018