### PR TITLE
Restore consistent row borders in grid

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1819,6 +1819,9 @@ setTimeout(() => {
   "--ww-data-grid_action-padding": this.content.actionPadding,
   "--ww-data-grid_action-border": this.content.actionBorder,
   "--ww-data-grid_action-borderRadius": this.content.actionBorderRadius,
+  ...(this.content.borderColor
+  ? { "--ww-data-grid_row-border-color": this.content.borderColor }
+  : {}),
   ...(this.content.actionFont
   ? { "--ww-data-grid_action-font": this.content.actionFont }
   : {
@@ -2399,8 +2402,15 @@ forceClearSelection() {
     }
 
     :deep(.ag-cell) {
-      border: none !important;
-      border-bottom: 1px solid #888 !important;
+      border-top: none !important;
+      border-right: none !important;
+      border-left: none !important;
+      border-bottom-width: 1px !important;
+      border-bottom-style: solid !important;
+      border-bottom-color: var(
+        --ww-data-grid_row-border-color,
+        var(--ag-row-border-color, var(--ag-border-color, #d9d9d9))
+      ) !important;
     }
 
     :deep(.ag-row) {
@@ -2413,8 +2423,14 @@ forceClearSelection() {
       border-bottom: none !important;
     }
 
+    :deep(.ag-row.ag-row-last .ag-cell),
     :deep(.ag-row:last-child .ag-cell) {
-      border-bottom: none !important;
+      border-bottom-width: 1px !important;
+      border-bottom-style: solid !important;
+      border-bottom-color: var(
+        --ww-data-grid_row-border-color,
+        var(--ag-row-border-color, var(--ag-border-color, #d9d9d9))
+      ) !important;
     }
 
     // Inputs de edição compactos e centralizados (ajuste agressivo)


### PR DESCRIPTION
## Summary
- expose a CSS variable so the grid rows can reuse the configured border color
- ensure every ag-Grid cell draws a 1px bottom border using the theme color fallback

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68c9492df2fc83308fe3413fad51c018