### PR TITLE
Ajusta separador e ícone de busca no filtro de deadline

### DIFF
--- a/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
@@ -771,6 +771,9 @@ export default class DeadlineFilterRenderer {
     this.eGui.innerHTML = `
       <div class="field-search">
         <input type="text" placeholder="Search..." class="search-input" />
+        <span class="search-icon" aria-hidden="true">
+          <i class="material-symbols-outlined-search">search</i>
+        </span>
       </div>
       <div class="filter-list"></div>
     `;
@@ -809,11 +812,21 @@ export default class DeadlineFilterRenderer {
 
     this.listEl.innerHTML = this.filteredOptions
       .map((opt) => {
-        const selected = this.selected === opt.value ? " selected" : "";
-        const custom = opt.value === "custom" ? " custom" : "";
-        return `<div class="filter-item${selected}${custom}" data-value="${opt.value}">
+        const isCustom = opt.value === "custom";
+        const isClear = opt.value === "clear";
+        const classes = ["filter-item"];
+
+        if (isCustom) classes.push("custom");
+        if (isClear) classes.push("clear");
+        if (this.selected === opt.value && !isCustom && !isClear) {
+          classes.push("selected");
+        }
+
+        const arrow = isCustom ? '<span class="arrow-icon">›</span>' : "";
+
+        return `<div class="${classes.join(" ")}" data-value="${opt.value}">
           <span class="filter-label">${opt.label}</span>
-          ${opt.value === "custom" ? '<span class="arrow-icon">›</span>' : ""}
+          ${arrow}
         </div>`;
       })
       .join("");

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -130,7 +130,7 @@
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  padding: 6px 0 6px 0;
+  padding: 6px 8px 6px 8px;
   border-radius: 8px;
   transition: background 0.15s;
   width: 100%;
@@ -153,7 +153,7 @@
 :is(.list-filter, .list-editor) .filter-item {
   display: flex;
   align-items: center;
-  padding: 6px 4px 6px 0;
+  padding: 6px 8px 6px 8px;
   font-size: 13px;
   font-family: Roboto, Arial, sans-serif;
   cursor: pointer;
@@ -196,13 +196,16 @@
 /* Specific styles for Deadline filter */
 .deadline-filter { max-width: none; max-height: none; overflow: visible; }
 .deadline-filter .field-search { padding-bottom: 12px; margin-bottom: 12px; border-bottom: 1px solid #ccc; }
+.deadline-filter .field-search .search-input { padding: 7px 36px 7px 13px; }
 .deadline-filter .filter-list { max-height: none; overflow: visible; }
-.deadline-filter .filter-item { width: 100%; padding: 12px 0; margin-bottom: 8px; }
+.deadline-filter .filter-item { width: 100%; padding: 12px 12px; margin-bottom: 8px; }
 
 .deadline-filter .filter-item.custom {
   border-top: 1px solid #ccc;
   margin-top: 12px;
   padding-top: 12px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 .deadline-filter .filter-item.custom .arrow-icon {
   margin-left: auto;
@@ -354,6 +357,10 @@
 .filter-item { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px; border-radius: 8px; cursor: pointer; }
 .filter-item:hover { background: #f3f4f6; }
 .filter-item.selected { background: #e0e7ff; }
+.filter-item.custom.selected,
+.filter-item.clear.selected {
+  background: transparent;
+}
 .custom-header { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; }
 .custom-title { font-weight: 400; }
 .custom-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 8px; }


### PR DESCRIPTION
## Summary
- impede que as opções Customize e Clear permaneçam destacadas após o clique nos filtros de prazo/data
- adiciona espaçamento interno aos itens dos filtros para afastar os rótulos das bordas e evita que Customize/Clear recebam cor de seleção
- acrescenta o ícone de busca do Material Symbols ao campo de pesquisa do filtro de deadline
- remove o arredondamento do separador da opção Customize para que a borda fique reta

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c9648d40c883309516477cecd9b875