### PR TITLE
Refine CADASTROS rich text theming

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -4,7 +4,11 @@
     :visible="!!error && showAlert"
     @close="showAlert = false"
   />
-  <div class="field-component" :class="[`field-type-${field.fieldType.toLowerCase()}`, { 'is-mandatory': field.is_mandatory }]">
+  <div
+    class="field-component"
+    :class="[`field-type-${field.fieldType.toLowerCase()}`, { 'is-mandatory': field.is_mandatory }]"
+    :style="componentStyleVars"
+  >
     <!-- Label do campo -->
     <label v-if="!field.is_hide_legend" class="field-label"> 
       {{ field.name }}
@@ -143,9 +147,9 @@
             :contenteditable="!field.is_readonly"
             dir="ltr"
             :class="['field-input', 'rich-text-input', { 'readonly-field': field.is_readonly }]"
+            :data-placeholder="field.placeholder || field.placeholder_translations?.pt_br || ''"
             @input="onContentEditableInput"
             @blur="updateValue"
-            style="min-height: 100px; border: 1px solid #ccc; border-radius: 0 0 6px 6px; padding: 8px; background: #fff;"
           ></div>
         </div>
       </template>
@@ -209,6 +213,23 @@ export default {
     };
   },
   computed: {
+    themeTokens() {
+      if (typeof window !== 'undefined' && window.wwLib?.wwVariable?.getValue) {
+        const value = window.wwLib.wwVariable.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726');
+        if (value && typeof value === 'object') {
+          return value;
+        }
+      }
+      return {};
+    },
+    componentStyleVars() {
+      const tokens = this.themeTokens || {};
+      return {
+        '--text-input-bg': tokens.inputBG || '#FFFFFF',
+        '--text-input-border': tokens.inputBorder || '#d1d5db',
+        '--text-input-border-focus': tokens.inputBorderInFocus || tokens.inputBorder || '#d1d5db'
+      };
+    },
     listOptions() {
       if (this.options && this.options.length > 0) {
         return this.options;
@@ -441,67 +462,101 @@ export default {
 
 <style scoped>
 .field-component {
-display: flex;
-flex-direction: column;
-width: 100%;
-margin-bottom: 5px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 5px;
+  --text-input-bg: #ffffff;
+  --text-input-border: #d1d5db;
+  --text-input-border-focus: #bdbdbd;
 }
 
 .field-label {
-font-size: 13px;
-font-weight: 400;
-margin-bottom: 4px;
-color: #333;
+  font-size: 12px;
+  font-weight: 400;
+  margin-bottom: 4px;
+  color: #787878;
+  padding-left: 8px;
 }
 
 .required-indicator {
-color: #e53935;
-margin-left: 2px;
-font-weight: bold;
+  color: #e53935;
+  margin-left: 2px;
+  font-weight: bold;
 }
 
 .field-row {
-display: flex;
-align-items: center;
-width: 100%;
+  display: flex;
+  align-items: center;
+  width: 100%;
 }
 
 .field-input {
-flex: 1;
-min-width: 0; /* This prevents the input from overflowing its container */
-padding: 8px 12px;
-border: 1px solid #ddd;
-border-radius: 4px;
-font-size: 13px;
-background-color: #fff;
-width: 100%;
+  flex: 1;
+  min-width: 0;
+  width: 100%;
+  box-sizing: border-box;
+  color: #787878;
+  font-size: 14px;
 }
 
-.field-input:focus {
-  outline: none;
-  border-color: #bdbdbd;
+input.field-input,
+textarea.field-input {
+  padding: 8px;
+  border: 1px solid var(--text-input-border);
+  border-radius: 4px;
+  background-color: var(--text-input-bg);
+}
+
+input.field-input {
+  height: 36px;
+}
+
+.text-input,
+.decimal-input,
+.integer-input {
+  background-color: var(--text-input-bg);
+}
+
+input.field-input:focus,
+textarea.field-input:focus {
+  border-color: var(--text-input-border-focus);
   box-shadow: none;
+  background-color: #ffffff;
+  color: #787878;
+}
+
+input.field-input::placeholder,
+textarea.field-input::placeholder {
+  color: #787878;
+  opacity: 1;
+}
+
+.field-component input.field-input:disabled,
+.field-component textarea.field-input:disabled {
+  background-color: #f5f5f5;
+  cursor: not-allowed;
 }
 
 .field-input[readonly] {
-background-color: #f5f5f5;
-cursor: not-allowed;
+  background-color: #f5f5f5;
+  cursor: not-allowed;
 }
 
 .field-tip {
-font-size: 12px;
-color: #666;
-margin-top: 4px;
-font-style: italic;
+  font-size: 12px;
+  color: #666;
+  margin-top: 4px;
+  font-style: italic;
 }
 
 .is-required .field-label::after {
-content: "*";
-color: #e53935;
-margin-left: 2px;
+  content: "*";
+  color: #e53935;
+  margin-left: 2px;
 }
 
-.tooltip-text {  
+.tooltip-text {
   color: rgb(120, 120, 120);
   padding: 8px;
   border-radius: 4px;
@@ -511,18 +566,45 @@ margin-left: 2px;
 }
 
 .field-tooltip:hover .tooltip-text {
-  
+
 }
 
 /* Estilos específicos por tipo de campo */
 .date-input {
-  min-width: 150px;  
-  padding: 7px 12px; 
+  min-width: 150px;
+  padding: 0;
+  border: 1px solid var(--text-input-border);
+  border-radius: 4px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  background-color: var(--text-input-bg);
+  box-sizing: border-box;
+}
+
+.date-input:focus-within {
+  border-color: var(--text-input-border-focus);
+  background-color: #ffffff;
+}
+
+.date-input :deep(.dp-input) {
+  border: none;
+  background: transparent;
+  padding: 0 32px 0 8px;
+  height: 100%;
+  color: #787878;
+  font-size: 14px;
+  box-sizing: border-box;
+}
+
+.date-input :deep(.dp-input::placeholder) {
+  color: #787878;
+  opacity: 1;
 }
 
 .decimal-input,
 .integer-input {
-  text-align: right; 
+  text-align: right;
 }
 
 .yes-no-container {
@@ -544,6 +626,7 @@ margin-left: 2px;
 .multiline-input {
   resize: vertical;
   min-height: 100px;
+  height: auto;
 }
 
 /* Estilos para campos obrigatórios */
@@ -649,7 +732,6 @@ margin-left: 2px;
   font-size: 15px;
   color: #333;
   transition: background 0.2s, border 0.2s;
-  outline: none;
   box-shadow: 0 1px 1px rgba(0,0,0,0.01);
   display: flex;
   align-items: center;
@@ -672,6 +754,28 @@ margin-left: 2px;
   overflow-x: auto;
   word-break: break-word;
   box-sizing: border-box;
+  min-height: 100px;
+  padding: 8px;
+  border: 1px solid var(--text-input-border);
+  border-radius: 4px;
+  background-color: var(--text-input-bg);
+  color: #787878;
+  font-size: 14px;
+  white-space: pre-wrap;
+  transition: background 0.3s, border-color 0.3s, color 0.3s;
+}
+
+.rich-text-input:focus {
+  border-color: var(--text-input-border-focus);
+  background-color: #ffffff;
+  color: #787878;
+}
+
+.rich-text-input[data-placeholder]:empty::before {
+  content: attr(data-placeholder);
+  color: #787878;
+  opacity: 1;
+  pointer-events: none;
 }
 
 .rich-text-input img,
@@ -715,7 +819,6 @@ margin-left: 2px;
   align-items: center;
   justify-content: center;
   transition: background 0.2s, border 0.2s;
-  outline: none;
   box-shadow: 0 1px 1px rgba(0,0,0,0.01);
   margin-left: 2px;
 }
@@ -771,7 +874,7 @@ margin-left: 2px;
   box-sizing: border-box;
   background: #f8f9fa;
   transition: border 0.2s;
-  outline: none !important;
+  color: #787878;
 }
 
 .list-search-input:focus,
@@ -779,7 +882,11 @@ margin-left: 2px;
 .list-search-input:hover {
   border-color: #bdbdbd !important;
   background: #fff;
-  outline: none !important;
+}
+
+.list-search-input::placeholder {
+  color: #787878;
+  opacity: 1;
 }
 
 .custom-dropdown-wrapper {
@@ -796,8 +903,7 @@ margin-left: 2px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  
-height:34px;
+  height: 34px;
   font-size: 13px;
   transition: border 0.2s;
 }

--- a/Project/CADASTROSFormRender/Component/components/FormSection.vue
+++ b/Project/CADASTROSFormRender/Component/components/FormSection.vue
@@ -322,36 +322,29 @@ export default {
 }
 
 .section-fields {
-  padding: 12px;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  column-gap: 24px;
+  row-gap: 16px;
+  justify-items: start;
+  align-items: stretch;
 }
 
 .form-row {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 16px;
-  margin-bottom: 16px;
+  display: contents;
+  margin: 0;
+  padding: 0;
 }
 
 .field-wrapper {
-  /* O gridColumn é definido inline via style */
-}
-
-.field-input {
   width: 100%;
-  padding: 8px 12px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  font-size: 14px;
-}
-
-.field-input:focus {
-  outline: none;
-  border-color: #4a90e2;
-}
-
-.field-input:disabled {
-  background-color: #f5f5f5;
-  cursor: not-allowed;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  /* O gridColumn é definido inline via style */
 }
 
 .action-icon-section {


### PR DESCRIPTION
## Summary
- restyle the CADASTROS rich-text editor to reuse the themed input tokens, including placeholder handling and focus feedback
- align text input backgrounds with the configured theme token and drop manual outline suppression to keep native focus indicators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9958b89bc83308b101663b47516b8