### PR TITLE
Fix dropdown arrow alignment when no selection

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -92,7 +92,21 @@
             tabindex="0"
             @keydown.enter.prevent="!field.is_readonly && toggleDropdown()"
           >
-            <span v-if="selectedOption" @click.stop="onDropdownClick" style="pointer-events:auto">{{ selectedOption.label }}</span>
+            <span
+              v-if="selectedOption"
+              @click.stop="onDropdownClick"
+              style="pointer-events:auto"
+            >
+              {{ selectedOption.label }}
+            </span>
+            <span
+              v-else
+              class="placeholder"
+              @click.stop="onDropdownClick"
+              style="pointer-events:auto"
+            >
+              {{ dropdownPlaceholder }}
+            </span>
             <span class="material-symbols-outlined dropdown-arrow" @click.stop="onDropdownClick" style="pointer-events:auto">expand_more</span>
           </div>
           <div v-if="dropdownOpen" :class="['custom-dropdown-list', { 'open-up': dropdownOpenUp } ]" ref="dropdownList">
@@ -229,6 +243,13 @@ export default {
         '--text-input-border': tokens.inputBorder || '#d1d5db',
         '--text-input-border-focus': tokens.inputBorderInFocus || tokens.inputBorder || '#d1d5db'
       };
+    },
+    dropdownPlaceholder() {
+      return (
+        this.field.placeholder ||
+        this.field.placeholder_translations?.pt_br ||
+        'Selecione uma opção'
+      );
     },
     listOptions() {
       if (this.options && this.options.length > 0) {


### PR DESCRIPTION
## Summary
- add a placeholder label to the custom dropdown rendering when no option is selected
- compute the placeholder text from the field metadata to keep the caret aligned to the right

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9a44ce7d483308cdd1953c841d6a8