### PR TITLE
Aplicar fonte global ao CADASTROSFormRender

### DIFF
--- a/Project/CADASTROSFormRender/Component/wwElement.vue
+++ b/Project/CADASTROSFormRender/Component/wwElement.vue
@@ -105,11 +105,28 @@ export default {
       return true;
     });
 
-    const formHeightStyle = computed(() => {
-      if (props.content.formHeight) {
-        return { height: props.content.formHeight };
+    const componentFontFamily = ref('');
+
+    const updateComponentFontFamily = () => {
+      try {
+        if (typeof window !== 'undefined' && window.wwLib?.wwVariable?.getValue) {
+          const typographySettings = window.wwLib.wwVariable.getValue('5e429bf8-2fe3-42e4-a41d-e3b4ac1b52fa');
+          componentFontFamily.value = typographySettings?.fontFamily || '';
+        } else {
+          componentFontFamily.value = '';
+        }
+      } catch (error) {
+        componentFontFamily.value = '';
       }
-      return {};
+    };
+
+    const formHeightStyle = computed(() => {
+      const style = {};
+      if (props.content.formHeight) {
+        style.height = props.content.formHeight;
+      }
+      style.fontFamily = componentFontFamily.value || 'inherit';
+      return style;
     });
 
     const loadFormData = () => {
@@ -311,6 +328,7 @@ export default {
       };
       const initializeComponent = async () => {
         try {
+          updateComponentFontFamily();
           loadFormData();
           loadFieldsData();
           await new Promise(resolve => setTimeout(resolve, 100));
@@ -329,7 +347,12 @@ export default {
       if (newContent !== oldContent) {
         loadFormData();
         loadFieldsData();
+        updateComponentFontFamily();
       }
+    }, { deep: true });
+
+    watch(() => props.wwEditorState, () => {
+      updateComponentFontFamily();
     }, { deep: true });
 
     // Watch para formSections para debug


### PR DESCRIPTION
## Summary
- garante que o contêiner do CADASTROSFormRender use a família de fontes definida na variável global de tipografia
- atualiza a família de fontes quando o componente é montado e quando seu conteúdo/editor é alterado

## Testing
- not run (não há scripts configurados)


------
https://chatgpt.com/codex/tasks/task_e_68c9a8cb01e88330a5824642bf6b8e3b