### PR TITLE
Ajusta borda em foco dos campos rich text

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -791,12 +791,15 @@ textarea.field-input::placeholder {
   font-size: 14px;
   white-space: pre-wrap;
   transition: background 0.3s, border-color 0.3s, color 0.3s;
+  outline: none;
 }
 
-.rich-text-input:focus {
-  border-color: var(--text-input-border-focus);
+.rich-text-input:focus,
+.rich-text-input:focus-visible {
+  border: 1px solid var(--text-input-border-focus);
   background-color: #ffffff;
   color: #787878;
+  outline: none;
 }
 
 .rich-text-input[data-placeholder]:empty::before {


### PR DESCRIPTION
## Summary
- remove o outline exibido nos campos rich-text do CADASTROSFormRender
- aplica borda de 1px usando o token `inputBorderInFocus` quando o campo recebe foco

## Testing
- not run (sem scripts disponíveis)


------
https://chatgpt.com/codex/tasks/task_e_68c9b0acfc108330b8f64ded040ae12e