### PR TITLE
Adjust deadline datepicker positioning

### DIFF
--- a/Project/FormRender/Component/components/CustomDatePicker.vue
+++ b/Project/FormRender/Component/components/CustomDatePicker.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="dp-wrapper" ref="dpWrapper">
     <input
+      ref="dpInput"
       :class="['dp-input', { error }]"
       type="text"
       :value="displayDate"
@@ -23,7 +24,7 @@
     >
       <span class="material-symbols-outlined">calendar_month</span>
     </button>
-    <div v-if="dpOpen" class="datepicker-pop" :style="dpPopStyle">
+    <div v-if="dpOpen" class="datepicker-pop" :style="dpPopStyle" ref="dpPop">
       <div class="dp-header">
         <button type="button" class="dp-nav" @click="prevMonth">&lt;</button>
         <div class="dp-title">{{ monthLabel }}</div>
@@ -108,6 +109,8 @@ export default {
     const dpInput = ref(null);
     const dpOpen = ref(false);
     const dpPopStyle = ref({});
+    const dpPop = ref(null);
+    const POPUP_Z_INDEX = 2147483647;
     const selectedDate = ref('');
     const timePart = ref('00:00');
 
@@ -205,17 +208,49 @@ export default {
 
     function updatePopoverPosition() {
       const wrap = dpWrapper.value;
-      if (!wrap) return;
+      const pop = dpPop.value;
+      if (!wrap || !pop) return;
+
       const rect = wrap.getBoundingClientRect();
-      const left = Math.round(rect.left);
-      const bottom = Math.round(window.innerHeight - rect.top + 4);
-      dpPopStyle.value = {
+      const viewportHeight = window.innerHeight;
+      const viewportWidth = window.innerWidth;
+      const desiredMinWidth = Math.max(rect.width, 230);
+      const popRect = pop.getBoundingClientRect();
+      const popHeight = popRect.height;
+      let left = Math.round(rect.left);
+
+      if (left + desiredMinWidth > viewportWidth) {
+        left = Math.max(0, Math.round(viewportWidth - desiredMinWidth - 4));
+      }
+
+      const spaceAbove = rect.top;
+      const spaceBelow = viewportHeight - rect.bottom;
+      let openUp;
+
+      if (spaceBelow >= popHeight) {
+        openUp = false;
+      } else if (spaceAbove >= popHeight) {
+        openUp = true;
+      } else {
+        openUp = spaceAbove > spaceBelow;
+      }
+
+      const style = {
         position: 'fixed',
         left: `${left}px`,
-        bottom: `${bottom}px`,
-        minWidth: `${Math.max(rect.width, 230)}px`,
-        zIndex: 2147483647
+        minWidth: `${desiredMinWidth}px`,
+        zIndex: POPUP_Z_INDEX,
+        top: 'auto',
+        bottom: 'auto'
       };
+
+      if (openUp) {
+        style.bottom = `${Math.round(viewportHeight - rect.top + 4)}px`;
+      } else {
+        style.top = `${Math.round(rect.bottom + 4)}px`;
+      }
+
+      dpPopStyle.value = style;
     }
 
     function openDp(){
@@ -292,6 +327,7 @@ export default {
       dpInput,
       dpOpen,
       dpPopStyle,
+      dpPop,
       openDp,
       prevMonth,
       nextMonth,


### PR DESCRIPTION
## Summary
- allow the CustomDatePicker popup to choose whether it opens above or below the deadline field based on available space
- keep the calendar popup anchored within the viewport and expose the popup/input refs for proper focus handling
- ensure the popup uses a very high z-index so it is not covered by other components

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c9f349348c8330a96dc3bde001ee9d