### PR TITLE
Padroniza placeholders e tipografia no CADASTROSFormRender

### DIFF
--- a/Project/CADASTROSFormRender/Component/components/CustomAlert.vue
+++ b/Project/CADASTROSFormRender/Component/components/CustomAlert.vue
@@ -48,6 +48,7 @@ export default {
   max-width: 400px;
   width: 100%;
   padding: 20px 24px 24px 24px;
+  font-size: 14px;
 }
 .custom-alert-header {
   display: flex;
@@ -58,17 +59,17 @@ export default {
 .custom-alert-title {
   font-weight: 600;
   color: #3a4047;
-  font-size: 18px;
+  font-size: 14px;
 }
 .custom-alert-close {
-  font-size: 20px;
+  font-size: 14px;
   color: #888;
   cursor: pointer;
   font-weight: bold;
 }
 .custom-alert-body {
   color: #3a4047;
-  font-size: 15px;
+  font-size: 14px;
   min-height: 30px;
 }
-</style> 
+</style>

--- a/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldComponent.vue
@@ -149,7 +149,7 @@
             <button type="button" @click="insertLink" title="Inserir link"><span class="material-symbols-outlined">link</span></button>
             <button type="button" @click="insertImage" title="Inserir imagem"><span class="material-symbols-outlined">image</span></button>
             <button type="button" class="color-btn" :style="{ color: currentColor }" title="Cor do texto">
-              <span style="font-weight:bold; font-size:16px;">A</span>
+              <span style="font-weight:bold; font-size:14px;">A</span>
               <input
                 type="color"
                 @mousedown="saveSelection"
@@ -246,7 +246,8 @@ export default {
       return {
         '--text-input-bg': tokens.inputBG || '#FFFFFF',
         '--text-input-border': tokens.inputBorder || '#d1d5db',
-        '--text-input-border-focus': tokens.inputBorderInFocus || tokens.inputBorder || '#d1d5db'
+        '--text-input-border-focus': tokens.inputBorderInFocus || tokens.inputBorder || '#d1d5db',
+        '--placeholder-color': tokens.normal || tokens.inputText || '#787878'
       };
     },
     dropdownPlaceholder() {
@@ -570,9 +571,11 @@ export default {
   flex-direction: column;
   width: 100%;
   margin-bottom: 5px;
+  font-size: 14px;
   --text-input-bg: #ffffff;
   --text-input-border: #d1d5db;
   --text-input-border-focus: #bdbdbd;
+  --placeholder-color: #787878;
 }
 
 .field-label {
@@ -634,7 +637,7 @@ textarea.field-input:focus {
 
 input.field-input::placeholder,
 textarea.field-input::placeholder {
-  color: #787878;
+  color: var(--placeholder-color, #787878);
   opacity: 1;
 }
 
@@ -650,7 +653,7 @@ textarea.field-input::placeholder {
 }
 
 .field-tip {
-  font-size: 12px;
+  font-size: 14px;
   color: #666;
   margin-top: 4px;
   font-style: italic;
@@ -666,7 +669,7 @@ textarea.field-input::placeholder {
   color: rgb(120, 120, 120);
   padding: 8px;
   border-radius: 4px;
-  font-size: 12px;
+  font-size: 14px;
   white-space: nowrap;
   z-index: 1;
 }
@@ -709,7 +712,7 @@ textarea.field-input::placeholder {
 }
 
 .date-input :deep(.dp-input::placeholder) {
-  color: #787878;
+  color: var(--placeholder-color, #787878);
   opacity: 1;
 }
 
@@ -753,7 +756,7 @@ textarea.field-input::placeholder {
 
 .field-feedback {
   margin-top: 6px;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 400;
   border-radius: 4px;
   padding: 4px 8px;
@@ -771,7 +774,7 @@ textarea.field-input::placeholder {
 }
 
 .deadline-diff {
-  font-size: 12px;
+  font-size: 14px;
   color: #007bff;
   margin-top: 4px;
 }
@@ -779,7 +782,7 @@ textarea.field-input::placeholder {
 .deadline-visual {
   border-radius: 20px !important;
   text-align: center;
-  font-size: 12px;
+  font-size: 14px;
   transition: background 0.3s, color 0.3s;
 }
 .deadline-green {
@@ -840,7 +843,7 @@ textarea.field-input::placeholder {
   border-radius: 4px;
   padding: 3px 10px;
   cursor: pointer;
-  font-size: 15px;
+  font-size: 14px;
   color: #333;
   transition: background 0.2s, border 0.2s;
   box-shadow: 0 1px 1px rgba(0,0,0,0.01);
@@ -886,7 +889,7 @@ textarea.field-input::placeholder {
 
 .rich-text-input[data-placeholder]:empty::before {
   content: attr(data-placeholder);
-  color: #787878;
+  color: var(--placeholder-color, #787878);
   opacity: 1;
   pointer-events: none;
 }
@@ -927,7 +930,7 @@ textarea.field-input::placeholder {
   border-radius: 4px;
   padding: 3px 10px;
   cursor: pointer;
-  font-size: 15px;
+  font-size: 14px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -999,12 +1002,12 @@ textarea.field-input::placeholder {
 }
 
 .list-search-input::placeholder {
-  color: #787878;
+  color: var(--placeholder-color, #787878);
   opacity: 1;
 }
 
 .list-search-input::placeholder {
-  color: #787878;
+  color: var(--placeholder-color, #787878);
   opacity: 1;
 }
 
@@ -1023,7 +1026,7 @@ textarea.field-input::placeholder {
   align-items: center;
   justify-content: space-between;
   height: 34px;
-  font-size: 13px;
+  font-size: 14px;
   transition: border 0.2s;
   color: #787878;
 }
@@ -1062,7 +1065,7 @@ textarea.field-input::placeholder {
 .custom-dropdown-option {
   padding: 0 12px;
   cursor: pointer;
-  font-size: 13px;
+  font-size: 14px;
   transition: background 0.15s;
   color: #000000;
   height: 34px;
@@ -1083,7 +1086,7 @@ textarea.field-input::placeholder {
 .custom-dropdown-no-options {
   padding: 8px 12px;
   color: #888;
-  font-size: 13px;
+  font-size: 14px;
   text-align: center;
 }
 
@@ -1094,7 +1097,7 @@ textarea.field-input::placeholder {
 }
 
 .custom-dropdown-selected .placeholder {
-  color: #aaa;
+  color: var(--placeholder-color, #787878);
 }
 
 .custom-dropdown-list.open-up {

--- a/Project/CADASTROSFormRender/Component/components/FieldPropertiesPanel.vue
+++ b/Project/CADASTROSFormRender/Component/components/FieldPropertiesPanel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="field-properties-panel">
+  <div class="field-properties-panel" :style="styleVars">
     <div class="panel-header" v-if="selectedField">
       <h3>{{ title }}</h3>
     </div>
@@ -148,6 +148,20 @@ export default {
   setup(props, { emit }) {
     // Generate a unique ID for this instance
     const uniqueId = ref(`fp-${Date.now()}`);
+
+    const themeTokens = computed(() => {
+      if (typeof window !== 'undefined' && window.wwLib?.wwVariable?.getValue) {
+        const value = window.wwLib.wwVariable.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726');
+        if (value && typeof value === 'object') {
+          return value;
+        }
+      }
+      return {};
+    });
+
+    const styleVars = computed(() => ({
+      '--placeholder-color': themeTokens.value.normal || themeTokens.value.inputText || '#787878'
+    }));
     
     // Field properties
     const isRequired = ref(false);
@@ -246,7 +260,8 @@ export default {
       showOnly,
       updateFieldProperty,
       toggleTip,
-      updateTip
+      updateTip,
+      styleVars
     };
   }
 };
@@ -261,6 +276,7 @@ export default {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
     font-family: Roboto-Regular, "Open Sans", Arial, sans-serif !important;
     height: calc(100vh - 150px);
+    font-size: 14px;
   }
 
   .panel-header {
@@ -270,7 +286,7 @@ export default {
   .panel-header h3 {
     line-height: 24px;
     color: rgb(48, 48, 48);
-    font-size: 18px;
+    font-size: 14px;
     font-weight: 400;
     margin-bottom: 4px;
   }
@@ -408,6 +424,11 @@ export default {
     border: 1px solid #ddd;
     border-radius: 4px;
     resize: vertical;
+  }
+
+  .tip-textarea::placeholder {
+    color: var(--placeholder-color, #787878);
+    opacity: 1;
   }
 
   .empty-state {

--- a/Project/CADASTROSFormRender/Component/components/FormSection.vue
+++ b/Project/CADASTROSFormRender/Component/components/FormSection.vue
@@ -303,6 +303,7 @@ export default {
   margin-bottom: 0px;
   border: 0px;
   background-color: #fff;
+  font-size: 14px;
 }
 
 .section-header {
@@ -315,7 +316,7 @@ export default {
 
 .section-title {
   margin: 0;
-  font-size: 18px;
+  font-size: 14px;
   font-weight: 400;
   color: #333;
   flex: 1;
@@ -349,7 +350,7 @@ export default {
 
 .action-icon-section {
     cursor: pointer;
-    font-size: 15px;
+    font-size: 14px;
     opacity: .7;
     border-radius: 50%;
     background-color: #f5f5f5;

--- a/Project/CADASTROSFormRender/Component/wwElement.vue
+++ b/Project/CADASTROSFormRender/Component/wwElement.vue
@@ -416,6 +416,7 @@ export default {
     display: flex;
     flex-direction: column;
     overflow: visible;
+    font-size: 14px;
   }
 
   .form-sections-container {


### PR DESCRIPTION
## Summary
- ajusta FieldComponent para usar o token de placeholder e padronizar textos em 14px
- aplica o mesmo token de placeholder e tipografia uniforme ao painel de propriedades
- garante tipografia de 14px em seções, alertas e contêiner principal do formulário

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68ca084589188330ac3cd758ef04faee