### PR TITLE
Stop applying text input styles to deadline fields

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -240,6 +240,10 @@ export default {
       return {};
     },
     componentStyleVars() {
+      if (this.field && this.field.fieldType === 'DEADLINE') {
+        return {};
+      }
+
       const tokens = this.themeTokens || {};
       return {
         '--text-input-bg': tokens.inputBG || '#FFFFFF',
@@ -787,6 +791,9 @@ export default {
     flex-direction: column;
     width: 100%;
     margin-bottom: 5px;
+  }
+
+  .field-component:not(.field-type-deadline) {
     --text-input-bg: #ffffff;
     --text-input-border: #d1d5db;
     --text-input-border-focus: #bdbdbd;


### PR DESCRIPTION
## Summary
- stop providing text-input token styles to deadline fields so they no longer inherit the generic background and border settings
- scope the default text-input CSS variables to non-deadline field components only

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caa39b40fc8330872606cd4891a212