### PR TITLE
Update GridView typography and placeholders

### DIFF
--- a/Project/GridViewDinamica/src/components/CustomDatePicker.vue
+++ b/Project/GridViewDinamica/src/components/CustomDatePicker.vue
@@ -288,13 +288,12 @@ export default {
 </script>
 
 <style scoped>
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400&display=swap');
 
 .dp-wrapper {
   position: relative;
   width: 100%;
-  font-family: 'Roboto', sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, sans-serif);
   font-size: 14px;
   z-index: 99999;
 }
@@ -306,7 +305,7 @@ export default {
   padding-right: 30px;
   height: 35px;
   cursor: pointer;
-  font-family: 'Roboto', sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, sans-serif);
   font-size: 13px;
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/DateTimeCellEditor.vue
@@ -72,6 +72,7 @@
 
 <script>
 import { ref, computed, watch, onBeforeUnmount, nextTick } from 'vue';
+import { readTypographyVariable, DEFAULT_FONT_FAMILY } from '../utils/fontFamily.js';
 
 export default {
   name: 'DateTimeCellEditor',
@@ -84,6 +85,7 @@ export default {
   },
   emits: ['update:modelValue'],
   setup(props, { emit, expose }) {
+    const getFontFamily = () => readTypographyVariable() || DEFAULT_FONT_FAMILY;
     const colDef = (props.params && props.params.colDef) ? props.params.colDef : {};
     const tag = String(colDef.TagControl || colDef.tagControl || (colDef.context && colDef.context.TagControl) || '').toUpperCase();
     const fieldName = String(colDef.field || '').toLowerCase();
@@ -470,7 +472,7 @@ export default {
       padding: '8px',
       minWidth: '260px',
       maxWidth: '320px',
-      fontFamily: 'Roboto, sans-serif',
+      fontFamily: getFontFamily(),
       userSelect: 'none'
     }));
     const rowBetweenStyle = { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '6px', marginBottom: '6px' };
@@ -508,13 +510,12 @@ export default {
 </script>
 
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400&display=swap');
 
 .dp-wrapper {
   position: relative;
   width: 100%;
-  font-family: 'Roboto', sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, sans-serif);
   font-size: 14px;
   z-index: 1;
 }
@@ -525,7 +526,7 @@ export default {
   padding-right: 30px;
   height: 35px;
   cursor: pointer;
-  font-family: 'Roboto', sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, sans-serif);
   font-size: 13px;
   border: 1px solid #ccc;
   border-radius: 4px;

--- a/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/DeadlineFilterRenderer.js
@@ -1,4 +1,5 @@
 import * as VueRuntimeModule from "vue";
+import { readTypographyVariable, DEFAULT_FONT_FAMILY } from "../utils/fontFamily.js";
 
 /* CustomDatePicker + DeadlineFilterRenderer
    - Popup via Teleport para <body>
@@ -8,7 +9,7 @@ import * as VueRuntimeModule from "vue";
    - ESTILO INLINE (imune a resets / CSS faltando)
 */
 
-const ROBOTO_FONT_FAMILY = "Roboto, Arial, sans-serif";
+const getResolvedFontFamily = () => readTypographyVariable() || DEFAULT_FONT_FAMILY;
 
 //import "./list-filter.css"; // opcional para o resto do filtro, o calendário não depende disso
 
@@ -281,6 +282,8 @@ const CustomDatePicker = (() => {
         return cells;
       });
 
+      const fontFamily = getResolvedFontFamily();
+
       // ===== estilos inline (críticos) =====
       const stylePopupBase = {
         position: "fixed",
@@ -293,7 +296,7 @@ const CustomDatePicker = (() => {
         padding: "8px",
         userSelect: "none",
         boxSizing: "border-box",
-        fontFamily: ROBOTO_FONT_FAMILY,
+        fontFamily: fontFamily,
         fontSize: "13px",
       };
       const styleBackdrop = {
@@ -308,7 +311,7 @@ const CustomDatePicker = (() => {
         justifyContent: "space-between",
         padding: "4px 4px 8px",
       };
-      const sTitle = { font: `600 13px/1.2 ${ROBOTO_FONT_FAMILY}` };
+      const sTitle = { font: `600 13px/1.2 ${fontFamily}` };
       const sNav = {
         minWidth: "28px",
         minHeight: "28px",
@@ -322,7 +325,7 @@ const CustomDatePicker = (() => {
         cursor: "pointer",
         lineHeight: "1",
         color: "#424242",
-        font: `600 13px/1 ${ROBOTO_FONT_FAMILY}`,
+        font: `600 13px/1 ${fontFamily}`,
       };
       const sWeek = {
         display: "grid",
@@ -330,7 +333,7 @@ const CustomDatePicker = (() => {
         gap: "2px",
         padding: "4px 2px",
         color: "#6b7280",
-        font: `600 13px/1 ${ROBOTO_FONT_FAMILY}`,
+        font: `600 13px/1 ${fontFamily}`,
         textTransform: "uppercase",
         letterSpacing: ".02em",
       };
@@ -352,7 +355,7 @@ const CustomDatePicker = (() => {
         alignItems: "center",
         justifyContent: "center",
         cursor: "pointer",
-        font: `500 13px/1 ${ROBOTO_FONT_FAMILY}`,
+        font: `500 13px/1 ${fontFamily}`,
         lineHeight: "1",
       };
       const sCellMuted = { color: "#9ca3af" };
@@ -376,7 +379,7 @@ const CustomDatePicker = (() => {
         alignItems: "center",
         justifyContent: "center",
         cursor: "pointer",
-        font: `600 13px/1 ${ROBOTO_FONT_FAMILY}`,
+        font: `600 13px/1 ${fontFamily}`,
       };
 
       // ===== posicionamento =====
@@ -542,7 +545,7 @@ const CustomDatePicker = (() => {
               background: props.disabled ? "#f2f4f7" : "#fff",
               color: props.disabled ? "#98a2b3" : "inherit",
               cursor: props.disabled ? "not-allowed" : "pointer",
-              font: `13px/1.2 ${ROBOTO_FONT_FAMILY}`,
+              font: `13px/1.2 ${fontFamily}`,
               boxSizing: "border-box",
             },
           }),
@@ -668,7 +671,7 @@ const CustomDatePicker = (() => {
                           border: "1px solid #ccc",
                           borderRadius: "6px",
                           padding: "0 8px",
-                          font: `13px/1 ${ROBOTO_FONT_FAMILY}`,
+                          font: `13px/1 ${fontFamily}`,
                           boxSizing: "border-box",
                         },
                       }),
@@ -929,7 +932,7 @@ export default class DeadlineFilterRenderer {
       const labelEl = document.createElement("div");
       labelEl.className = "picker-label";
       labelEl.textContent = labelText;
-      labelEl.style.fontFamily = ROBOTO_FONT_FAMILY;
+      labelEl.style.fontFamily = getResolvedFontFamily();
       labelEl.style.fontSize = "13px";
       labelEl.style.fontWeight = "500";
       labelEl.style.lineHeight = "1.2";
@@ -967,8 +970,9 @@ export default class DeadlineFilterRenderer {
       }
 
       if (!runtime || !CustomDatePicker) {
+        const fallbackFont = getResolvedFontFamily();
         mountEl.innerHTML =
-          `<div class="dp-fallback" title="Vue indisponível" style="font: 13px/1 ${ROBOTO_FONT_FAMILY};">Select date</div>`;
+          `<div class="dp-fallback" title="Vue indisponível" style="font: 13px/1 ${fallbackFont};">Select date</div>`;
         return { unmount: () => {} };
       }
       const { createApp, h } = runtime;

--- a/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
+++ b/Project/GridViewDinamica/src/components/FormatterCellRenderer.vue
@@ -12,6 +12,7 @@
  
 <script>
 import { ref, onMounted, onUnmounted, computed } from 'vue';
+import { readTypographyVariable, DEFAULT_FONT_FAMILY } from '../utils/fontFamily.js';
   // Função global original
 function getRoundedSpanColor(value, colorArray, fieldName, isBold) {
 
@@ -108,6 +109,8 @@ export default {
     formattedValue() {
       try {
         const rawValue = this.params.value;
+        const typographyFont = readTypographyVariable();
+        const fontFamily = typographyFont || DEFAULT_FONT_FAMILY;
         let displayValue = rawValue;
 
         const fieldKey = this.params.colDef?.colId || this.params.colDef?.field;
@@ -135,12 +138,22 @@ if (
         const identifier = (this.params.colDef?.FieldDB || '').toString().toUpperCase();
         const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
         if (categoryTags.includes(tag) || categoryTags.includes(identifier)) {
-          return `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${displayValue}</span>`;
+          const hasValue = displayValue != null && String(displayValue).trim() !== '';
+          const background = hasValue ? '#c9edf9' : '#ffffff';
+          const borderColor = hasValue ? '#c9edf9' : '#bdbdbd';
+          const textColor = hasValue ? '#303030' : '#9e9e9e';
+          const content = hasValue ? displayValue : '';
+          return `<span style="height:25px; color:${textColor}; background:${background}; border:1px solid ${borderColor}; border-radius:12px; font-weight:normal; font-family:${fontFamily}; display:inline-flex; align-items:center; justify-content:center; padding:0 12px;">${content}</span>`;
         }
         // DEADLINE: barra proporcional
         if (this.params.colDef?.TagControl === 'DEADLINE' || this.params.colDef?.tagControl === 'DEADLINE') {
           const value = this.params.value;
-          if (!value) return '';
+          if (!value) {
+            return `<span style="display:inline-flex;align-items:center;justify-content:center;gap:6px;height:26px;min-width:100px;padding:0 12px;border:1px solid #bdbdbd;border-radius:12px;background:#ffffff;color:#9e9e9e;font-size:12px;font-weight:500;font-family:${fontFamily};text-transform:none;box-sizing:border-box;">
+              <span class="material-symbols-outlined" style="font-size:16px;line-height:1;font-variation-settings:'OPSZ' 24;">calendar_today</span>
+              Select
+            </span>`;
+          }
           // Parse data DEADLINE
           let dateStr = value;
           if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)) {
@@ -214,7 +227,7 @@ if (
           return `
             <div class="deadline-bar-bg" style="width:100%;height:22px;position:relative;background:#f5f5f5;border-radius:8px;overflow:hidden;display:block;">
               <div class="deadline-bar-fill" style="position:absolute;left:0;top:0;height:100%;width:${percent}%;background:${cor};border-radius:8px;transition:width 0.4s;z-index:1;"></div>
-              <span class="deadline-label" style="position:absolute;left:0;top:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-size:13px;color:${textColor};font-weight:bold;z-index:2;">${label}</span>
+              <span class="deadline-label" style="position:absolute;left:0;top:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-size:13px;color:${textColor};font-weight:bold;font-family:${fontFamily};z-index:2;">${label}</span>
               <div style="position:absolute;left:0;top:0;width:100%;height:100%;border:1.5px solid ${border};border-radius:8px;pointer-events:none;z-index:3;"></div>
             </div>
           `;

--- a/Project/GridViewDinamica/src/components/UserSelector.vue
+++ b/Project/GridViewDinamica/src/components/UserSelector.vue
@@ -328,22 +328,25 @@ export default {
       return { groups: Array.from(groups, ([label, items]) => ({ label, items })), ungrouped };
     },
     nameStyle() {
+      const fallbackFont = "var(--grid-view-dinamica-font-family, inherit)";
       return {
-        fontFamily: this.nameFontFamily,
+        fontFamily: this.nameFontFamily || fallbackFont,
         fontSize: this.nameFontSize,
         fontWeight: this.nameFontWeight,
       };
     },
     initialStyle() {
+      const fallbackFont = "var(--grid-view-dinamica-font-family, inherit)";
       return {
-        fontFamily: this.initialFontFamily,
+        fontFamily: this.initialFontFamily || fallbackFont,
         fontSize: this.initialFontSize,
         fontWeight: this.initialFontWeight,
       };
     },
     inputStyle() {
+      const fallbackFont = "var(--grid-view-dinamica-font-family, inherit)";
       return {
-        fontFamily: this.inputFontFamily,
+        fontFamily: this.inputFontFamily || fallbackFont,
         fontSize: this.inputFontSize,
         fontWeight: this.inputFontWeight,
       };

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -10,7 +10,7 @@
   border-radius: 15px;
   box-shadow: 0 2px 8px rgba(255, 255, 255, 0.067);
   font-size: 15px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
   overflow: hidden;
   position: relative;
 }
@@ -50,7 +50,7 @@
 :is(.list-filter, .list-editor) .filter-list,
 :is(.list-filter, .list-editor) .filter-item,
 :is(.list-filter, .list-editor) .filter-label {
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
   font-size: 13px;
 }
 
@@ -67,7 +67,7 @@
   border: 1px solid #ddd;
   border-radius: 20px;
   font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
   outline: none;
   background: #fff;
   color: #444;
@@ -77,7 +77,7 @@
 :is(.list-filter, .list-editor) .search-input::placeholder {
   color: #aaa;
   font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
 }
 
 :is(.list-filter, .list-editor) .search-icon {
@@ -120,7 +120,7 @@
   padding-bottom: 8px;
   border-bottom: 1px solid #e0e0e0;
   font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
   color: #444;
   gap: 8px;
 }
@@ -155,7 +155,7 @@
   align-items: center;
   padding: 6px 8px 6px 8px;
   font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
   cursor: pointer;
   gap: 8px;
   border-radius: 8px;
@@ -190,7 +190,7 @@
   display: inline-block;
   color: #444;
   font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
 }
 
 /* Specific styles for Deadline filter */
@@ -248,7 +248,7 @@
   border: 1px solid #ddd;
   border-radius: 6px;
   font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
   background: #fff;
   color: #444;
   box-sizing: border-box;
@@ -263,7 +263,7 @@
   border: 1px solid #ddd;
   border-radius: 6px;
   font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
   color: #444;
   box-sizing: border-box;
 }
@@ -294,7 +294,7 @@
 
 /* ---- DatePicker base ---- */
 .dp-wrapper { position: relative; display: inline-flex; align-items: center; gap: 6px; }
-.dp-input { width: 160px; padding: 8px 10px; border: 1px solid #d0d5dd; border-radius: 8px; background: #fff; font: 14px/1.2 Roboto, Arial, sans-serif; cursor: pointer; }
+.dp-input { width: 160px; padding: 8px 10px; border: 1px solid #d0d5dd; border-radius: 8px; background: #fff; font: 14px/1.2 var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif); cursor: pointer; }
 .dp-input[disabled] { background: #f2f4f7; color: #98a2b3; cursor: not-allowed; }
 .dp-icon { border: 0; background: transparent; cursor: pointer; padding: 4px; border-radius: 6px; }
 .dp-icon:hover { background: #f2f4f7; }

--- a/Project/GridViewDinamica/src/utils/fontFamily.js
+++ b/Project/GridViewDinamica/src/utils/fontFamily.js
@@ -1,0 +1,61 @@
+const DEFAULT_FONT_FAMILY = "Roboto, Arial, sans-serif";
+
+const TYPOGRAPHY_VARIABLE_ID = "5e429bf8-2fe3-42e4-a41d-e3b4ac1b52fa";
+
+function sanitizeFontFamily(fontFamily) {
+  if (typeof fontFamily !== "string") {
+    return "";
+  }
+
+  const trimmed = fontFamily.trim();
+  return trimmed.length > 0 ? trimmed : "";
+}
+
+export function readTypographyVariable() {
+  try {
+    if (typeof window === "undefined") {
+      return "";
+    }
+
+    const getter = window?.wwLib?.wwVariable?.getValue;
+    if (typeof getter !== "function") {
+      return "";
+    }
+
+    const typographySettings = getter(TYPOGRAPHY_VARIABLE_ID);
+    return sanitizeFontFamily(typographySettings?.fontFamily);
+  } catch (error) {
+    console.warn("[GridViewDinamica] Failed to read typography variable", error);
+    return "";
+  }
+}
+
+export function resolveTypographyFontFamily(customFallback) {
+  const typographyFontFamily = readTypographyVariable();
+  if (typographyFontFamily) {
+    return typographyFontFamily;
+  }
+
+  const fallback = sanitizeFontFamily(customFallback);
+  if (fallback) {
+    return fallback;
+  }
+
+  return DEFAULT_FONT_FAMILY;
+}
+
+export function applyGlobalGridFontFamily(fontFamily) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const target = document.documentElement;
+  if (!fontFamily) {
+    target.style.removeProperty("--grid-view-dinamica-font-family");
+    return;
+  }
+
+  target.style.setProperty("--grid-view-dinamica-font-family", fontFamily);
+}
+
+export { DEFAULT_FONT_FAMILY, TYPOGRAPHY_VARIABLE_ID };


### PR DESCRIPTION
## Summary
- centralize typography handling with a new utility that reads the design token font family and exposes it as a global CSS variable
- update GridView core component, renderers, editors and supporting styles to consume the shared font family instead of hard-coded Roboto declarations
- add empty-state styling for Deadline cells with a calendar icon, and neutral placeholders for empty category cells to match the requested design

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cabe754184833092777ac7bcba0ee4