### PR TITLE
Fix dropdown alignment when no list option is selected

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -116,6 +116,7 @@
             :class="{ open: dropdownOpen, 'readonly-field': field.is_readonly, error: error && field.is_mandatory }"
             @click="onDropdownClick" tabindex="0" @keydown.enter.prevent="!field.is_readonly && toggleDropdown()">
             <span v-if="selectedOption" @click.stop="onDropdownClick" style="pointer-events:auto">{{ selectedOption.label }}</span>
+            <span v-else class="placeholder" @click.stop="onDropdownClick" style="pointer-events:auto">{{ dropdownPlaceholder }}</span>
             <span class="material-symbols-outlined dropdown-arrow" @click.stop="onDropdownClick" style="pointer-events:auto">expand_more</span>
           </div>
           <div v-if="dropdownOpen" :class="['custom-dropdown-list', { 'open-up': dropdownOpenUp } ]" ref="dropdownList">
@@ -275,6 +276,13 @@ export default {
         '--text-input-border': tokens.inputBorder || '#d1d5db',
         '--text-input-border-focus': tokens.inputBorderInFocus || tokens.inputBorder || '#d1d5db'
       };
+    },
+    dropdownPlaceholder() {
+      return (
+        this.field.placeholder ||
+        this.field.placeholder_translations?.pt_br ||
+        'Selecione uma opção'
+      );
     },
     listOptions() {
       // Se temos opções passadas via prop (da API), usa essas


### PR DESCRIPTION
## Summary
- render a placeholder within the custom dropdown when no option is selected so the expand arrow stays right-aligned
- expose a computed placeholder text that reuses configured placeholders or a sensible default for list fields

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cac1477b008330830fb0603539a15f