### PR TITLE
Atualiza variável ao modificar filtros e ordenações da grid

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -287,6 +287,34 @@
   // TODO: maybe register less modules
   // TODO: maybe register modules per grid instead of globally
   ModuleRegistry.registerModules([AllCommunityModule]);
+
+  const HIDE_SAVE_BUTTON_VARIABLE_ID = "09c5aacd-b697-4e04-9571-d5db1f671877";
+
+  const updateHideSaveButtonVisibility = (value) => {
+    try {
+      const wwVariable = window?.wwLib?.wwVariable;
+      if (!wwVariable) return;
+
+      if (typeof wwVariable.setValue === "function") {
+        wwVariable.setValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+        return;
+      }
+
+      if (typeof wwVariable.updateValue === "function") {
+        wwVariable.updateValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+        return;
+      }
+
+      if (typeof wwVariable.setComponentValue === "function") {
+        wwVariable.setComponentValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+      }
+    } catch (error) {
+      console.warn(
+        "[GridViewDinamica] Failed to update escondeBotaoSalvarGrid variable",
+        error
+      );
+    }
+  };
   
   export default {
   components: {
@@ -1080,6 +1108,7 @@ setTimeout(() => {
   JSON.stringify(filterValue.value || {})
   ) {
   setFilters(filterModel);
+  updateHideSaveButtonVisibility(false);
   ctx.emit("trigger-event", {
   name: "filterChanged",
   event: filterModel,
@@ -1096,6 +1125,7 @@ setTimeout(() => {
   JSON.stringify(sortValue.value || [])
   ) {
   setSort(state.sort?.sortModel || []);
+  updateHideSaveButtonVisibility(false);
   ctx.emit("trigger-event", {
   name: "sortChanged",
   event: state.sort?.sortModel || [],
@@ -1111,6 +1141,7 @@ setTimeout(() => {
   updateColumnsPosition();
   const current = JSON.stringify(columnsPositionValue.value || []);
   if (prev !== current) {
+  updateHideSaveButtonVisibility(false);
   ctx.emit("trigger-event", {
   name: "columnMoved",
   event: columnsPositionValue.value,


### PR DESCRIPTION
## Summary
- adiciona helper para atualizar a variável escondeBotaoSalvarGrid
- força a variável a receber false ao alterar filtros, ordenações ou posição de colunas

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cae97a2fbc8330a9f642df9af86263