### PR TITLE
Restaura visibilidade do botão salvar ao reiniciar grid

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -287,6 +287,62 @@
   // TODO: maybe register less modules
   // TODO: maybe register modules per grid instead of globally
   ModuleRegistry.registerModules([AllCommunityModule]);
+
+  const HIDE_SAVE_BUTTON_VARIABLE_ID = "09c5aacd-b697-4e04-9571-d5db1f671877";
+
+  const updateHideSaveButtonVisibility = (value) => {
+    try {
+      const wwVariable = window?.wwLib?.wwVariable;
+      if (!wwVariable) return;
+
+      if (typeof wwVariable.setValue === "function") {
+        wwVariable.setValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+        return;
+      }
+
+      if (typeof wwVariable.updateValue === "function") {
+        wwVariable.updateValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+        return;
+      }
+
+      if (typeof wwVariable.setComponentValue === "function") {
+        wwVariable.setComponentValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+      }
+    } catch (error) {
+      console.warn(
+        "[GridViewDinamica] Failed to update escondeBotaoSalvarGrid variable",
+        error
+      );
+    }
+  };
+
+  const shouldRevealSaveButton = (event) => {
+    if (!event) return true;
+
+    if (event.afterDataChange) return false;
+
+    const ignoreSources = [
+      "api",
+      "columnEverythingChanged",
+      "gridInitializing",
+      "rowDataChanged",
+      "rowDataUpdated",
+    ];
+
+    if (event.source && ignoreSources.includes(event.source)) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const syncHideSaveButtonVisibility = (event) => {
+    updateHideSaveButtonVisibility(!shouldRevealSaveButton(event));
+  };
+
+  const resetHideSaveButtonVisibility = () => {
+    updateHideSaveButtonVisibility(true);
+  };
   
   export default {
   components: {
@@ -778,6 +834,7 @@ setTimeout(() => {
     applyExternalSortAndSync();
   }
 }, 0);
+    resetHideSaveButtonVisibility();
   }, { deep: true });
 
 
@@ -803,6 +860,8 @@ setTimeout(() => {
     const onGridReady = (params) => {
       gridApi.value = params.api;
       columnApi.value = params.columnApi;
+
+      resetHideSaveButtonVisibility();
 
       // Restaura imediatamente e também em pequenos delays
       restoreGridState();
@@ -1080,6 +1139,7 @@ setTimeout(() => {
   JSON.stringify(filterValue.value || {})
   ) {
   setFilters(filterModel);
+  syncHideSaveButtonVisibility(event);
   ctx.emit("trigger-event", {
   name: "filterChanged",
   event: filterModel,
@@ -1096,6 +1156,7 @@ setTimeout(() => {
   JSON.stringify(sortValue.value || [])
   ) {
   setSort(state.sort?.sortModel || []);
+  syncHideSaveButtonVisibility(event);
   ctx.emit("trigger-event", {
   name: "sortChanged",
   event: state.sort?.sortModel || [],
@@ -1111,6 +1172,7 @@ setTimeout(() => {
   updateColumnsPosition();
   const current = JSON.stringify(columnsPositionValue.value || []);
   if (prev !== current) {
+  syncHideSaveButtonVisibility(event);
   ctx.emit("trigger-event", {
   name: "columnMoved",
   event: columnsPositionValue.value,


### PR DESCRIPTION
## Summary
- adiciona helpers para sincronizar a variável `escondeBotaoSalvarGrid` com eventos da grid
- volta a esconder o botão ao montar a grid e sempre que o datasource é atualizado
- ajusta handlers de filtro, ordenação e movimentação de colunas para também restaurar a variável durante eventos de inicialização

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cae97a2fbc8330a9f642df9af86263