### PR TITLE
Fix save button visibility sync for grid state changes

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -509,13 +509,27 @@
   };
 
   const syncHideSaveButtonVisibility = (event) => {
+    const pristine = isGridStatePristine();
+    const programmatic = isProgrammaticEvent(event);
+
     if (!shouldRevealSaveButton(event)) {
-      updateHideSaveButtonVisibility(true);
+      if (suppressRevealUntilCapture) {
+        updateHideSaveButtonVisibility(true);
+        scheduleCaptureInitialGridState(50);
+        return;
+      }
+
+      if (programmatic && !pristine) {
+        updateHideSaveButtonVisibility(false);
+        return;
+      }
+
+      updateHideSaveButtonVisibility(pristine);
       scheduleCaptureInitialGridState(50);
       return;
     }
 
-    updateHideSaveButtonVisibility(isGridStatePristine());
+    updateHideSaveButtonVisibility(pristine);
   };
 
   const resetHideSaveButtonVisibility = () => {


### PR DESCRIPTION
## Summary
- ensure the grid state watcher no longer forces the hide-save variable to true for programmatic events when the grid is dirty
- respect programmatic suppression while still reporting false when user changes are misidentified as API events

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd4633821c8330a35d19143bf4100b