### PR TITLE
Fix sort change detection for dirty state

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -352,6 +352,7 @@
 
   let suppressRevealUntilCapture = false;
   let pendingInitialGridState = null;
+  let userInteractedDuringCapture = false;
 
   const PROGRAMMATIC_EVENT_SOURCES = new Set([
     "api",
@@ -484,7 +485,9 @@
 
   const captureInitialGridState = () => {
     if (!gridApi.value) return;
-    initialGridState.value = getNormalizedGridState();
+    const snapshot = getNormalizedGridState();
+    initialGridState.value = snapshot;
+    pendingInitialGridState = snapshot;
   };
 
   const scheduleCaptureInitialGridState = (delay = 0) => {
@@ -493,29 +496,33 @@
       captureInitialStateTimeout = null;
     }
 
-    pendingInitialGridState = getNormalizedGridState();
     suppressRevealUntilCapture = true;
+    pendingInitialGridState = getNormalizedGridState();
+    userInteractedDuringCapture = false;
 
     const finalizeCapture = () => {
       captureInitialStateTimeout = null;
 
-      if (pendingInitialGridState) {
-        initialGridState.value = pendingInitialGridState;
-        pendingInitialGridState = null;
-      } else {
-        captureInitialGridState();
+      try {
+        const nextState = getNormalizedGridState();
+        if (userInteractedDuringCapture && pendingInitialGridState) {
+          initialGridState.value = pendingInitialGridState;
+        } else {
+          pendingInitialGridState = nextState;
+          initialGridState.value = nextState;
+        }
+      } finally {
+        suppressRevealUntilCapture = false;
+        userInteractedDuringCapture = false;
+
+        // Depois de recapturar o estado inicial, sincroniza imediatamente
+        // a visibilidade do botão para refletir o novo snapshot.
+        updateHideSaveButtonVisibility(isGridStatePristine());
       }
-
-      suppressRevealUntilCapture = false;
-
-      // Depois de recapturar o estado inicial, sincroniza imediatamente
-      // a visibilidade do botão para refletir o novo snapshot.
-      updateHideSaveButtonVisibility(isGridStatePristine());
     };
 
     const timeoutDelay = typeof delay === "number" && delay > 0 ? delay : 0;
     captureInitialStateTimeout = setTimeout(finalizeCapture, timeoutDelay);
-
   };
 
   const runWithSuppressedReveal = (operation, { recaptureDelay = 50 } = {}) => {
@@ -555,8 +562,14 @@
   };
 
   const syncHideSaveButtonVisibility = (event) => {
+    const isSortEvent = event?.type === "sortChanged";
     const isRowDataSourceChange =
-      event?.source === "rowDataChanged" || event?.source === "rowDataUpdated";
+      !isSortEvent &&
+      (event?.source === "rowDataChanged" || event?.source === "rowDataUpdated");
+
+    if (captureInitialStateTimeout && event && !isProgrammaticEvent(event)) {
+      userInteractedDuringCapture = true;
+    }
 
     if (isRowDataSourceChange) {
       updateHideSaveButtonVisibility(true);
@@ -1397,22 +1410,23 @@ const remountComponent = () => {
   };
   
   const onSortChanged = (event) => {
-  if (!gridApi.value) return;
-  const state = gridApi.value.getState();
-  if (
-  JSON.stringify(state.sort?.sortModel || []) !==
-  JSON.stringify(sortValue.value || [])
-  ) {
-  setSort(state.sort?.sortModel || []);
-  syncHideSaveButtonVisibility(event);
+    if (!gridApi.value) return;
 
-  ctx.emit("trigger-event", {
-  name: "sortChanged",
-  event: state.sort?.sortModel || [],
-  });
-  }
-  updateColumnsSort();
-  saveGridState();
+    const { sort: normalizedSort } = getNormalizedGridState();
+    const previousSort = normalizeSortModel(sortValue.value || []);
+
+    if (JSON.stringify(normalizedSort) !== JSON.stringify(previousSort)) {
+      setSort(normalizedSort);
+      syncHideSaveButtonVisibility(event);
+
+      ctx.emit("trigger-event", {
+        name: "sortChanged",
+        event: normalizedSort,
+      });
+    }
+
+    updateColumnsSort();
+    saveGridState();
   };
 
   const onColumnMoved = (event) => {


### PR DESCRIPTION
## Summary
- detect column sort changes using the normalized grid snapshot instead of the unstable getState API
- update the saved sort variable and dirty-state tracking whenever the normalized model changes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd5a017c1083309783737de559afb0