### PR TITLE
Restore form validity component variable

### DIFF
--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -107,6 +107,13 @@ export default {
       defaultValue: {}
     });
 
+    const { value: formIsValid, setValue: setFormIsValid } = wwLib.wwVariable.useComponentVariable({
+      uid: props.uid,
+      name: 'formIsValid',
+      type: 'boolean',
+      defaultValue: true
+    });
+
  
 
     const formSections = ref([]);
@@ -233,6 +240,53 @@ export default {
       allAvailableFields.value = [...fields];
     };
 
+    const hasValue = (value) => {
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+
+      if (value instanceof Date) {
+        return !Number.isNaN(value.getTime());
+      }
+
+      if (value && typeof value === 'object') {
+        return Object.keys(value).length > 0;
+      }
+
+      if (typeof value === 'number') {
+        return true;
+      }
+
+      if (typeof value === 'boolean') {
+        return true;
+      }
+
+      return value !== null && value !== undefined && String(value).trim() !== '';
+    };
+
+    const evaluateFormValidity = () => {
+      let valid = true;
+
+      formSections.value.forEach(section => {
+        if (!section || !Array.isArray(section.fields)) {
+          return;
+        }
+
+        section.fields.forEach(field => {
+          if (!field || !field.is_mandatory || field.is_readonly) {
+            return;
+          }
+
+          if (!hasValue(field.value)) {
+            valid = false;
+          }
+        });
+      });
+
+      setFormIsValid(valid);
+      return valid;
+    };
+
     const updateFormState = () => {
       try {
         const formState = {
@@ -253,6 +307,8 @@ export default {
           }))
         };
         setFormData(formState);
+
+        evaluateFormValidity();
 
         emit('trigger-event', {
           name: 'fieldsUpdated',
@@ -416,12 +472,20 @@ export default {
           if (!sectionValid) valid = false;
         }
       });
+
+      const computedValid = evaluateFormValidity();
+      if (!computedValid) {
+        valid = false;
+      }
+
+      setFormIsValid(valid);
       return valid;
     };
 
     return {
       isEditing,
       formData,
+      formIsValid,
       formSections,
       formSectionsContainer,
       allAvailableFields,


### PR DESCRIPTION
## Summary
- reintroduce the `formIsValid` component variable for FormRender so builders can inspect validity
- compute and update the validity flag whenever sections change or validation runs to keep it accurate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d190f4b35483308c106c8f210ef21e