### PR TITLE
Synchronize form validity flag with validation action

### DIFF
--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -107,6 +107,13 @@ export default {
       defaultValue: {}
     });
 
+    const { value: formIsValid, setValue: setFormIsValid } = wwLib.wwVariable.useComponentVariable({
+      uid: props.uid,
+      name: 'formIsValid',
+      type: 'boolean',
+      defaultValue: true
+    });
+
  
 
     const formSections = ref([]);
@@ -128,6 +135,24 @@ export default {
       if (typeof val === 'boolean') return val;
       if (typeof val === 'string') return val.toLowerCase() === 'true';
       return undefined;
+    };
+
+    const normalizeBoolean = value => {
+      if (typeof value === 'string') {
+        const normalized = value.trim().toLowerCase();
+        if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+          return true;
+        }
+        if (['false', '0', 'no', 'n', 'off', ''].includes(normalized)) {
+          return false;
+        }
+      }
+
+      if (typeof value === 'number') {
+        return value !== 0;
+      }
+
+      return Boolean(value);
     };
 
     const autoSave = computed(() => {
@@ -183,6 +208,9 @@ export default {
             }
             // FORMATED_TEXT mantém como string
             // Outros tipos mantêm valor original
+            const originalReadonly = normalizeBoolean(field.original_readonly ?? field.is_readonly);
+            const isMandatory = normalizeBoolean(field.is_mandatory);
+            const hideLegend = normalizeBoolean(field.is_hide_legend);
             const processedField = {
               ...field,
               id: field.id || field.ID || field.field_id || `field-${Date.now()}`,
@@ -190,10 +218,10 @@ export default {
               name: field.name || field.Name || 'Campo sem nome',
               fieldType: field.fieldType || 'text',
               columns: parseInt(field.columns) || 1,
-              is_mandatory: Boolean(field.is_mandatory),
-              original_readonly: Boolean(field.is_readonly),
-              is_readonly: Boolean(field.is_readonly || formReadOnly.value),
-              is_hide_legend: Boolean(field.is_hide_legend),
+              is_mandatory: isMandatory,
+              original_readonly: originalReadonly,
+              is_readonly: originalReadonly || normalizeBoolean(formReadOnly.value),
+              is_hide_legend: hideLegend,
               dataSource: field.dataSource || field.data_source,
               list_options: field.list_options || field.listOptions,
               value: processedValue
@@ -233,26 +261,96 @@ export default {
       allAvailableFields.value = [...fields];
     };
 
+    const hasValue = (value) => {
+      if (Array.isArray(value)) {
+        return value.length > 0;
+      }
+
+      if (value instanceof Date) {
+        return !Number.isNaN(value.getTime());
+      }
+
+      if (value && typeof value === 'object') {
+        return Object.keys(value).length > 0;
+      }
+
+      if (typeof value === 'number') {
+        return true;
+      }
+
+      if (typeof value === 'boolean') {
+        return true;
+      }
+
+      return value !== null && value !== undefined && String(value).trim() !== '';
+    };
+
+    const computeFormValidity = () => {
+      let valid = true;
+
+      formSections.value.forEach(section => {
+        if (!section || !Array.isArray(section.fields)) {
+          return;
+        }
+
+        section.fields.forEach(field => {
+          if (!field) {
+            return;
+          }
+
+          const isMandatory = normalizeBoolean(field.is_mandatory);
+          const isReadonly = normalizeBoolean(field.is_readonly);
+
+          if (!isMandatory || isReadonly) {
+            return;
+          }
+
+          if (!hasValue(field.value)) {
+            valid = false;
+          }
+        });
+      });
+
+      return valid;
+    };
+
+    const applyFormValidity = valid => {
+      if (formIsValid && typeof formIsValid === 'object' && 'value' in formIsValid) {
+        formIsValid.value = valid;
+      }
+      setFormIsValid(valid);
+      return valid;
+    };
+
+    const refreshFormValidity = () => {
+      return applyFormValidity(computeFormValidity());
+    };
+
     const updateFormState = () => {
       try {
         const formState = {
           sections: formSections.value.map(section => ({
             ...section,
-            fields: section.fields.map(field => ({
-              ...field,
-              id: field.id || field.ID || field.field_id,
-              field_id: field.field_id || field.ID || field.id,
-              name: field.name || field.Name,
-              fieldType: field.fieldType || 'text',
-              columns: parseInt(field.columns) || 1,
-              is_mandatory: Boolean(field.is_mandatory),
-              original_readonly: Boolean(field.original_readonly),
-              is_readonly: Boolean(field.original_readonly || formReadOnly.value),
-              is_hide_legend: Boolean(field.is_hide_legend)
-            }))
+            fields: section.fields.map(field => {
+              const originalReadonly = normalizeBoolean(field.original_readonly ?? field.is_readonly);
+              return {
+                ...field,
+                id: field.id || field.ID || field.field_id,
+                field_id: field.field_id || field.ID || field.id,
+                name: field.name || field.Name,
+                fieldType: field.fieldType || 'text',
+                columns: parseInt(field.columns) || 1,
+                is_mandatory: normalizeBoolean(field.is_mandatory),
+                original_readonly: originalReadonly,
+                is_readonly: originalReadonly || normalizeBoolean(formReadOnly.value),
+                is_hide_legend: normalizeBoolean(field.is_hide_legend)
+              };
+            })
           }))
         };
         setFormData(formState);
+
+        refreshFormValidity();
 
         emit('trigger-event', {
           name: 'fieldsUpdated',
@@ -307,6 +405,12 @@ export default {
             original_readonly: section.fields[fieldIndex].original_readonly,
             ...field
           };
+          const updatedField = section.fields[fieldIndex];
+          const originalReadonly = normalizeBoolean(updatedField.original_readonly ?? updatedField.is_readonly);
+          updatedField.is_mandatory = normalizeBoolean(updatedField.is_mandatory);
+          updatedField.original_readonly = originalReadonly;
+          updatedField.is_readonly = originalReadonly || normalizeBoolean(formReadOnly.value);
+          updatedField.is_hide_legend = normalizeBoolean(updatedField.is_hide_legend);
           updateFormState();
         }
       }
@@ -376,12 +480,19 @@ export default {
     watch(
       formReadOnly,
       newVal => {
+        const normalizedNewVal = normalizeBoolean(newVal);
         formSections.value.forEach(section => {
           section.fields.forEach(field => {
-            if (field.original_readonly === undefined) {
-              field.original_readonly = Boolean(field.is_readonly);
+            if (!field) {
+              return;
             }
-            field.is_readonly = field.original_readonly || newVal;
+
+            if (field.original_readonly === undefined) {
+              field.original_readonly = normalizeBoolean(field.is_readonly);
+            } else {
+              field.original_readonly = normalizeBoolean(field.original_readonly);
+            }
+            field.is_readonly = field.original_readonly || normalizedNewVal;
           });
         });
         updateFormState();
@@ -392,11 +503,11 @@ export default {
     watch(
       () => props.readOnly,
       val => {
-        const normalized = val === 'true' || val === true;
-        if (normalized !== formReadOnly.value) {
+        const normalized = normalizeBoolean(val);
+        if (normalized !== normalizeBoolean(formReadOnly.value)) {
           formSections.value.forEach(section => {
             section.fields.forEach(field => {
-              field.is_readonly = field.original_readonly || normalized;
+              field.is_readonly = normalizeBoolean(field.original_readonly) || normalized;
             });
           });
           updateFormState();
@@ -409,19 +520,34 @@ export default {
     }, { deep: true });
 
     const validateRequiredFields = () => {
-      let valid = true;
+      let sectionsValid = true;
       sectionComponents.value.forEach(section => {
         if (section && typeof section.validateFields === 'function') {
           const sectionValid = section.validateFields();
-          if (!sectionValid) valid = false;
+          if (!sectionValid) {
+            sectionsValid = false;
+          }
         }
       });
-      return valid;
+
+      const computedValid = computeFormValidity();
+      const finalValidity = sectionsValid && computedValid;
+
+      return applyFormValidity(finalValidity);
     };
+
+    watch(
+      formSections,
+      () => {
+        refreshFormValidity();
+      },
+      { deep: true }
+    );
 
     return {
       isEditing,
       formData,
+      formIsValid,
       formSections,
       formSectionsContainer,
       allAvailableFields,


### PR DESCRIPTION
## Summary
- centralize form validity updates into a helper so the component variable and local ref stay in sync
- ensure the "Validate required fields" action applies the combined validity result to the `formIsValid` variable

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d190f4b35483308c106c8f210ef21e