### PR TITLE
Track form validity from field validations

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -213,6 +213,10 @@ export default {
     autoSave: {
       type: [Boolean, String],
       default: true
+    },
+    componentUid: {
+      type: String,
+      required: false
     }
   },
   data() {
@@ -230,7 +234,14 @@ export default {
       dataNow: new Date(),
       currentColor: '#699d8c',
       isUserInput: false,
+      isFormValid: true,
+      formIsValidVariable: null,
+      formValidityRegistryKey: null,
+      currentFieldKey: null
     }
+  },
+  created() {
+    this.initializeFormValidityTracking();
   },
   computed: {
     autoSaveEnabled() {
@@ -467,9 +478,16 @@ export default {
   },
   watch: {
     field: {
-      handler(newField) {
+      handler(newField, oldField) {
+        const previousKey = this.getFieldKey(oldField);
         this.localValue = newField.value ?? '';
         this.originalValue = newField.value ?? '';
+        const newKey = this.getFieldKey(newField);
+        if (previousKey && previousKey !== newKey) {
+          this.removeFieldKeyFromRegistry(previousKey);
+        }
+        this.currentFieldKey = newKey;
+        this.syncFormValidityState();
       },
       deep: true,
       immediate: true
@@ -526,6 +544,7 @@ export default {
         case 'YES_NO':
           value = event.target.value === 'true';
           apiValue = value;
+          this.error = null;
           break;
         case 'SIMPLE_LIST':
           value = value + '';
@@ -541,6 +560,8 @@ export default {
           this.validateText(value);
           break;
       }
+      const validationFailed = Boolean(this.error);
+      this.updateFormValidityFlag(!validationFailed);
       if (!this.error) {
         // Só salva se o valor realmente mudou (comparação robusta)
         let isChanged = false;
@@ -562,6 +583,142 @@ export default {
           }
           this.originalValue = value;
         }
+      }
+    },
+    getFieldKey(field = this.field) {
+      if (!field || typeof field !== 'object') {
+        return `field-${this._uid}`;
+      }
+      return (
+        field.id ||
+        field.field_id ||
+        field.ID ||
+        (field.name ? `field-${field.name}` : `field-${this._uid}`)
+      );
+    },
+    getValidityRegistry(createIfMissing = true) {
+      if (typeof window === 'undefined') {
+        return null;
+      }
+      if (!this.formValidityRegistryKey) {
+        const root = this.$root;
+        const fallback = this.componentUid || root?.uid || root?._uid || `form-render-${this._uid}`;
+        this.formValidityRegistryKey = fallback;
+      }
+      if (!window.__formRenderValidityRegistry) {
+        if (!createIfMissing) {
+          return null;
+        }
+        window.__formRenderValidityRegistry = {};
+      }
+      const registry = window.__formRenderValidityRegistry;
+      if (!registry[this.formValidityRegistryKey]) {
+        if (!createIfMissing) {
+          return { registry, map: null, key: this.formValidityRegistryKey };
+        }
+        registry[this.formValidityRegistryKey] = {};
+      }
+      return {
+        registry,
+        map: registry[this.formValidityRegistryKey],
+        key: this.formValidityRegistryKey
+      };
+    },
+    initializeFormValidityTracking() {
+      this.getValidityRegistry(true);
+      if (!this.formIsValidVariable && this.componentUid && typeof window !== 'undefined') {
+        const wwVariable = window.wwLib?.wwVariable;
+        if (wwVariable?.useComponentVariable) {
+          try {
+            this.formIsValidVariable = wwVariable.useComponentVariable({
+              uid: this.componentUid,
+              name: 'formIsValid',
+              type: 'boolean',
+              defaultValue: true
+            });
+          } catch (error) {
+            this.formIsValidVariable = null;
+          }
+        }
+      }
+      this.currentFieldKey = this.getFieldKey();
+      this.syncFormValidityState();
+    },
+    syncFormValidityState() {
+      this.updateFormValidityFlag(!this.error);
+    },
+    updateFormValidityFlag(isFieldValid) {
+      const registryInfo = this.getValidityRegistry(true);
+      let aggregated = isFieldValid;
+      const fieldKey = this.getFieldKey();
+      this.currentFieldKey = fieldKey;
+      if (registryInfo?.map && fieldKey) {
+        registryInfo.map[fieldKey] = isFieldValid;
+        aggregated = Object.values(registryInfo.map).every(Boolean);
+      }
+      this.isFormValid = aggregated;
+      this.setPublicFormValidity(aggregated);
+    },
+    setPublicFormValidity(value) {
+      if (typeof window === 'undefined') {
+        this.isFormValid = value;
+        return;
+      }
+      if (this.formIsValidVariable?.setValue) {
+        try {
+          this.formIsValidVariable.setValue(value);
+          return;
+        } catch (error) {
+        }
+      }
+      const wwVariable = window.wwLib?.wwVariable;
+      if (!wwVariable) {
+        return;
+      }
+      if (this.componentUid) {
+        if (typeof wwVariable.setComponentValue === 'function') {
+          wwVariable.setComponentValue(this.componentUid, 'formIsValid', value);
+          return;
+        }
+        if (typeof wwVariable.updateComponentValue === 'function') {
+          wwVariable.updateComponentValue(this.componentUid, 'formIsValid', value);
+          return;
+        }
+      }
+      if (typeof wwVariable.setValue === 'function') {
+        wwVariable.setValue('formIsValid', value);
+        return;
+      }
+      if (typeof wwVariable.updateValue === 'function') {
+        wwVariable.updateValue('formIsValid', value);
+      }
+    },
+    removeFieldKeyFromRegistry(fieldKey) {
+      const registryInfo = this.getValidityRegistry(false);
+      if (!registryInfo || !registryInfo.map || !fieldKey) {
+        return;
+      }
+      delete registryInfo.map[fieldKey];
+      if (Object.keys(registryInfo.map).length === 0) {
+        delete registryInfo.registry[registryInfo.key];
+        this.isFormValid = true;
+        this.setPublicFormValidity(true);
+      } else {
+        const aggregated = Object.values(registryInfo.map).every(Boolean);
+        this.isFormValid = aggregated;
+        this.setPublicFormValidity(aggregated);
+      }
+    },
+    cleanupFormValidity() {
+      const key = this.currentFieldKey || this.getFieldKey();
+      if (key) {
+        this.removeFieldKeyFromRegistry(key);
+      }
+    },
+    clearDeadlineTimer() {
+      if (this.deadlineTimer) {
+        clearInterval(this.deadlineTimer);
+        this.deadlineTimer = null;
       }
     },
     async saveFieldValueToApi(value) {
@@ -775,11 +932,12 @@ export default {
         );
         if (!hasValue) {
           this.error = 'Campo obrigatório';
-
+          this.updateFormValidityFlag(false);
           return false;
         }
       }
       this.error = null;
+      this.updateFormValidityFlag(true);
       return true;
     },
     onDropdownClick(e) {
@@ -797,12 +955,15 @@ export default {
         this.dataNow = new Date();
       }, 1000);
     }
+    this.syncFormValidityState();
+  },
+  beforeUnmount() {
+    this.cleanupFormValidity();
+    this.clearDeadlineTimer();
   },
   beforeDestroy() {
-    if (this.deadlineTimer) {
-      clearInterval(this.deadlineTimer);
-      this.deadlineTimer = null;
-    }
+    this.cleanupFormValidity();
+    this.clearDeadlineTimer();
   }
 }
 </script>

--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -22,6 +22,7 @@ class="action-icon-section"
             :options="getFieldOptions(field.id)"
             :user-id="userId"
             :auto-save="autoSave"
+            :component-uid="componentUid"
             @update:value="value => updateFieldValue(field.id, value)"
           />
         </div>
@@ -83,6 +84,10 @@ export default {
     autoSave: {
       type: [Boolean, String],
       default: undefined
+    },
+    componentUid: {
+      type: String,
+      required: false
     }
   },
   emits: ['update:value'],
@@ -334,7 +339,8 @@ export default {
       fieldRows,
       autoSave,
       fieldComponents,
-      validateFields
+      validateFields,
+      componentUid: props.componentUid
     };
   }
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -31,6 +31,7 @@
               :language="language"
               :read-only="formReadOnly"
               :auto-save="autoSave"
+              :component-uid="uid"
               @update-section="updateFormState"
               @edit-section="editSection"
               @edit-field="editFormField"
@@ -107,7 +108,7 @@ export default {
       defaultValue: {}
     });
 
-    const { value: formIsValid, setValue: setFormIsValid } = wwLib.wwVariable.useComponentVariable({
+    const { value: formIsValid } = wwLib.wwVariable.useComponentVariable({
       uid: props.uid,
       name: 'formIsValid',
       type: 'boolean',
@@ -283,7 +284,6 @@ export default {
         });
       });
 
-      setFormIsValid(valid);
       return valid;
     };
 
@@ -478,7 +478,6 @@ export default {
         valid = false;
       }
 
-      setFormIsValid(valid);
       return valid;
     };
 


### PR DESCRIPTION
## Summary
- add form validity tracking logic to `FieldComponent.vue` to aggregate validation results and update the public `formIsValid` variable
- pass the component UID into each field component from the section renderer so field components can publish validity changes
- stop updating `formIsValid` directly in `wwElement.vue` so the new field-level flag is the single source of truth

## Testing
- npm install *(fails: registry returned HTTP 403 for sortablejs tarball)*

------
https://chatgpt.com/codex/tasks/task_e_68d1d4416378833091082923bcfde2d7