### PR TITLE
Clear shifts when disabling calendar day

### DIFF
--- a/Project/CALENDARIO/src/wwElement.vue
+++ b/Project/CALENDARIO/src/wwElement.vue
@@ -553,11 +553,23 @@ export default {
     }
 
     const hasHourInconsistency = ref(false);
-    watch(weekDays, (days) => {
-      hasHourInconsistency.value = days.some((day) =>
-        ["shift1Start", "shift1End", "shift2Start", "shift2End"].some((field) => isInconsistent(day, field))
-      );
-    }, { deep: true, immediate: true });
+    watch(
+      weekDays,
+      (days) => {
+        for (const day of days) {
+          if (!day.active) {
+            ["shift1Start", "shift1End", "shift2Start", "shift2End"].forEach((field) => {
+              if (day[field]) day[field] = "";
+            });
+          }
+        }
+
+        hasHourInconsistency.value = days.some((day) =>
+          ["shift1Start", "shift1End", "shift2Start", "shift2End"].some((field) => isInconsistent(day, field))
+        );
+      },
+      { deep: true, immediate: true }
+    );
 
     const excludedDates = ref([]);
     const showConfirm = ref(false);


### PR DESCRIPTION
## Summary
- clear all shift selections whenever a weekday is marked as inactive
- keep the hour inconsistency flag in sync after clearing inactive days

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dacdbde5e883309a1f0339b05df533