### PR TITLE
Ensure StatusID options lazy-load without breaking grid display

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -400,10 +400,12 @@
       const previousEntry = previousMetadata.get(rowId);
 
       if (previousEntry && previousEntry.hash === fingerprint) {
+        primeLazyStatusDisplayLabels(previousEntry.data);
         nextMetadata.set(rowId, previousEntry);
         nextRows.push(previousEntry.data);
       } else {
         const clonedRow = { ...rawRow };
+        primeLazyStatusDisplayLabels(clonedRow);
         const entry = { data: clonedRow, hash: fingerprint };
         nextMetadata.set(rowId, entry);
         nextRows.push(clonedRow);
@@ -459,6 +461,7 @@
       return;
     }
     const clonedRow = { ...matchedRow };
+    primeLazyStatusDisplayLabels(clonedRow);
 
     const nextMetadata = new Map(rowMetadata.value || []);
     const entry = { data: clonedRow, hash: fingerprint };
@@ -549,6 +552,160 @@
     return false;
   };
 
+  const shouldLazyLoadStatus = col => {
+    if (!col) return false;
+    const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+    const identifier = (col.FieldDB || '').toUpperCase();
+    return tag === 'STATUSID' || identifier === 'STATUSID';
+  };
+
+  const deriveStatusDisplayLabel = (row, col) => {
+    if (!row || typeof row !== 'object' || !col) return undefined;
+
+    const fieldKey = col.field || col.FieldDB || col.id;
+    if (!fieldKey) return undefined;
+
+    const labelField = `${fieldKey}__displayLabel`;
+    const existingLabel = row[labelField];
+    if (existingLabel != null && existingLabel !== '') {
+      return existingLabel;
+    }
+
+    const explicitKeys = [
+      col.DisplayField,
+      col.displayField,
+      col.display_field,
+      col.DisplayLabel,
+      col.displayLabel,
+      col.display_label,
+    ];
+
+    const baseVariants = [
+      `${fieldKey}Label`,
+      `${fieldKey}label`,
+      `${fieldKey}Name`,
+      `${fieldKey}name`,
+      `${fieldKey}Description`,
+      `${fieldKey}description`,
+      `${fieldKey}_Label`,
+      `${fieldKey}_label`,
+      `${fieldKey}_Name`,
+      `${fieldKey}_name`,
+      `${fieldKey}_Description`,
+      `${fieldKey}_description`,
+    ];
+
+    const statusFallbacks = [
+      'StatusName',
+      'statusName',
+      'Status',
+      'status',
+      'StatusDescription',
+      'statusDescription',
+      'StatusLabel',
+      'statusLabel',
+    ];
+
+    const candidateKeys = [...explicitKeys, ...baseVariants, ...statusFallbacks];
+    for (const key of candidateKeys) {
+      if (!key) continue;
+      const value = row[key];
+      if (value != null && value !== '') {
+        return value;
+      }
+    }
+
+    const nestedCandidates = [
+      row[fieldKey],
+      row.Status,
+      row.status,
+    ];
+
+    for (const candidate of nestedCandidates) {
+      if (!candidate || typeof candidate !== 'object') continue;
+      const nestedValue =
+        candidate.label ??
+        candidate.Label ??
+        candidate.name ??
+        candidate.Name ??
+        candidate.description ??
+        candidate.Description ??
+        candidate.value ??
+        candidate.Value ??
+        null;
+      if (nestedValue != null && nestedValue !== '') {
+        return nestedValue;
+      }
+    }
+
+    return undefined;
+  };
+
+  const primeLazyStatusDisplayLabels = row => {
+    if (!row || typeof row !== 'object') return;
+    if (!props.content || !Array.isArray(props.content.columns)) return;
+
+    props.content.columns.forEach(col => {
+      if (!shouldLazyLoadStatus(col)) return;
+      const fieldKey = col.field || col.FieldDB || col.id;
+      if (!fieldKey) return;
+
+      const labelField = `${fieldKey}__displayLabel`;
+      if (row[labelField] != null && row[labelField] !== '') return;
+
+      const label = deriveStatusDisplayLabel(row, col);
+      if (label != null && label !== '') {
+        row[labelField] = String(label);
+      }
+    });
+  };
+
+  const readStatusValueFromRow = (row, col) => {
+    if (!row || typeof row !== 'object' || !col) return undefined;
+    const fieldCandidates = [col.field, col.FieldDB, col.id];
+    for (const key of fieldCandidates) {
+      if (!key) continue;
+      const value = row[key];
+      if (value != null && value !== '') {
+        return value;
+      }
+    }
+    return undefined;
+  };
+
+  const buildLazyStatusFallbackOptions = col => {
+    if (!col) return [];
+
+    const fieldKey = col.field || col.FieldDB || col.id;
+    if (!fieldKey) return [];
+
+    const rows = Array.isArray(displayedRowData.value) ? displayedRowData.value : [];
+    const seen = new Map();
+
+    rows.forEach(row => {
+      if (!row || typeof row !== 'object') return;
+      const rawValue = readStatusValueFromRow(row, col);
+      if (rawValue == null || rawValue === '') return;
+
+      const labelField = `${fieldKey}__displayLabel`;
+      let label = row[labelField];
+      if (label == null || label === '') {
+        label = deriveStatusDisplayLabel(row, col);
+      }
+
+      const mapKey = String(rawValue);
+      if (seen.has(mapKey)) return;
+
+      const finalLabel = label != null && label !== '' ? label : rawValue;
+      seen.set(mapKey, {
+        value: rawValue,
+        label: String(finalLabel),
+      });
+    });
+
+    return Array.from(seen.values());
+  };
+
   const refreshRowListOptions = async (rowData, rowNode = null, editedColumn = null) => {
     if (!rowData || !props.content || !Array.isArray(props.content.columns)) return;
 
@@ -590,6 +747,10 @@
       }
 
       delete columnOptions.value[fieldKey][cacheKey];
+
+      if (shouldLazyLoadStatus(col)) {
+        return;
+      }
 
       const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
       const identifier = (col.FieldDB || '').toUpperCase();
@@ -1335,9 +1496,15 @@ const remountComponent = () => {
 
   let responsibleUserCache = null;
 
-  async function getColumnOptions(col, ticketId) {
+  async function getColumnOptions(col, ticketId, { force = false } = {}) {
     const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
     const identifier = (col.FieldDB || '').toUpperCase();
+    const lazyStatus = shouldLazyLoadStatus(col);
+
+    if (lazyStatus && !force) {
+      return [];
+    }
+
     if (tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') {
       if (!responsibleUserCache) {
         responsibleUserCache = await loadResponsibleUserOptions();
@@ -2049,6 +2216,7 @@ setTimeout(() => {
       columnOptions,
       refreshRowFromSource,
       refreshRowListOptions,
+      buildLazyStatusFallbackOptions,
       getRowMetadataHash,
       waitForRowHydration,
       getColumnOptions,
@@ -2204,12 +2372,16 @@ setTimeout(() => {
           };
           const fieldKey = colCopy.id || colCopy.field;
           const useTicket = this.usesTicketId(colCopy);
+          const lazyStatus = shouldLazyLoadStatus(colCopy);
           const getDsOptionsSync = params => {
             const ticketId = params.data?.TicketID;
             const key = this.getOptionsCacheKey(colCopy, ticketId);
             const colOpts = this.columnOptions[fieldKey] || {};
             const cached = colOpts[key];
             if (cached) return cached;
+            if (lazyStatus) {
+              return this.buildLazyStatusFallbackOptions(colCopy);
+            }
             if (tagControl === 'RESPONSIBLEUSERID') {
               this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
                 if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
@@ -2225,7 +2397,11 @@ setTimeout(() => {
             const colOpts = this.columnOptions[fieldKey] || {};
             const cached = colOpts[key];
             if (cached) return Promise.resolve(cached);
-            return this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
+            return this.getColumnOptions(
+              colCopy,
+              useTicket ? ticketId : undefined,
+              { force: lazyStatus }
+            ).then(opts => {
               if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
               this.columnOptions[fieldKey][key] = opts;
               params.api?.refreshCells?.({ columns: [fieldKey], force: true });
@@ -2342,12 +2518,16 @@ setTimeout(() => {
             {
               const fieldKey = colCopy.id || colCopy.field;
               const useTicket = this.usesTicketId(colCopy);
+              const lazyStatus = shouldLazyLoadStatus(colCopy);
               const getDsOptionsSync = params => {
                 const ticketId = params.data?.TicketID;
                 const key = this.getOptionsCacheKey(colCopy, ticketId);
                 const colOpts = this.columnOptions[fieldKey] || {};
                 const cached = colOpts[key];
                 if (cached) return cached;
+                if (lazyStatus) {
+                  return this.buildLazyStatusFallbackOptions(colCopy);
+                }
                 this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
                   if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
                   this.columnOptions[fieldKey][key] = opts;
@@ -2361,7 +2541,11 @@ setTimeout(() => {
                 const colOpts = this.columnOptions[fieldKey] || {};
                 const cached = colOpts[key];
                 if (cached) return Promise.resolve(cached);
-                return this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
+                return this.getColumnOptions(
+                  colCopy,
+                  useTicket ? ticketId : undefined,
+                  { force: lazyStatus }
+                ).then(opts => {
 
                   if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
                   this.columnOptions[fieldKey][key] = opts;
@@ -2638,12 +2822,16 @@ setTimeout(() => {
             }
             const fieldKey = colCopy.id || colCopy.field;
             const useTicket = this.usesTicketId(colCopy);
+            const lazyStatus = shouldLazyLoadStatus(colCopy);
             const getDsOptionsSync = params => {
               const ticketId = params.data?.TicketID;
               const key = this.getOptionsCacheKey(colCopy, ticketId);
               const colOpts = this.columnOptions[fieldKey] || {};
               const cached = colOpts[key];
               if (cached) return cached;
+              if (lazyStatus) {
+                return this.buildLazyStatusFallbackOptions(colCopy);
+              }
               this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
                 if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
                 this.columnOptions[fieldKey][key] = opts;
@@ -2657,7 +2845,11 @@ setTimeout(() => {
               const colOpts = this.columnOptions[fieldKey] || {};
               const cached = colOpts[key];
               if (cached) return Promise.resolve(cached);
-              return this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
+              return this.getColumnOptions(
+                colCopy,
+                useTicket ? ticketId : undefined,
+                { force: lazyStatus }
+              ).then(opts => {
 
                 if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
                 this.columnOptions[fieldKey][key] = opts;


### PR DESCRIPTION
## Summary
- derive display labels for StatusID rows from existing dataset fields before skipping remote option loads
- provide fallback list options from current grid data so renderers and filters keep working until edit-time fetches occur
- expose the fallback helper to column definitions to share the derived options when StatusID editors open

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dbbf87f14c8330a3a2a2f2f6956943