### PR TITLE
Add action to update grid rows from JSON

### DIFF
--- a/Project/GridViewDinamica/ww-config.js
+++ b/Project/GridViewDinamica/ww-config.js
@@ -179,6 +179,17 @@ export default {
       ]
     },
     {
+      action: 'updateRow',
+      label: { en: 'Update Row' },
+      args: [
+        {
+          name: 'row',
+          type: 'object',
+          label: { en: 'Row JSON' }
+        }
+      ]
+    },
+    {
       action: 'remountComponent',
       label: { en: 'Remount Component' },
       args: []


### PR DESCRIPTION
## Summary
- expose the internal row id resolver and add a new `updateRow` method that updates row nodes from a JSON payload
- register the `updateRow` component action so consumers can trigger row updates programmatically

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbde82ef848330865c6b1b700fa97d