### PR TITLE
Ensure grid filters request datasource options without ticket context

### DIFF
--- a/Project/GridViewDinamica/src/components/ListFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ListFilterRenderer.js
@@ -6,12 +6,23 @@ export default class ListFilterRenderer {
     this.filteredValues = [];
     this.selectAll = false;
     this.formattedValues = [];
+    this.rendererConfig = {};
   }
 
   init(params) {
     this.params = params;
-    this.loadValues();
-    this.createGui();
+    const maybePromise = this.loadValues();
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      maybePromise
+        .then(() => {
+          this.createGui();
+        })
+        .catch(() => {
+          this.createGui();
+        });
+    } else {
+      this.createGui();
+    }
   }
 
   createGui() {
@@ -98,40 +109,113 @@ export default class ListFilterRenderer {
     const api = this.params.api;
     const column = this.params.column;
     const colDef = column.getColDef();
-    const field = colDef.field || column.getColId();
 
     const tag = (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toString().toUpperCase();
     const identifier = (colDef.FieldDB || '').toString().toUpperCase();
     const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
     this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
 
-    const normalize = (opt) => {
-      if (typeof opt === 'object') {
-        const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
-        const labelKey = findKey('label') || findKey('name');
-        const valueKey = findKey('value') || findKey('id');
-        return {
-          ...opt,
-          value: valueKey ? opt[valueKey] : opt.value,
-          label: labelKey ? opt[labelKey] : opt.label || opt.name
-        };
+    this.rendererConfig = this.params.filterParams?.rendererConfig || {};
+
+    const optionsSource = this.resolveFilterOptions();
+
+    if (optionsSource && typeof optionsSource.then === 'function') {
+      return optionsSource
+        .then(options => {
+          const populated = this.populateFromExplicitOptions(options, colDef);
+          if (!populated) {
+            this.populateFromRows(api, column, colDef);
+          }
+        })
+        .catch(error => {
+          console.warn('[GridViewDinamica] Failed to load filter options from data source', error);
+          this.populateFromRows(api, column, colDef);
+        });
+    }
+
+    const populated = this.populateFromExplicitOptions(optionsSource, colDef);
+    if (!populated) {
+      this.populateFromRows(api, column, colDef);
+    }
+
+    return null;
+  }
+
+  resolveFilterOptions() {
+    const filterParams = this.params?.filterParams || {};
+    if (typeof filterParams.getFilterOptions === 'function') {
+      try {
+        return filterParams.getFilterOptions(this.params);
+      } catch (error) {
+        console.warn('[GridViewDinamica] Failed to resolve filter options from filterParams', error);
       }
-      return { value: opt, label: String(opt) };
-    };
+    }
+    if (Array.isArray(filterParams.options)) {
+      return filterParams.options;
+    }
+    return null;
+  }
+
+  populateFromExplicitOptions(optionsInput, colDef) {
+    const options = Array.isArray(optionsInput) ? optionsInput : [];
+    if (!options.length) {
+      this.allValues = [];
+      this.formattedValues = [];
+      this.filteredValues = [];
+      return false;
+    }
+
+    const normalized = options
+      .map(opt => this.normalizeOption(opt))
+      .filter(opt => opt && (opt.value !== undefined || opt.value === null));
+
+    if (!normalized.length) {
+      this.allValues = [];
+      this.formattedValues = [];
+      this.filteredValues = [];
+      return false;
+    }
+
+    const zipped = normalized.map(opt => {
+      const rawValue = opt.value;
+      const display = opt.label != null ? opt.label : opt.value;
+      const formatted = this.formatDisplayValue(this.ensureDisplayText(display), colDef);
+      return { raw: rawValue, formatted };
+    });
+
+    const uniqueMap = new Map();
+    zipped.forEach(item => {
+      const key = this.buildRawKey(item.raw);
+      if (!uniqueMap.has(key)) {
+        uniqueMap.set(key, item);
+      }
+    });
+
+    const unique = Array.from(uniqueMap.values());
+    unique.sort((a, b) => this.compareFormattedValues(a.formatted, b.formatted));
+
+    this.allValues = unique.map(item => item.raw);
+    this.formattedValues = unique.map(item => item.formatted);
+    this.filteredValues = [...this.allValues];
+    this.selectedValues = this.selectedValues.map(value => this.resolveRawValue(value));
+    return true;
+  }
+
+  populateFromRows(api, column, colDef) {
+    const field = colDef.field || column.getColId();
 
     this.allValues = [];
     this.formattedValues = [];
+
     api.forEachNode(node => {
       if (!node.data) return;
       const rawValue = this.getNestedValue(node.data, field);
       if (rawValue === undefined || rawValue === null) return;
 
-      // Resolve renderer params (pode ser função)
       const rendererParams = typeof colDef.cellRendererParams === 'function'
         ? colDef.cellRendererParams({ data: node.data, value: rawValue, colDef })
         : colDef.cellRendererParams || {};
 
-      // Obtém opções para mapear valor -> label
       let optionsArr = [];
       if (Array.isArray(rendererParams.options)) {
         optionsArr = rendererParams.options;
@@ -145,11 +229,11 @@ export default class ListFilterRenderer {
         optionsArr = colDef.dataSource.list_options.split(',').map(o => o.trim());
       }
 
-      const options = (optionsArr || []).map(normalize);
+      const options = (optionsArr || []).map(opt => this.normalizeOption(opt));
       const match = options.find(o => o.value == rawValue);
-      const display = match ? (match.label != null ? match.label : match.value) : rawValue;
+      const baseDisplay = match ? (match.label != null ? match.label : match.value) : rawValue;
+      const display = this.ensureDisplayText(baseDisplay);
 
-      // Aplica formatter ou style array conforme editor
       let formatted = display;
       try {
         if (this.isCategoryField) {
@@ -181,34 +265,172 @@ export default class ListFilterRenderer {
       this.allValues.push(rawValue);
       this.formattedValues.push(formatted);
     });
-    // Remover duplicatas mantendo o mapeamento
-    const seen = new Set();
-    const uniqueRaw = [];
-    const uniqueFormatted = [];
+
+    const seen = new Map();
+    const unique = [];
     this.allValues.forEach((raw, idx) => {
-      if (!seen.has(raw)) {
-        seen.add(raw);
-        uniqueRaw.push(raw);
-        uniqueFormatted.push(this.formattedValues[idx]);
+      const key = this.buildRawKey(raw);
+      if (!seen.has(key)) {
+        seen.set(key, true);
+        unique.push({ raw, formatted: this.formattedValues[idx] });
       }
     });
-    // Função utilitária para extrair texto puro de HTML
-    function stripHtml(html) {
-      const tmp = document.createElement('div');
-      tmp.innerHTML = html;
-      return tmp.textContent || tmp.innerText || '';
-    }
-    // Ordena os valores alfabeticamente pelo texto visível formatado
-    const zipped = uniqueRaw.map((raw, idx) => ({ raw, formatted: uniqueFormatted[idx] }));
-    zipped.sort((a, b) => {
-      const textA = stripHtml(String(a.formatted)).toLowerCase();
-      const textB = stripHtml(String(b.formatted)).toLowerCase();
-      return textA.localeCompare(textB, undefined, { sensitivity: 'base' });
-    });
-    this.allValues = zipped.map(z => z.raw);
-    this.formattedValues = zipped.map(z => z.formatted);
+
+    unique.sort((a, b) => this.compareFormattedValues(a.formatted, b.formatted));
+
+    this.allValues = unique.map(item => item.raw);
+    this.formattedValues = unique.map(item => item.formatted);
     this.filteredValues = [...this.allValues];
     this.selectedValues = this.selectedValues.map(value => this.resolveRawValue(value));
+  }
+
+  normalizeOption(opt) {
+    if (opt === undefined) return null;
+    if (opt === null) return { value: null, label: '' };
+
+    if (typeof opt === 'object') {
+      const lowerKeyMap = Object.keys(opt).reduce((acc, key) => {
+        acc[key.toLowerCase()] = key;
+        return acc;
+      }, {});
+
+      const findKey = candidates => {
+        for (const candidate of candidates) {
+          const actual = lowerKeyMap[candidate];
+          if (actual) return actual;
+        }
+        return null;
+      };
+
+      const valueKey = findKey([
+        'value',
+        'id',
+        'key',
+        'valor',
+        'codigo',
+        'code',
+        'statusid',
+        'userid',
+      ]);
+
+      const labelKey = findKey([
+        'label',
+        'name',
+        'displayname',
+        'descricao',
+        'description',
+        'text',
+        'valor',
+        'title',
+      ]);
+
+      const rawValue = valueKey != null ? opt[valueKey] : undefined;
+      const labelSource = labelKey != null ? opt[labelKey] : undefined;
+
+      let finalValue = rawValue;
+      if (finalValue === undefined) {
+        if (labelSource !== undefined) {
+          finalValue = labelSource;
+        } else if (Array.isArray(opt.options) && opt.options.length === 1) {
+          finalValue = opt.options[0];
+        } else if (valueKey == null && labelKey == null) {
+          const firstKey = Object.keys(opt)[0];
+          if (firstKey) {
+            finalValue = opt[firstKey];
+          }
+        }
+      }
+
+      let finalLabel = labelSource;
+      if (finalLabel === undefined) {
+        finalLabel = finalValue;
+      }
+
+      let normalizedValue = finalValue !== undefined ? finalValue : '';
+      if (typeof normalizedValue === 'object') {
+        normalizedValue = this.ensureDisplayText(normalizedValue);
+      }
+
+      let normalizedLabel = finalLabel != null ? finalLabel : normalizedValue;
+      if (typeof normalizedLabel === 'object') {
+        normalizedLabel = this.ensureDisplayText(normalizedLabel);
+      }
+
+      return {
+        value: normalizedValue,
+        label: normalizedLabel,
+      };
+    }
+
+    return { value: opt, label: opt == null ? '' : String(opt) };
+  }
+
+  formatDisplayValue(display, colDef) {
+    let formatted = this.ensureDisplayText(display);
+    try {
+      if (this.isCategoryField) {
+        formatted = `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${display}</span>`;
+      } else if (this.rendererConfig.useCustomFormatter && typeof this.rendererConfig.formatter === 'string') {
+        const formatterFn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          this.rendererConfig.formatter
+        );
+        formatted = formatterFn(
+          display,
+          {},
+          colDef,
+          this.getRoundedSpanColor,
+          this.dateFormatter
+        );
+      } else if (this.rendererConfig.useStyleArray && Array.isArray(this.rendererConfig.styleArray)) {
+        const styled = this.getRoundedSpanColor(display, this.rendererConfig.styleArray, colDef.FieldDB);
+        if (styled) formatted = styled;
+      }
+    } catch (e) {
+      // se der erro, mantém valor calculado
+    }
+    return formatted;
+  }
+
+  buildRawKey(raw) {
+    if (raw === null) return 'raw:null';
+    if (raw === undefined) return 'raw:undefined';
+    if (typeof raw === 'object') {
+      try {
+        return `raw:object:${JSON.stringify(raw)}`;
+      } catch (error) {
+        return `raw:object:${String(raw)}`;
+      }
+    }
+    return `raw:${typeof raw}:${String(raw)}`;
+  }
+
+  compareFormattedValues(a, b) {
+    const textA = this.stripHtml(String(a)).toLowerCase();
+    const textB = this.stripHtml(String(b)).toLowerCase();
+    return textA.localeCompare(textB, undefined, { sensitivity: 'base' });
+  }
+
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  ensureDisplayText(value) {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    if (value instanceof Date) return this.dateFormatter(value);
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      return String(value);
+    }
   }
 
   filterValues() {
@@ -290,10 +512,11 @@ export default class ListFilterRenderer {
       const formattedValue = this.formattedValues[idx] || rawValue;
       const checked = this.selectedValues.includes(rawValue) ? 'checked' : '';
       const itemClass = this.selectedValues.includes(rawValue) ? ' selected' : '';
+      const title = this.stripHtml(this.ensureDisplayText(formattedValue)).replace(/"/g, '&quot;');
       return `
         <label class="filter-item${itemClass}">
           <input type="checkbox" value="${idx}" data-raw-index="${idx}" ${checked} />
-          <span class="filter-label" title="">${formattedValue}</span>
+          <span class="filter-label" title="${title}">${formattedValue}</span>
         </label>
       `;
     }).join('');
@@ -366,7 +589,17 @@ export default class ListFilterRenderer {
   }
 
   onNewRowsLoaded() {
-    this.loadValues();
-    this.filterValues();
+    const maybePromise = this.loadValues();
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      maybePromise
+        .then(() => {
+          this.filterValues();
+        })
+        .catch(() => {
+          this.filterValues();
+        });
+    } else {
+      this.filterValues();
+    }
   }
-} 
+}

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1575,14 +1575,19 @@ const remountComponent = () => {
       const ds = col.dataSource?.dataSource || col.dataSource;
       if (!apiUrl || !ds?.functionName) return [];
 
+      const payload = {
+        ...(companyId ? { p_idcompany: companyId } : {}),
+        ...(lang ? { p_language: lang } : {}),
+      };
+
+      if (ticketId !== undefined) {
+        payload.p_ticketid = ticketId;
+      }
+
       const fetchOptions = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          ...(companyId ? { p_idcompany: companyId } : {}),
-          ...(lang ? { p_language: lang } : {}),
-          ...(ticketId ? { p_ticketid: ticketId } : {})
-        })
+        body: JSON.stringify(payload)
       };
       if (apiKey) fetchOptions.headers['apikey'] = apiKey;
       if (apiAuth) fetchOptions.headers['Authorization'] = apiAuth;
@@ -1673,27 +1678,81 @@ const remountComponent = () => {
 
   const loadAllColumnOptions = async () => {
     if (!props.content || !Array.isArray(props.content.columns)) return;
+
     const rows = wwLib.wwUtils.getDataFromCollection(props.content.rowData) || [];
     const result = {};
-    const promises = [];
+    const tasks = [];
+
     for (const col of props.content.columns) {
-      const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
-      const identifier = (col.FieldDB || '').toUpperCase();
-      const isResponsible = tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
-      if (!isResponsible) continue;
+      if (!isListLikeColumn(col)) continue;
+
       const colId = col.id || col.field;
-      result[colId] = {};
-      for (const row of rows) {
-        const ticketId = row?.TicketID;
-        const cacheKey = getOptionsCacheKey(col, ticketId);
-        if (result[colId][cacheKey]) continue;
-        const p = getColumnOptions(col, usesTicketId(col) ? ticketId : undefined).then(opts => {
-          result[colId][cacheKey] = opts;
+      if (!colId) continue;
+
+      const usesTicket = usesTicketId(col);
+      const lazyStatus = shouldLazyLoadStatus(col);
+      const forceOptions = lazyStatus ? { force: true } : undefined;
+
+      if (!result[colId]) {
+        result[colId] = {};
+      }
+
+      const seenKeys = new Set();
+
+      if (usesTicket) {
+        rows.forEach(row => {
+          const ticketId = row?.TicketID;
+          const cacheKey = getOptionsCacheKey(col, ticketId);
+          if (seenKeys.has(cacheKey)) return;
+          seenKeys.add(cacheKey);
+          const promise = getColumnOptions(
+            col,
+            ticketId,
+            forceOptions
+          ).then(opts => {
+            result[colId][cacheKey] = opts;
+          }).catch(() => {
+            result[colId][cacheKey] = [];
+          });
+          tasks.push(promise);
         });
-        promises.push(p);
+
+        const globalCacheKey = getOptionsCacheKey(col, null);
+        if (!seenKeys.has(globalCacheKey)) {
+          seenKeys.add(globalCacheKey);
+          const promise = getColumnOptions(
+            col,
+            null,
+            forceOptions
+          ).then(opts => {
+            result[colId][globalCacheKey] = opts;
+          }).catch(() => {
+            result[colId][globalCacheKey] = [];
+          });
+          tasks.push(promise);
+        }
+      } else {
+        const cacheKey = getOptionsCacheKey(col, undefined);
+        if (!seenKeys.has(cacheKey)) {
+          seenKeys.add(cacheKey);
+          const promise = getColumnOptions(
+            col,
+            undefined,
+            forceOptions
+          ).then(opts => {
+            result[colId][cacheKey] = opts;
+          }).catch(() => {
+            result[colId][cacheKey] = [];
+          });
+          tasks.push(promise);
+        }
       }
     }
-    await Promise.all(promises);
+
+    if (tasks.length) {
+      await Promise.allSettled(tasks);
+    }
+
     columnOptions.value = result;
   };
 
@@ -2511,6 +2570,17 @@ setTimeout(() => {
         // Se o filtro for agListColumnFilter, usar o filtro customizado
         if (colCopy.filter === 'agListColumnFilter') {
           const isResponsible = tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+          const baseFilterParams = typeof colCopy.filterParams === 'object' && colCopy.filterParams
+            ? colCopy.filterParams
+            : {};
+          const filterRendererConfig = {
+            ...(baseFilterParams.rendererConfig || {}),
+            useCustomFormatter: !!colCopy.useCustomFormatter,
+            formatter: colCopy.formatter,
+            useStyleArray: !!colCopy.useStyleArray,
+            styleArray: colCopy.useStyleArray ? this.content.cellStyleArray : baseFilterParams.rendererConfig?.styleArray,
+          };
+
           const result = {
             ...commonProperties,
             id: colId,
@@ -2524,6 +2594,11 @@ setTimeout(() => {
               useCustomFormatter: colCopy.useCustomFormatter,
               formatter: colCopy.formatter,
               // options will be added below when available
+            },
+            filterParams: {
+              ...baseFilterParams,
+              rendererConfig: filterRendererConfig,
+              getFilterOptions: () => this.getFilterOptionsForColumn(colCopy),
             }
           };
           const fieldKey = colCopy.id || colCopy.field;
@@ -2740,6 +2815,17 @@ setTimeout(() => {
                 : null;
 
               const isResponsible = tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+              const baseFilterParams = typeof colCopy.filterParams === 'object' && colCopy.filterParams
+                ? colCopy.filterParams
+                : {};
+              const filterRendererConfig = {
+                ...(baseFilterParams.rendererConfig || {}),
+                useCustomFormatter: !!colCopy.useCustomFormatter,
+                formatter: colCopy.formatter,
+                useStyleArray: !!colCopy.useStyleArray,
+                styleArray: colCopy.useStyleArray ? this.content.cellStyleArray : baseFilterParams.rendererConfig?.styleArray,
+              };
+
               const result = {
                 ...commonProperties,
                 id: colId,
@@ -2755,6 +2841,11 @@ setTimeout(() => {
                 },
                 editable: false,
                 cellEditor: staticOptions && staticOptions.length ? ListCellEditor : (tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor),
+                filterParams: {
+                  ...baseFilterParams,
+                  rendererConfig: filterRendererConfig,
+                  getFilterOptions: () => this.getFilterOptionsForColumn(colCopy),
+                },
               };
               if (staticOptions && staticOptions.length) {
                 result.options = staticOptions;
@@ -2820,6 +2911,21 @@ setTimeout(() => {
               result.filter = (tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID')
                 ? ResponsibleUserFilterRenderer
                 : ListFilterRenderer;
+              const baseFilterParams = typeof colCopy.filterParams === 'object' && colCopy.filterParams
+                ? colCopy.filterParams
+                : {};
+              const filterRendererConfig = {
+                ...(baseFilterParams.rendererConfig || {}),
+                useCustomFormatter: !!colCopy.useCustomFormatter,
+                formatter: colCopy.formatter,
+                useStyleArray: !!colCopy.useStyleArray,
+                styleArray: colCopy.useStyleArray ? this.content.cellStyleArray : baseFilterParams.rendererConfig?.styleArray,
+              };
+              result.filterParams = {
+                ...baseFilterParams,
+                rendererConfig: filterRendererConfig,
+                getFilterOptions: () => this.getFilterOptionsForColumn(colCopy),
+              };
             }
             // Apply custom formatter if enabled
             if (colCopy.useCustomFormatter) {
@@ -3200,6 +3306,127 @@ setTimeout(() => {
   },
   },
   methods: {
+  async getFilterOptionsForColumn(col) {
+    if (!col) return [];
+
+    const fieldKey = col.id || col.field;
+    if (!fieldKey) return [];
+
+    const lazyStatus = this.shouldLazyLoadStatus(col);
+    const usesTicket = this.usesTicketId(col);
+
+    const ensureColStore = () => {
+      if (!this.columnOptions) {
+        this.columnOptions = {};
+      }
+      if (!this.columnOptions[fieldKey]) {
+        this.columnOptions[fieldKey] = {};
+      }
+      const colStore = this.columnOptions[fieldKey];
+      if (!colStore.__fetchedKeys) {
+        Object.defineProperty(colStore, '__fetchedKeys', {
+          value: new Set(),
+          enumerable: false,
+          configurable: true,
+          writable: true,
+        });
+      }
+      return colStore;
+    };
+
+    const store = ensureColStore();
+    const aggregated = [];
+    const seen = new Set();
+
+    const pushOption = option => {
+      if (option === undefined) return;
+      let mapKey;
+      if (option === null) {
+        mapKey = 'null-option';
+      } else if (typeof option === 'object') {
+        const valueKey =
+          option.value ??
+          option.Value ??
+          option.id ??
+          option.Id ??
+          option.ID ??
+          option.UserID ??
+          option.UserId ??
+          option.StatusID ??
+          option.statusId ??
+          option.key ??
+          null;
+        const typeKey = option.type || (Array.isArray(option.groupUsers) ? 'group' : 'object');
+        if (valueKey != null) {
+          mapKey = `${typeKey}::${String(valueKey)}`;
+        } else {
+          try {
+            mapKey = `${typeKey}::${JSON.stringify(option)}`;
+          } catch (error) {
+            mapKey = `${typeKey}::${Date.now()}::${aggregated.length}`;
+          }
+        }
+      } else {
+        mapKey = `primitive::${String(option)}`;
+      }
+
+      if (!seen.has(mapKey)) {
+        seen.add(mapKey);
+        aggregated.push(option);
+      }
+    };
+
+    const hydrateOptionsForTicket = async ticketId => {
+      const requestTicketId = usesTicket ? null : ticketId;
+      const cacheKey = this.getOptionsCacheKey(col, requestTicketId);
+      let options = store[cacheKey];
+      const fetchedKeys = store.__fetchedKeys;
+      const hasFetchedBefore = fetchedKeys?.has(cacheKey);
+
+      if (!Array.isArray(options) || (!options.length && !hasFetchedBefore)) {
+        try {
+          options = await this.getColumnOptions(col, requestTicketId, { force: true });
+        } catch (error) {
+          console.warn('[GridViewDinamica] Failed to load filter options from data source', error);
+          options = [];
+        }
+        store[cacheKey] = Array.isArray(options) ? options : [];
+        if (store.__fetchedKeys) {
+          if (store[cacheKey].length) {
+            store.__fetchedKeys.delete(cacheKey);
+          } else {
+            store.__fetchedKeys.add(cacheKey);
+          }
+        }
+      }
+
+      const list = store[cacheKey];
+      if (Array.isArray(list)) {
+        list.forEach(pushOption);
+      }
+    };
+
+    const ticketsToFetch = usesTicket ? [null] : [undefined];
+
+    const tasks = ticketsToFetch.map(ticketId => hydrateOptionsForTicket(ticketId));
+    if (tasks.length) {
+      await Promise.allSettled(tasks);
+    }
+
+    Object.entries(store).forEach(([cacheKey, list]) => {
+      if (cacheKey === '__fetchedKeys') return;
+      if (Array.isArray(list)) {
+        list.forEach(pushOption);
+      }
+    });
+
+    if (!aggregated.length && lazyStatus) {
+      const fallback = this.buildLazyStatusFallbackOptions(col);
+      return Array.isArray(fallback) ? fallback : [];
+    }
+
+    return aggregated;
+  },
   deselectAllRows() {
     if (this.gridApi) {
       this.gridApi.deselectAll();


### PR DESCRIPTION
## Summary
- always include p_ticketid in datasource payloads when provided, allowing filters to request global options with a null ticket id
- preload ticket-aware column caches with both per-ticket and global option sets so list, status, and responsible filters hydrate from datasource results
- aggregate filter options from the datasource using a null ticket context while preserving any cached per-ticket values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc1d6c5a048330b46e782167837656