### PR TITLE
Match FormBuilder fields to FormRender visuals

### DIFF
--- a/Project/FormBuilder/Component/components/CustomDatePicker.vue
+++ b/Project/FormBuilder/Component/components/CustomDatePicker.vue
@@ -1,0 +1,429 @@
+<template>
+  <div class="dp-wrapper" ref="dpWrapper">
+    <input
+      ref="dpInput"
+      :class="['dp-input', { error }]"
+      type="text"
+      :value="displayDate"
+      readonly
+      :disabled="disabled"
+      @pointerdown.stop.prevent="!disabled && openDp()"
+      @mousedown.stop.prevent="!disabled && openDp()"
+      @click.stop.prevent="!disabled && openDp()"
+      @focus="!disabled && openDp()"
+      aria-haspopup="dialog"
+      :aria-expanded="dpOpen ? 'true' : 'false'"
+    />
+    <button
+      v-if="!disabled"
+      type="button"
+      class="dp-icon"
+      @pointerdown.stop.prevent="openDp()"
+      @mousedown.stop.prevent="openDp()"
+      @click.stop.prevent="openDp()"
+    >
+      <span class="material-symbols-outlined">calendar_month</span>
+    </button>
+    <div v-if="dpOpen" class="datepicker-pop" :style="dpPopStyle" ref="dpPop">
+      <div class="dp-header">
+        <button type="button" class="dp-nav" @click="prevMonth">&lt;</button>
+        <div class="dp-title">{{ monthLabel }}</div>
+        <button type="button" class="dp-nav" @click="nextMonth">&gt;</button>
+      </div>
+      <div class="dp-weekdays">
+        <div class="dp-weekday" v-for="d in weekdayAbbrs" :key="d">{{ d }}</div>
+      </div>
+      <div class="dp-grid">
+        <button
+          v-for="d in gridDays"
+          :key="d.dateStr"
+          type="button"
+          class="dp-cell"
+          :class="{ 'is-muted': !d.inMonth, 'is-selected': d.isSelected, 'is-today': d.isToday }"
+          @click="selectDay(d)"
+        >
+          {{ d.label }}
+        </button>
+      </div>
+      <div v-if="showTime" class="dp-time">
+        <input type="time" v-model="timePart" @input="onTimeInput" />
+      </div>
+      <div class="dp-actions">
+        <button type="button" class="dp-action" @click="pickToday">{{ labelToday }}</button>
+        <button type="button" class="dp-action" @click="clearDate">{{ labelClear }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+
+export default {
+  name: 'CustomDatePicker',
+  props: {
+    modelValue: { type: String, default: '' },
+    disabled: { type: Boolean, default: false },
+    showTime: { type: Boolean, default: false },
+    error: { type: Boolean, default: false },
+    openUpOffset: { type: Number, default: 0 }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const translateText = (t) => t;
+    const ww = window.wwLib?.wwVariable;
+    const lang = ww?.getValue('aa44dc4c-476b-45e9-a094-16687e063342') || navigator.language;
+    const formatStyleRaw = ww?.getValue('21a41590-e7d8-46a5-af76-bb3542da1df3') || 'european';
+    const formatStyle = String(formatStyleRaw).toLowerCase() === 'american' ? 'american' : 'european';
+
+    const isPt = computed(() => String(lang || '').toLowerCase().startsWith('pt'));
+    const PT_MONTHS = [
+      'janeiro','fevereiro','março','abril','maio','junho',
+      'julho','agosto','setembro','outubro','novembro','dezembro'
+    ];
+    const labelToday = computed(() => (isPt.value ? 'Hoje' : translateText('Today')));
+    const labelClear = computed(() => (isPt.value ? 'Limpar' : translateText('Clear')));
+
+    function toYMD(date) {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, '0');
+      const d = String(date.getDate()).padStart(2, '0');
+      return `${y}-${m}-${d}`;
+    }
+    function parseYMD(ymd) {
+      if (!ymd) return null;
+      const [y,m,d] = ymd.split('-').map(Number);
+      if (!y || !m || !d) return null;
+      return new Date(y, m - 1, d);
+    }
+    function formatDateByStyle(yyyyMmDd, style = formatStyle) {
+      if (!yyyyMmDd) return '';
+      const [y,m,d] = yyyyMmDd.split('-').map(Number);
+      const DD = String(d).padStart(2,'0');
+      const MM = String(m).padStart(2,'0');
+      const YYYY = String(y);
+      return style === 'american' ? `${MM}/${DD}/${YYYY}` : `${DD}/${MM}/${YYYY}`;
+    }
+    function sameYMD(a,b){ return a && b && toYMD(a) === toYMD(b); }
+
+    const dpWrapper = ref(null);
+    const dpInput = ref(null);
+    const dpOpen = ref(false);
+    const dpPopStyle = ref({});
+    const dpPop = ref(null);
+    const POPUP_Z_INDEX = 2147483647;
+    const selectedDate = ref('');
+    const timePart = ref('00:00');
+
+    watch(
+      () => props.modelValue,
+      v => {
+        if (props.showTime) {
+          const [d, t] = (v || '').split('T');
+          selectedDate.value = d || '';
+          timePart.value = t ? t.slice(0,5) : '00:00';
+        } else {
+          selectedDate.value = v || '';
+        }
+      },
+      { immediate: true }
+    );
+
+    const dpMonth = ref(0);
+    const dpYear = ref(0);
+    const weekStart = computed(() => (formatStyle === 'american' ? 0 : 1));
+
+    const weekdayAbbrs = computed(() => {
+      if (isPt.value) {
+        const base = ['dom','seg','ter','qua','qui','sex','sáb'];
+        return weekStart.value === 1 ? base.slice(1).concat(base.slice(0,1)) : base;
+      }
+      try {
+        const base = Array.from({ length: 7 }, (_, i) =>
+          new Intl.DateTimeFormat(lang, { weekday: 'short' }).format(
+            new Date(Date.UTC(2021,7,1+i))
+          )
+        );
+        return weekStart.value === 1 ? base.slice(1).concat(base.slice(0,1)) : base;
+      } catch {
+        const en = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+        return weekStart.value === 1 ? en.slice(1).concat(en.slice(0,1)) : en;
+      }
+    });
+
+    const monthLabel = computed(() => {
+      if (isPt.value) return `${PT_MONTHS[dpMonth.value]} ${dpYear.value}`;
+      try {
+        return new Intl.DateTimeFormat(lang, { month: 'long', year: 'numeric' }).format(new Date(dpYear.value, dpMonth.value, 1));
+      } catch {
+        const EN_MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+        return `${EN_MONTHS[dpMonth.value]} ${dpYear.value}`;
+      }
+    });
+
+    function makeCell(date, inMonth){
+      const label = date.getDate();
+      const today = new Date();
+      const selected = parseYMD(selectedDate.value);
+      return {
+        label,
+        dateStr: toYMD(date),
+        inMonth,
+        isToday: sameYMD(date,today),
+        isSelected: selected && sameYMD(date, selected)
+      };
+    }
+
+    const gridDays = computed(() => {
+      const first = new Date(dpYear.value, dpMonth.value, 1);
+      const startWeekday = first.getDay();
+      const lead = (startWeekday - weekStart.value + 7) % 7;
+      const daysInCur = new Date(dpYear.value, dpMonth.value + 1, 0).getDate();
+      const prevYear = dpMonth.value === 0 ? dpYear.value - 1 : dpYear.value;
+      const prevMonth = dpMonth.value === 0 ? 11 : dpMonth.value - 1;
+      const daysInPrev = new Date(prevYear, prevMonth + 1, 0).getDate();
+      const cells = [];
+      for (let i = daysInPrev - lead + 1; i <= daysInPrev; i++) {
+        cells.push(makeCell(new Date(prevYear, prevMonth, i), false));
+      }
+      for (let i = 1; i <= daysInCur; i++) {
+        cells.push(makeCell(new Date(dpYear.value, dpMonth.value, i), true));
+      }
+      const tail = 42 - cells.length;
+      const nextYear = dpMonth.value === 11 ? dpYear.value + 1 : dpYear.value;
+      const nextMonth = dpMonth.value === 11 ? 0 : dpMonth.value + 1;
+      for (let i = 1; i <= tail; i++) {
+        cells.push(makeCell(new Date(nextYear, nextMonth, i), false));
+      }
+      return cells;
+    });
+
+    function emitValue(){
+      if(!selectedDate.value){
+        emit('update:modelValue', '');
+        return;
+      }
+      const val = props.showTime ? `${selectedDate.value}T${timePart.value}` : selectedDate.value;
+      emit('update:modelValue', val);
+    }
+
+    function updatePopoverPosition() {
+      const wrap = dpWrapper.value;
+      const pop = dpPop.value;
+      if (!wrap || !pop) return;
+
+      const rect = wrap.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      const viewportWidth = window.innerWidth;
+      const desiredMinWidth = Math.max(rect.width, 230);
+      const popRect = pop.getBoundingClientRect();
+      const popHeight = popRect.height;
+      let left = Math.round(rect.left);
+
+      if (left + desiredMinWidth > viewportWidth) {
+        left = Math.max(0, Math.round(viewportWidth - desiredMinWidth - 4));
+      }
+
+      const spaceAbove = rect.top;
+      const spaceBelow = viewportHeight - rect.bottom;
+      let openUp;
+
+      if (spaceBelow >= popHeight) {
+        openUp = false;
+      } else if (spaceAbove >= popHeight) {
+        openUp = true;
+      } else {
+        openUp = spaceAbove > spaceBelow;
+      }
+
+      const gap = 4;
+      const offset = typeof props.openUpOffset === 'number' ? props.openUpOffset : 0;
+      const style = {
+        position: 'fixed',
+        left: `${left}px`,
+        minWidth: `${desiredMinWidth}px`,
+        zIndex: POPUP_Z_INDEX,
+        top: 'auto',
+        bottom: 'auto'
+      };
+
+      if (openUp) {
+        const bottomValue = viewportHeight - rect.top + gap - offset;
+        style.bottom = `${Math.max(0, Math.round(bottomValue))}px`;
+      } else {
+        style.top = `${Math.round(rect.bottom + gap)}px`;
+      }
+
+      dpPopStyle.value = style;
+    }
+
+    function openDp(){
+      const base = parseYMD(selectedDate.value) || new Date();
+      dpMonth.value = base.getMonth();
+      dpYear.value = base.getFullYear();
+      if(props.showTime && !selectedDate.value){
+        const pad = n => String(n).padStart(2,'0');
+        timePart.value = `${pad(base.getHours())}:${pad(base.getMinutes())}`;
+      }
+      dpOpen.value = true;
+      nextTick(() => {
+        updatePopoverPosition();
+        try { dpInput.value && dpInput.value.focus(); } catch(e){}
+        window.addEventListener('scroll', updatePopoverPosition, true);
+        window.addEventListener('resize', updatePopoverPosition, true);
+      });
+    }
+    function closeDp(){
+      dpOpen.value = false;
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      window.removeEventListener('resize', updatePopoverPosition, true);
+    }
+    function prevMonth(){ dpMonth.value = dpMonth.value === 0 ? 11 : dpMonth.value - 1; if (dpMonth.value === 11) dpYear.value--; nextTick(updatePopoverPosition); }
+    function nextMonth(){ dpMonth.value = dpMonth.value === 11 ? 0 : dpMonth.value + 1; if (dpMonth.value === 0) dpYear.value++; nextTick(updatePopoverPosition); }
+    function selectDay(d){
+      if(!d.inMonth) return;
+      selectedDate.value = d.dateStr;
+      emitValue();
+      if(!props.showTime) closeDp();
+    }
+    function pickToday(){
+      const now = new Date();
+      selectedDate.value = toYMD(now);
+      if(props.showTime){
+        const pad = n => String(n).padStart(2,'0');
+        timePart.value = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+      }
+      emitValue();
+      closeDp();
+    }
+    function clearDate(){
+      selectedDate.value = '';
+      if(props.showTime) timePart.value = '00:00';
+      emit('update:modelValue', '');
+      closeDp();
+    }
+
+    function onTimeInput(e){
+      timePart.value = e.target.value;
+      emitValue();
+    }
+
+    function onDocClick(e){
+      if(!dpOpen.value) return;
+      const inside = dpWrapper.value && dpWrapper.value.contains(e.target);
+      if(!inside) closeDp();
+    }
+    onMounted(() => document.addEventListener('click', onDocClick, true));
+    onBeforeUnmount(() => {
+      document.removeEventListener('click', onDocClick, true);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      window.removeEventListener('resize', updatePopoverPosition, true);
+    });
+
+    const displayDate = computed(() => {
+      if (!selectedDate.value) return '';
+      const base = formatDateByStyle(selectedDate.value, formatStyle);
+      return props.showTime ? `${base} ${timePart.value}` : base;
+    });
+
+    return {
+      dpWrapper,
+      dpInput,
+      dpOpen,
+      dpPopStyle,
+      dpPop,
+      openDp,
+      prevMonth,
+      nextMonth,
+      selectDay,
+      pickToday,
+      clearDate,
+      weekdayAbbrs,
+      monthLabel,
+      gridDays,
+      displayDate,
+      labelToday,
+      labelClear,
+      timePart,
+      onTimeInput,
+      showTime: props.showTime,
+      disabled: props.disabled,
+      error: props.error
+    };
+  }
+};
+</script>
+
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400&display=swap');
+
+.dp-wrapper {
+  position: relative;
+  width: 100%;
+  font-family: 'Roboto', sans-serif;
+  font-size: 14px;
+}
+
+.dp-input {
+  display: block;
+  width: 100%;
+  padding-left: 5px;
+  padding-right: 30px;
+  height: 35px;
+  cursor: pointer;
+  font-family: 'Roboto', sans-serif;
+  font-size: 13px;
+  border: 1px solid #ccc; /* borda fina e cinza escura */
+  border-radius: 4px;
+}
+
+.dp-input.error {
+  border-color: #ff0000;
+  box-shadow: 0 0 0 1px #ff0000;
+}
+
+.dp-icon {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: #ddd; /* ícone cinza escuro */
+}
+
+.dp-icon:hover {
+  color: #ccc; /* um tom mais escuro ao passar o mouse */
+}
+
+
+.datepicker-pop {
+  position: fixed;
+  background: #fff;
+  border: 1px solid #acacad;
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+  padding: 6px;
+  z-index: 2147483647;
+}
+.dp-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; margin-bottom: 4px; }
+.dp-title { font-weight: 500; text-transform: capitalize; }
+.dp-nav { border: 1px solid #ccc; background: #f7f7f7; border-radius: 6px; padding: 2px 8px; cursor: pointer; }
+.dp-weekdays, .dp-grid { display: grid; grid-template-columns: repeat(7,1fr); gap: 2px; }
+.dp-weekday { text-align: center; font-size: 12px; color: #666; padding: 3px 0; }
+.dp-cell { border: 0; background: transparent; border-radius: 6px; padding: 5px 0; cursor: pointer; align-items:center; text-align: center; justify-content: center;}
+.dp-cell:hover { background: #f0f0f0; }
+.dp-cell.is-muted { color: #aaa; cursor: default; }
+.dp-cell.is-selected { background: #689d8c; color: #fff; }
+.dp-cell.is-today { outline: 1px dashed #689d8c; }
+.dp-actions { display: flex; justify-content: space-between; margin-top: 6px; }
+.dp-action { border: 1px solid #ccc; background: #f7f7f7; border-radius: 6px; padding: 4px 8px; cursor: pointer; }
+</style>

--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -1,121 +1,246 @@
 <template>
-  <div class="field-component" :class="[`field-type-${field.fieldType.toLowerCase()}`, { 'is-mandatory': field.is_mandatory }]">
-    <!-- Label do campo -->
-    <label v-if="!field.is_hide_legend" class="field-label"> 
+  <div
+    class="field-component"
+    :class="[`field-type-${(field.fieldType || '').toLowerCase()}`, { 'is-mandatory': field.is_mandatory }]"
+    :style="componentStyleVars"
+  >
+    <label v-if="!field.is_hide_legend" class="field-label">
       {{ field.name }}
-      <span v-if="field.is_mandatory" class="required-mark"></span>
+      <span v-if="field.is_mandatory" class="required-indicator">*</span>
     </label>
 
-    
-
-    <!-- Campos de entrada baseados no tipo -->
     <div class="field-input-container">
-      <!-- DATE -->
-      <input
-        v-if="field.fieldType === 'DATE'"
-        type="date"
-        :value="field.value"
-        :disabled="field.is_readonly"
-        @input="updateValue"
-        class="field-input date-input"
-      />
+      <template v-if="field.fieldType === 'DATE'">
+        <CustomDatePicker
+          v-model="localValue"
+          :disabled="field.is_readonly"
+          :error="!!error && field.is_mandatory"
+          @update:modelValue="onDateChange"
+          :class="['field-input', 'date-input', { error: !!error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
+        />
+      </template>
 
-      <!-- DECIMAL -->
-      <input
-        v-else-if="field.fieldType === 'DECIMAL'"
-        type="number"
-        step="0.01"
-        :value="field.value"
-        :disabled="field.is_readonly"
-        @input="updateValue"
-        class="field-input decimal-input"
-      />
-
-      <!-- INTEGER -->
-      <input
-        v-else-if="field.fieldType === 'INTEGER'"
-        type="number"
-        step="1"
-        :value="field.value"
-        :disabled="field.is_readonly"
-        @input="updateValue"
-        class="field-input integer-input"
-      />
-
-      <!-- YES_NO -->
-      <div v-else-if="field.fieldType === 'YES_NO'" class="yes-no-container">
-        <label class="radio-label">
-          <input
-            type="radio"
-            :name="field.id"
-            :value="true"
-            :checked="field.value === true"
+      <template v-else-if="field.fieldType === 'DEADLINE'">
+        <div style="position: relative;">
+          <div
+            class="deadline-visual"
+            :class="[
+              deadlineColorClass,
+              { 'readonly-field': field.is_readonly, 'deadline-empty': !deadlineHasValue }
+            ]"
+            :title="deadlineOriginalFormatted"
+            role="button"
+            :tabindex="field.is_readonly ? -1 : 0"
+            @click="openDeadlinePicker"
+            @keydown.enter.prevent="openDeadlinePicker"
+            @keydown.space.prevent="openDeadlinePicker"
+          >
+            <template v-if="deadlineHasValue">
+              <span class="deadline-diff-display">{{ deadlineDiff }}</span>
+            </template>
+            <template v-else>
+              <span class="material-symbols-outlined deadline-empty-icon">calendar_month</span>
+              <span class="deadline-empty-text">Select</span>
+            </template>
+          </div>
+          <CustomDatePicker
+            ref="deadlineDatePicker"
+            v-model="deadlineValue"
             :disabled="field.is_readonly"
-            @change="updateValue"
+            :show-time="true"
+            :open-up-offset="60"
+            @update:modelValue="onDeadlineChange"
+            :class="['field-input', 'date-input', { error: !!error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
+            style="position: absolute; top: 0; left: 0; width: 100%; height: 0; overflow: hidden;"
           />
-          Yes
-        </label>
-        <label class="radio-label">
-          <input
-            type="radio"
-            :name="field.id"
-            :value="false"
-            :checked="field.value === false"
-            :disabled="field.is_readonly"
-            @change="updateValue"
-          />
-          No
-        </label>
-      </div>
+        </div>
+      </template>
 
-      <!-- SIMPLE_LIST -->
-      <select
-        v-else-if="field.fieldType === 'SIMPLE_LIST'"
-        :value="field.value"
-        :disabled="field.is_readonly"
-        @change="updateValue"
-        class="field-input list-input"
-      >
-        <option value="">Select an option</option>
-        <option v-for="option in field.options" :key="option.value" :value="option.value">
-          {{ option.label }}
-        </option>
-      </select>
+      <template v-else-if="field.fieldType === 'DECIMAL'">
+        <input
+          type="number"
+          step="0.01"
+          v-model="localValue"
+          :disabled="field.is_readonly"
+          @blur="updateValue"
+          :class="['field-input', 'decimal-input', { error: !!error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
+        />
+      </template>
 
-      <!-- MULTILINE_TEXT -->
-      <textarea
-        v-else-if="field.fieldType === 'MULTILINE_TEXT'"
-        :value="field.value"
-        :disabled="field.is_readonly"
-        @input="updateValue"
-        class="field-input multiline-input"
-        rows="4"
-      ></textarea>
+      <template v-else-if="field.fieldType === 'INTEGER'">
+        <input
+          type="number"
+          step="1"
+          v-model="localValue"
+          :disabled="field.is_readonly"
+          @blur="updateValue"
+          :class="['field-input', 'integer-input', { error: !!error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
+        />
+      </template>
 
-      <!-- SIMPLE_TEXT e FORMATED_TEXT -->
-      <input
-        v-else
-        type="text"
-        :value="field.value"
-        :disabled="field.is_readonly"
-        @input="updateValue"
-        class="field-input text-input"
-      />
+      <template v-else-if="field.fieldType === 'YES_NO'">
+        <div class="yes-no-container">
+          <label class="radio-label">
+            <input
+              type="radio"
+              :name="field.id"
+              value="true"
+              :checked="localValue === true"
+              :disabled="field.is_readonly"
+              @change="onYesNoChange(true)"
+            />
+            Sim
+          </label>
+          <label class="radio-label">
+            <input
+              type="radio"
+              :name="field.id"
+              value="false"
+              :checked="localValue === false"
+              :disabled="field.is_readonly"
+              @change="onYesNoChange(false)"
+            />
+            Não
+          </label>
+        </div>
+      </template>
+
+      <template v-else-if="field.fieldType === 'FORMATED_TEXT'">
+        <div class="formatted-text-wrapper">
+          <div v-if="!field.is_readonly" class="toolbar">
+            <button type="button" @click="format('bold')" title="Negrito"><span class="material-symbols-outlined">format_bold</span></button>
+            <button type="button" @click="format('italic')" title="Itálico"><span class="material-symbols-outlined">format_italic</span></button>
+            <button type="button" @click="format('underline')" title="Sublinhado"><span class="material-symbols-outlined">format_underlined</span></button>
+            <button type="button" @click="format('insertUnorderedList')" title="Lista"><span class="material-symbols-outlined">format_list_bulleted</span></button>
+            <button type="button" @click="format('insertOrderedList')" title="Lista numerada"><span class="material-symbols-outlined">format_list_numbered</span></button>
+            <button type="button" @click="format('removeFormat')" title="Limpar formatação"><span class="material-symbols-outlined">format_clear</span></button>
+            <button type="button" @click="insertLink" title="Inserir link"><span class="material-symbols-outlined">link</span></button>
+            <button type="button" @click="insertImage" title="Inserir imagem"><span class="material-symbols-outlined">image</span></button>
+            <button type="button" class="color-btn" :style="{ color: currentColor }" title="Cor do texto">
+              <span style="font-weight: bold; font-size: 16px;">A</span>
+              <input type="color" @input="setColor($event)" :value="currentColor" class="color-input" title="Cor do texto" />
+            </button>
+          </div>
+          <div
+            ref="rte"
+            :contenteditable="!field.is_readonly"
+            dir="ltr"
+            :class="['field-input', 'rich-text-input', { 'readonly-field': field.is_readonly }]"
+            :data-placeholder="field.placeholder || field.placeholder_translations?.pt_br || ''"
+            @input="onContentEditableInput"
+            @blur="updateValue"
+          >
+          </div>
+        </div>
+      </template>
+
+      <template v-else-if="isListField">
+        <div class="custom-dropdown-wrapper" :class="{ 'readonly-field': field.is_readonly }">
+          <div
+            class="custom-dropdown-selected"
+            :class="{
+              open: dropdownOpen,
+              'readonly-field': field.is_readonly,
+              error: !!error && field.is_mandatory
+            }"
+            @click="onDropdownClick"
+            tabindex="0"
+            @keydown.enter.prevent="!field.is_readonly && toggleDropdown()"
+          >
+            <span
+              v-if="selectedOption"
+              @click.stop="onDropdownClick"
+              style="pointer-events: auto"
+            >
+              {{ selectedOption.label }}
+            </span>
+            <span
+              v-else
+              class="placeholder"
+              @click.stop="onDropdownClick"
+              style="pointer-events: auto"
+            >
+              {{ dropdownPlaceholder }}
+            </span>
+            <span
+              class="material-symbols-outlined dropdown-arrow"
+              @click.stop="onDropdownClick"
+              style="pointer-events: auto"
+            >
+              expand_more
+            </span>
+          </div>
+          <div
+            v-if="dropdownOpen"
+            :class="['custom-dropdown-list', { 'open-up': dropdownOpenUp }]"
+            ref="dropdownList"
+          >
+            <div class="dropdown-search-wrapper">
+              <span class="material-symbols-outlined search-icon">search</span>
+              <input
+                type="text"
+                v-model="searchTerm"
+                placeholder="Pesquisar..."
+                class="list-search-input"
+                @keydown.stop
+                autofocus
+              />
+            </div>
+            <div
+              v-if="filteredListOptions.length === 0"
+              class="custom-dropdown-no-options"
+            >
+              Nenhuma opção encontrada
+            </div>
+            <div
+              v-for="option in filteredListOptions"
+              :key="option.value"
+              class="custom-dropdown-option"
+              :class="{ selected: localValue == option.value }"
+              @click="selectDropdownOption(option)"
+            >
+              {{ option.label }}
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <template v-else-if="field.fieldType === 'MULTILINE_TEXT'">
+        <textarea
+          v-model="localValue"
+          :disabled="field.is_readonly"
+          @blur="updateValue"
+          :class="['field-input', 'multiline-input', { error: !!error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
+          rows="4"
+        ></textarea>
+      </template>
+
+      <template v-else>
+        <input
+          type="text"
+          v-model="localValue"
+          :disabled="field.is_readonly"
+          @blur="updateValue"
+          :class="['field-input', 'text-input', { error: !!error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
+        />
+      </template>
     </div>
 
-
-    <!-- Tooltip -->
-    <div v-if="field.tip_translations?.[this.currentLang]" class="field-tooltip">
-      <span class="tooltip-text">{{ field.tip_translations[this.currentLang] }}</span>
+    <div v-if="field.tip_translations?.[currentLang]" class="field-tooltip">
+      <span class="tooltip-text">{{ field.tip_translations[currentLang] }}</span>
     </div>
-    <!-- Mensagem de erro -->
-    <div v-if="error" class="field-error">{{ error }}</div>
+    <div v-if="error" class="field-feedback error">{{ error }}</div>
   </div>
 </template>
 
 <script>
+import CustomDatePicker from './CustomDatePicker.vue';
+
 export default {
   name: 'FieldComponent',
+  components: {
+    CustomDatePicker
+  },
   props: {
     field: {
       type: Object,
@@ -124,51 +249,661 @@ export default {
   },
   data() {
     return {
-      error: null
-    }
+      error: null,
+      dropdownOpen: false,
+      dropdownOpenUp: false,
+      searchTerm: '',
+      localValue: this.field?.value ?? '',
+      remoteOptions: [],
+      isLoadingOptions: false,
+      deadlineTimer: null,
+      dataNow: new Date(),
+      currentColor: '#699d8c'
+    };
   },
   computed: {
-    currentLang() {
-      if (typeof window !== 'undefined' && window.wwLib && window.wwLib.wwVariable) {
-        return window.wwLib.wwVariable.getValue('aa44dc4c-476b-45e9-a094-16687e063342') || 'en-US';
+    themeTokens() {
+      if (typeof window !== 'undefined' && window.wwLib?.wwVariable?.getValue) {
+        const value = window.wwLib.wwVariable.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726');
+        if (value && typeof value === 'object') {
+          return value;
+        }
       }
-      return 'en-US';
+      return {};
+    },
+    componentStyleVars() {
+      if (this.field && this.field.fieldType === 'DEADLINE') {
+        return {};
+      }
+
+      const tokens = this.themeTokens || {};
+      return {
+        '--text-input-bg': tokens.inputBG || '#FFFFFF',
+        '--text-input-border': tokens.inputBorder || '#d1d5db',
+        '--text-input-border-focus': tokens.inputBorderInFocus || tokens.inputBorder || '#d1d5db',
+        '--placeholder-color': tokens.normal || tokens.inputText || '#787878'
+      };
+    },
+    currentLang() {
+      if (typeof window !== 'undefined' && window.wwLib?.wwVariable) {
+        return window.wwLib.wwVariable.getValue('aa44dc4c-476b-45e9-a094-16687e063342') || 'pt-BR';
+      }
+      return 'pt-BR';
+    },
+    dataSourceConfig() {
+      return this.normalizeDataSource(this.field);
+    },
+    isListField() {
+      return ['SIMPLE_LIST', 'LIST', 'CONTROLLED_LIST'].includes(this.field.fieldType);
+    },
+    dropdownPlaceholder() {
+      return (
+        this.field.placeholder ||
+        this.field.placeholder_translations?.[this.currentLang] ||
+        'Selecione uma opção'
+      );
+    },
+    listOptions() {
+      if (Array.isArray(this.remoteOptions) && this.remoteOptions.length) {
+        return this.remoteOptions;
+      }
+
+      if (Array.isArray(this.field.options) && this.field.options.length) {
+        return [...this.field.options].sort((a, b) => {
+          if (typeof a.label === 'string' && typeof b.label === 'string') {
+            return a.label.localeCompare(b.label);
+          }
+          return 0;
+        });
+      }
+
+      const rawOptions =
+        this.field.list_options ||
+        this.field.listOptions ||
+        this.field.ListOptions ||
+        null;
+
+      if (typeof rawOptions === 'string' && rawOptions.trim() !== '') {
+        return rawOptions
+          .split(',')
+          .map(opt => {
+            const trimmed = opt.trim();
+            return { value: trimmed, label: trimmed };
+          })
+          .sort((a, b) => a.label.localeCompare(b.label));
+      }
+
+      if (Array.isArray(rawOptions)) {
+        return [...rawOptions].map(opt => ({
+          value: opt.value ?? opt.id ?? opt,
+          label: opt.label ?? opt.name ?? String(opt.value ?? opt)
+        }));
+      }
+
+      return [];
+    },
+    selectedOption() {
+      return this.listOptions.find(opt => opt.value == this.localValue) || null;
+    },
+    filteredListOptions() {
+      if (!this.searchTerm) return this.listOptions;
+      const term = this.searchTerm.toLowerCase();
+      return this.listOptions.filter(opt => String(opt.label).toLowerCase().includes(term));
+    },
+    deadlineHasValue() {
+      if (this.field.fieldType !== 'DEADLINE') return false;
+      const val = this.localValue || this.field.value;
+      return !!(val && String(val).trim());
+    },
+    deadlineValue: {
+      get() {
+        if (this.field.fieldType !== 'DEADLINE') return this.localValue;
+        const val = this.localValue || this.field.value;
+        if (!val) return '';
+        const match = String(val).match(/(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2})/);
+        if (match) {
+          return `${match[1]}T${match[2]}`;
+        }
+        const d = new Date(val);
+        if (!isNaN(d.getTime())) {
+          const pad = n => String(n).padStart(2, '0');
+          return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+        }
+        return '';
+      },
+      set(v) {
+        this.localValue = v;
+      }
+    },
+    deadlineDiff() {
+      if (this.field.fieldType !== 'DEADLINE') return '';
+      const val = this.localValue || this.field.value;
+      if (!val) return '';
+      let dateStr = val;
+      if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(val)) {
+        dateStr = val;
+      } else if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{2}/.test(val)) {
+        dateStr = val.replace(' ', 'T').replace(/([\+\-]\d{2})$/, '$1:00');
+      }
+      const deadline = new Date(dateStr);
+      if (isNaN(deadline.getTime())) return '';
+      const diffMs = deadline - this.dataNow;
+      if (isNaN(diffMs)) return '';
+      const abs = Math.abs(diffMs);
+      const isPast = diffMs < 0;
+      if (abs < 60 * 1000) {
+        const s = Math.floor(abs / 1000);
+        return `${isPast ? '-' : ''}${s}s`;
+      }
+      if (abs < 60 * 60 * 1000) {
+        const m = Math.floor(abs / (60 * 1000));
+        return `${isPast ? '-' : ''}${m}m`;
+      }
+      if (abs < 24 * 60 * 60 * 1000) {
+        const h = Math.floor(abs / (60 * 60 * 1000));
+        const m = Math.floor((abs % (60 * 60 * 1000)) / (60 * 1000));
+        return `${isPast ? '-' : ''}${h}h${m > 0 ? ` ${m}m` : ''}`;
+      }
+      const d = Math.floor(abs / (24 * 60 * 60 * 1000));
+      const h = Math.floor((abs % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+      const m = Math.floor((abs % (60 * 60 * 1000)) / (60 * 1000));
+      let str = `${isPast ? '-' : ''}${d}d`;
+      if (h > 0) str += ` ${h}h`;
+      if (m > 0) str += ` ${m}m`;
+      return str;
+    },
+    deadlineColorClass() {
+      if (this.field.fieldType !== 'DEADLINE') return '';
+      const val = this.localValue || this.field.value;
+      if (!val) return '';
+      let dateStr = val;
+      if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(val)) {
+        dateStr = val;
+      } else if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{2}/.test(val)) {
+        dateStr = val.replace(' ', 'T').replace(/([\+\-]\d{2})$/, '$1:00');
+      }
+      const deadline = new Date(dateStr);
+      if (isNaN(deadline.getTime())) return '';
+      const diffMs = deadline - this.dataNow;
+      if (isNaN(diffMs)) return '';
+      const diffDays = diffMs / (24 * 60 * 60 * 1000);
+      if (diffDays > 5) return 'deadline-green';
+      if (diffDays > 0) return 'deadline-yellow';
+      return 'deadline-red';
+    },
+    deadlineOriginalFormatted() {
+      if (this.field.fieldType !== 'DEADLINE') return '';
+      const val = this.localValue || this.field.value;
+      if (!val) return '';
+      let dateStr = val;
+      if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(val)) {
+        dateStr = val;
+      } else if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{2}/.test(val)) {
+        dateStr = val.replace(' ', 'T').replace(/([\+\-]\d{2})$/, '$1:00');
+      }
+      const lang =
+        (typeof window !== 'undefined' && window.wwLib?.wwVariable?.getValue('aa44dc4c-476b-45e9-a094-16687e063342')) ||
+        (typeof navigator !== 'undefined' ? navigator.language : 'pt-BR');
+      try {
+        const formulaApi = window.wwLib?.wwFormula;
+        const use = formulaApi?.useFormula?.();
+        const resolveMappingFormula = use?.resolveMappingFormula;
+        const mapping = resolveMappingFormula ? resolveMappingFormula('95a5a105-48b6-48d4-95c5-7179a664451d') : null;
+        if (mapping && typeof formulaApi?.getValue === 'function') {
+          const res = formulaApi.getValue(mapping, {}, { args: [dateStr, lang] });
+          if (!(res instanceof Promise) && res !== undefined && res !== null) {
+            return String(res);
+          }
+        }
+      } catch (e) {
+        // ignore and fallback
+      }
+      const deadline = new Date(dateStr);
+      if (isNaN(deadline.getTime())) return val;
+      return deadline.toLocaleString(lang);
+    }
+  },
+  watch: {
+    field: {
+      handler(newField, oldField) {
+        this.localValue = newField?.value ?? '';
+        if (newField?.fieldType === 'FORMATED_TEXT' && this.$refs.rte) {
+          this.$nextTick(() => {
+            if (this.$refs.rte) {
+              this.$refs.rte.innerHTML = this.localValue || '';
+            }
+          });
+        }
+        if (newField?.fieldType === 'DEADLINE' && !this.deadlineTimer) {
+          this.deadlineTimer = setInterval(() => {
+            this.dataNow = new Date();
+          }, 1000);
+        } else if (oldField?.fieldType === 'DEADLINE' && newField?.fieldType !== 'DEADLINE' && this.deadlineTimer) {
+          clearInterval(this.deadlineTimer);
+          this.deadlineTimer = null;
+        }
+        const newSource = JSON.stringify(this.normalizeDataSource(newField));
+        const oldSource = JSON.stringify(this.normalizeDataSource(oldField));
+        if (newSource !== oldSource) {
+          this.loadDataSourceOptions();
+        }
+      },
+      deep: true
+    },
+    localValue(newVal) {
+      if (this.field.fieldType === 'FORMATED_TEXT' && this.$refs.rte && this.$refs.rte.innerHTML !== newVal) {
+        this.$refs.rte.innerHTML = newVal || '';
+      }
+    },
+    dataSourceConfig: {
+      handler() {
+        this.loadDataSourceOptions();
+      },
+      deep: true,
+      immediate: true
+    },
+    dropdownOpen(val) {
+      if (!val) {
+        this.searchTerm = '';
+        document.removeEventListener('click', this.handleClickOutsideDropdown);
+      }
+    }
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutsideDropdown);
+    if (this.deadlineTimer) {
+      clearInterval(this.deadlineTimer);
+      this.deadlineTimer = null;
+    }
+  },
+  mounted() {
+    if (this.field.fieldType === 'FORMATED_TEXT' && this.$refs.rte) {
+      this.$refs.rte.innerHTML = this.localValue || '';
+    }
+    if (this.field.fieldType === 'DEADLINE') {
+      this.deadlineTimer = setInterval(() => {
+        this.dataNow = new Date();
+      }, 1000);
     }
   },
   methods: {
-    // Função simples para tradução
     translateText(text) {
       return text;
     },
-    
-    updateValue(event) {
-      let value = event.target.value;
-      
-      // Validação específica por tipo de campo
+    normalizeDataSource(field) {
+      if (!field) return null;
+      const rawDataSource = field.dataSource ?? field.DataSource ?? null;
+      if (!rawDataSource) return null;
+
+      if (typeof rawDataSource !== 'object') {
+        return rawDataSource;
+      }
+
+      const transform = rawDataSource.transform ?? rawDataSource.Transform ?? null;
+      const method = rawDataSource.method ?? rawDataSource.Method ?? undefined;
+      const valueField = rawDataSource.valueField ?? rawDataSource.ValueField ?? undefined;
+      const labelField = rawDataSource.labelField ?? rawDataSource.LabelField ?? undefined;
+      const functionName = rawDataSource.functionName ?? rawDataSource.FunctionName ?? undefined;
+
+      return {
+        ...rawDataSource,
+        ...(transform ? { transform } : {}),
+        ...(method ? { method } : {}),
+        ...(valueField ? { valueField } : {}),
+        ...(labelField ? { labelField } : {}),
+        ...(functionName ? { functionName } : {}),
+      };
+    },
+    extractArrayFromResponse(payload, visited = new WeakSet()) {
+      if (Array.isArray(payload)) {
+        return payload;
+      }
+
+      if (!payload || typeof payload !== 'object') {
+        return null;
+      }
+
+      if (visited.has(payload)) {
+        return null;
+      }
+
+      visited.add(payload);
+
+      const priorityKeys = [
+        'items',
+        'data',
+        'results',
+        'value',
+        'values',
+        'options',
+        'records',
+        'list',
+        'rows',
+        'collection',
+      ];
+
+      for (const key of priorityKeys) {
+        if (Array.isArray(payload?.[key])) {
+          return payload[key];
+        }
+      }
+
+      for (const key of Object.keys(payload)) {
+        const value = payload[key];
+        const result = this.extractArrayFromResponse(value, visited);
+        if (Array.isArray(result)) {
+          return result;
+        }
+      }
+
+      return null;
+    },
+    mapOptionsFromData(dataArray, dataSource) {
+      if (!Array.isArray(dataArray)) {
+        return [];
+      }
+
+      const transform = dataSource && typeof dataSource === 'object'
+        ? (dataSource.transform ?? null)
+        : null;
+
+      if (transform && (transform.value || transform.label)) {
+        return dataArray
+          .map(item => {
+            if (!item || typeof item !== 'object') return null;
+            const value = item?.[transform.value] ?? item?.id ?? item?.ID;
+            const label = item?.[transform.label] ?? item?.name ?? item?.Name;
+            if (value === undefined || label === undefined) {
+              return null;
+            }
+            return { value, label };
+          })
+          .filter(option => option !== null);
+      }
+
+      const valueField =
+        (dataSource && typeof dataSource === 'object' && (dataSource.valueField ?? dataSource.ValueField)) ||
+        'id';
+      const labelField =
+        (dataSource && typeof dataSource === 'object' && (dataSource.labelField ?? dataSource.LabelField)) ||
+        'name';
+
+      return dataArray
+        .map(item => {
+          if (!item || typeof item !== 'object') {
+            const primitiveValue = item;
+            if (primitiveValue === undefined || primitiveValue === null) {
+              return null;
+            }
+            const normalized = String(primitiveValue);
+            return { value: primitiveValue, label: normalized };
+          }
+
+          const value = item?.[valueField] ?? item?.id ?? item?.ID;
+          const label = item?.[labelField] ?? item?.name ?? item?.Name;
+
+          if (value === undefined || label === undefined) {
+            return null;
+          }
+
+          return { value, label };
+        })
+        .filter(option => option !== null);
+    },
+    async loadDataSourceOptions() {
+      if (typeof window === 'undefined') {
+        this.remoteOptions = [];
+        return;
+      }
+
+      const dataSource = this.dataSourceConfig;
+
+      if (!dataSource) {
+        this.remoteOptions = [];
+        return;
+      }
+
+      const lang = window.wwLib?.wwVariable?.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+      const companyId = window.wwLib?.wwVariable?.getValue('5d099f04-cd42-41fd-94ad-22d4de368c3a');
+      const apiUrl = window.wwLib?.wwVariable?.getValue('1195995b-34c3-42a5-b436-693f0f4f8825') || '';
+      const apiKey = window.wwLib?.wwVariable?.getValue('d180be98-8926-47a7-b7f1-6375fbb95fa3');
+      const apiAuth = window.wwLib?.wwVariable?.getValue('dfcde09f-42f3-4b5c-b2e8-4314650655db');
+
+      const headers = { 'Content-Type': 'application/json' };
+      if (apiKey) headers.apikey = apiKey;
+      if (apiAuth) headers.Authorization = apiAuth;
+
+      let url = '';
+      let method = 'POST';
+
+      if (typeof dataSource === 'string') {
+        if (!dataSource.trim()) {
+          this.remoteOptions = [];
+          return;
+        }
+        url = this.combineUrl(apiUrl, dataSource);
+      } else if (dataSource.url) {
+        url = this.combineUrl(apiUrl, dataSource.url);
+        const rawMethod = dataSource.method ?? dataSource.Method;
+        if (rawMethod && rawMethod.toUpperCase() === 'GET') {
+          method = 'GET';
+        }
+      } else if (dataSource.functionName) {
+        url = this.combineUrl(apiUrl, dataSource.functionName);
+      } else {
+        this.remoteOptions = [];
+        return;
+      }
+
+      const fetchOptions = { method, headers };
+      if (method !== 'GET') {
+        fetchOptions.body = JSON.stringify({
+          ...(companyId ? { p_idcompany: companyId } : {}),
+          ...(lang ? { p_language: lang } : {})
+        });
+      }
+
+      this.isLoadingOptions = true;
+      try {
+        const response = await fetch(url, fetchOptions);
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        const dataArray = this.extractArrayFromResponse(data);
+
+        if (!Array.isArray(dataArray)) {
+          this.remoteOptions = [];
+          return;
+        }
+
+        const options = this.mapOptionsFromData(dataArray, dataSource);
+
+        this.remoteOptions = options.sort((a, b) => {
+          if (typeof a.label === 'string' && typeof b.label === 'string') {
+            return a.label.localeCompare(b.label);
+          }
+          return 0;
+        });
+      } catch (err) {
+        console.error('Failed to load data source options', err);
+        this.remoteOptions = [];
+      } finally {
+        this.isLoadingOptions = false;
+      }
+    },
+    combineUrl(baseUrl, path) {
+      if (!path) return baseUrl || '';
+      if (/^https?:\/\//i.test(path)) {
+        return path;
+      }
+
+      const sanitizedBase = (baseUrl || '').replace(/\/+$/, '');
+      const sanitizedPath = path.replace(/^\/+/, '');
+
+      if (!sanitizedBase) {
+        return `/${sanitizedPath}`;
+      }
+
+      return `${sanitizedBase}/${sanitizedPath}`;
+    },
+    onDateChange(value) {
+      this.updateValue(value);
+    },
+    onYesNoChange(value) {
+      this.localValue = value;
+      this.updateValue(value);
+    },
+    onDeadlineChange(value) {
+      this.updateValue(value);
+    },
+    openDeadlinePicker() {
+      if (this.field.fieldType === 'DEADLINE' && !this.field.is_readonly) {
+        const dp = this.$refs.deadlineDatePicker;
+        if (dp && typeof dp.openDp === 'function') {
+          dp.openDp();
+        }
+      }
+    },
+    onContentEditableInput(event) {
+      this.localValue = event.target.innerHTML;
+    },
+    format(cmd) {
+      if (this.$refs.rte) {
+        this.$refs.rte.focus();
+      }
+      document.execCommand(cmd, false, null);
+    },
+    setColor(event) {
+      if (this.$refs.rte) {
+        this.$refs.rte.focus();
+      }
+      document.execCommand('foreColor', false, event.target.value);
+      this.currentColor = event.target.value;
+    },
+    insertLink() {
+      if (this.$refs.rte) {
+        this.$refs.rte.focus();
+      }
+      const url = typeof window !== 'undefined' ? window.prompt('Digite a URL do link:') : null;
+      if (url) {
+        document.execCommand('createLink', false, url);
+      }
+    },
+    insertImage() {
+      if (this.$refs.rte) {
+        this.$refs.rte.focus();
+      }
+      const url = typeof window !== 'undefined' ? window.prompt('Digite a URL da imagem:') : null;
+      if (url) {
+        document.execCommand('insertImage', false, url);
+      }
+    },
+    onDropdownClick() {
+      if (this.field.is_readonly) return;
+      this.toggleDropdown();
+    },
+    toggleDropdown() {
+      this.dropdownOpen = !this.dropdownOpen;
+      if (this.dropdownOpen) {
+        this.$nextTick(() => {
+          const trigger = this.$el.querySelector('.custom-dropdown-selected');
+          const dropdown = this.$refs.dropdownList;
+          if (trigger && dropdown) {
+            const scrollParent = this.getScrollParent(trigger);
+            const triggerRect = trigger.getBoundingClientRect();
+            const dropdownHeight = 320;
+            let spaceBelow;
+            if (scrollParent === document.body) {
+              spaceBelow = window.innerHeight - triggerRect.bottom;
+            } else {
+              const parentRect = scrollParent.getBoundingClientRect();
+              spaceBelow = parentRect.bottom - triggerRect.bottom;
+            }
+            this.dropdownOpenUp = spaceBelow < dropdownHeight;
+          }
+          document.addEventListener('click', this.handleClickOutsideDropdown);
+        });
+      }
+    },
+    handleClickOutsideDropdown(event) {
+      if (!this.dropdownOpen) return;
+      const dropdown = this.$refs.dropdownList;
+      if (!dropdown) return;
+      if (!dropdown.contains(event.target) && !event.target.closest('.custom-dropdown-selected')) {
+        this.dropdownOpen = false;
+      }
+    },
+    selectDropdownOption(option) {
+      this.localValue = option.value;
+      this.updateValue(option.value);
+      this.dropdownOpen = false;
+    },
+    getScrollParent(element) {
+      let style = getComputedStyle(element);
+      const excludeStaticParent = style.position === 'absolute';
+      const overflowRegex = /(auto|scroll|overlay)/;
+      if (style.position === 'fixed') return document.body;
+      for (let parent = element; (parent = parent.parentElement);) {
+        style = getComputedStyle(parent);
+        if (excludeStaticParent && style.position === 'static') {
+          continue;
+        }
+        if (overflowRegex.test(style.overflow + style.overflowY + style.overflowX)) return parent;
+      }
+      return document.body;
+    },
+    updateValue(eventOrValue) {
+      const rawValue = this.field.fieldType === 'FORMATED_TEXT'
+        ? this.localValue
+        : eventOrValue && eventOrValue.target
+          ? eventOrValue.target.value
+          : eventOrValue;
+      let value = rawValue;
+
       switch (this.field.fieldType) {
         case 'DATE':
           this.validateDate(value);
           break;
-        case 'DECIMAL':
-          value = parseFloat(value);
-          this.validateDecimal(value);
+        case 'DEADLINE':
+          this.validateDeadline(value);
           break;
-        case 'INTEGER':
-          value = parseInt(value);
-          this.validateInteger(value);
+        case 'DECIMAL': {
+          const numericValue =
+            value === '' || value === null || value === undefined ? null : parseFloat(value);
+          value = numericValue;
+          this.validateDecimal(numericValue);
           break;
+        }
+        case 'INTEGER': {
+          const numericValue =
+            value === '' || value === null || value === undefined ? null : parseInt(value, 10);
+          value = numericValue;
+          this.validateInteger(numericValue);
+          break;
+        }
         case 'YES_NO':
-          value = event.target.value === 'true';
+          value = Boolean(value);
           break;
         case 'SIMPLE_LIST':
+        case 'LIST':
+        case 'CONTROLLED_LIST':
+          value = value !== null && value !== undefined ? String(value) : value;
           this.validateList(value);
           break;
+        case 'FORMATED_TEXT':
+          this.validateText(typeof value === 'string' ? value : value != null ? String(value) : '');
+          break;
         case 'MULTILINE_TEXT':
-          this.validateMultilineText(value);
+          this.validateMultilineText(typeof value === 'string' ? value : '');
           break;
         case 'SIMPLE_TEXT':
-        case 'FORMATED_TEXT':
-          this.validateText(value);
+        case 'TEXT':
+        case 'EMAIL':
+        case 'PHONE':
+        default:
+          this.validateText(typeof value === 'string' ? value : value != null ? String(value) : '');
           break;
       }
 
@@ -176,183 +911,643 @@ export default {
         this.$emit('update:value', value);
       }
     },
-
     validateDate(value) {
       if (!value) {
-        this.error = this.field.is_mandatory ? this.translateText('Date is required') : null;
+        this.error = this.field.is_mandatory ? this.translateText('Campo obrigatório') : null;
+        return;
+      }
+      const date = new Date(`${value}T00:00:00`);
+      this.error = isNaN(date.getTime()) ? this.translateText('Data inválida') : null;
+    },
+    validateDeadline(value) {
+      if (!value) {
+        this.error = this.field.is_mandatory ? this.translateText('Campo obrigatório') : null;
         return;
       }
       const date = new Date(value);
       if (isNaN(date.getTime())) {
-        this.error = this.translateText('Invalid date');
+        this.error = this.translateText('Data e hora inválidas');
       } else {
         this.error = null;
       }
     },
-
     validateDecimal(value) {
-      if (isNaN(value)) {
-        this.error = this.translateText('Invalid decimal value');
+      if (value === null || isNaN(value)) {
+        this.error = this.field.is_mandatory ? this.translateText('Campo obrigatório') : null;
         return;
       }
-      if (this.field.is_mandatory && value === '') {
-        this.error = this.translateText('Required field');
-      } else {
-        this.error = null;
-      }
+      this.error = null;
     },
-
     validateInteger(value) {
-      if (isNaN(value)) {
-        this.error = this.translateText('Invalid integer value');
+      if (value === null || isNaN(value)) {
+        this.error = this.field.is_mandatory ? this.translateText('Campo obrigatório') : null;
         return;
       }
-      if (this.field.is_mandatory && value === '') {
-        this.error = this.translateText('Required field');
-      } else {
-        this.error = null;
-      }
+      this.error = null;
     },
-
     validateList(value) {
       if (this.field.is_mandatory && !value) {
-        this.error = this.translateText('Select an option');
+        this.error = this.translateText('Campo obrigatório');
       } else {
         this.error = null;
       }
     },
-
     validateMultilineText(value) {
       if (this.field.is_mandatory && !value.trim()) {
-        this.error = this.translateText('Required field');
+        this.error = this.translateText('Campo obrigatório');
       } else {
         this.error = null;
       }
     },
-
     validateText(value) {
       if (this.field.is_mandatory && !value.trim()) {
-        this.error = this.translateText('Required field');
+        this.error = this.translateText('Campo obrigatório');
       } else {
         this.error = null;
       }
     }
   }
-}
+};
 </script>
 
 <style scoped>
-.field-component {
-display: flex;
-flex-direction: column;
-width: 100%;
-margin-bottom: 5px;
-}
+  .field-component {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin-bottom: 5px;
+  }
 
-.field-label {
-font-size: 13px;
-font-weight: 400;
-margin-bottom: 4px;
-color: #333;
-}
+  .field-component:not(.field-type-deadline) {
+    --text-input-bg: #ffffff;
+    --text-input-border: #d1d5db;
+    --text-input-border-focus: #bdbdbd;
+  }
 
-.required-indicator {
-color: #e53935;
-margin-left: 2px;
-}
+  .field-label {
+    font-size: 12px;
+    font-weight: 400;
+    margin-bottom: 4px;
+    color: #787878;
+    padding-left: 8px;
+  }
 
-.field-row {
-display: flex;
-align-items: center;
-width: 100%;
-}
+  .required-indicator {
+    color: #e53935;
+    margin-left: 2px;
+    font-weight: bold;
+  }
 
-.field-input {
-flex: 1;
-min-width: 0; /* This prevents the input from overflowing its container */
-padding: 8px 12px;
-border: 1px solid #ddd;
-border-radius: 4px;
-font-size: 13px;
-background-color: #fff;
-width: 100%;
-}
+  .field-row {
+    display: flex;
+    align-items: center;
+    width: 100%;
+  }
 
-.field-input:focus {
-outline: none;
-border-color: #007bff;
-box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
-}
+  .field-input {
+    flex: 1;
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+    color: #787878;
+    font-size: 0.845rem;
+    letter-spacing: 0px;
+    text-overflow: ellipsis;
+  }
 
-.field-input[readonly] {
-background-color: #f5f5f5;
-cursor: not-allowed;
-}
+  input.field-input,
+  textarea.field-input {
+    padding: 8px;
+    border: 1px solid var(--text-input-border);
+    border-radius: 4px;
+    background-color: var(--text-input-bg);
+  }
 
-.field-tip {
-font-size: 12px;
-color: #666;
-margin-top: 4px;
-font-style: italic;
-}
+  input.field-input {
+    height: 34px;
+  }
 
-.is-required .field-label::after {
-content: "*";
-color: #e53935;
-margin-left: 2px;
-}
+  .text-input,
+  .decimal-input,
+  .integer-input {
+    background-color: var(--text-input-bg);
+  }
 
-.tooltip-text {  
-  color: rgb(120, 120, 120);
-  padding: 8px;
-  border-radius: 4px;
-  font-size: 12px;
-  white-space: nowrap;
-  z-index: 1;
-}
+  input.field-input:focus,
+  textarea.field-input:focus {
+    border-color: var(--text-input-border-focus);
+    box-shadow: none;
+    background-color: #ffffff;
+    color: #787878;
+  }
 
-.field-tooltip:hover .tooltip-text {
-  
-}
+  input.field-input::placeholder,
+  textarea.field-input::placeholder {
+    color: var(--placeholder-color, #787878);
+    opacity: 1;
+  }
 
-/* Estilos específicos por tipo de campo */
-.date-input {
-  min-width: 150px;
-}
+  .field-component input.field-input:disabled,
+  .field-component textarea.field-input:disabled {
+    background-color: #f5f5f5;
+    cursor: not-allowed;
+  }
 
-.decimal-input,
-.integer-input {
-  text-align: right;
-}
+  .field-input[readonly] {
+    background-color: #f5f5f5;
+    cursor: not-allowed;
+  }
 
-.yes-no-container {
-  display: flex;
-  gap: 16px;
-}
+  .field-tip {
+    font-size: 12px;
+    color: #666;
+    margin-top: 4px;
+    font-style: italic;
+  }
 
-.radio-label {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  cursor: pointer;
-}
+  .is-required .field-label::after {
+    content: "*";
+    color: #e53935;
+    margin-left: 2px;
+  }
 
-.list-input {
-  min-width: 200px;
-}
+  .tooltip-text {
+    color: rgb(120, 120, 120);
+    padding: 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    white-space: nowrap;
+    z-index: 1;
+  }
 
-.multiline-input {
-  resize: vertical;
-  min-height: 100px;
-}
+  .date-input {
+    min-width: 150px;
+    padding: 0;
+    border: 1px solid var(--text-input-border);
+    border-radius: 4px;
+    height: 34px;
+    display: flex;
+    align-items: center;
+    background-color: var(--text-input-bg);
+    box-sizing: border-box;
+  }
 
-/* Estilos para campos obrigatórios */
-.is-mandatory .field-label {
-  font-weight: 400;
-}
+  .date-input:focus-within {
+    border-color: var(--text-input-border-focus);
+    background-color: #ffffff;
+  }
 
-/* Estilos para campos com erro */
-.field-input.error {
-  border-color: #ff0000;
-}
-</style> 
+  .date-input :deep(.dp-input) {
+    border: none;
+    background: transparent;
+    padding: 0 32px 0 8px;
+    height: 100%;
+    color: #787878;
+    font-size: 0.845rem;
+    letter-spacing: 0px;
+    text-overflow: ellipsis;
+    box-sizing: border-box;
+  }
+
+  .date-input :deep(.dp-input::placeholder) {
+    color: var(--placeholder-color, #787878);
+    opacity: 1;
+  }
+
+  .decimal-input,
+  .integer-input {
+    text-align: right;
+  }
+
+  .yes-no-container {
+    display: flex;
+    gap: 16px;
+  }
+
+  .radio-label {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+  }
+
+  .list-input {
+    min-width: 200px;
+  }
+
+  .multiline-input {
+    resize: vertical;
+    min-height: 100px;
+    height: auto;
+  }
+
+  .is-mandatory .field-label {
+    font-weight: 400;
+  }
+
+  .field-input.error {
+    border-color: #ff0000;
+    box-shadow: 0 0 0 1px #ff0000;
+  }
+
+  .field-feedback {
+    margin-top: 6px;
+    font-size: 0.845rem;
+    letter-spacing: 0px;
+    text-overflow: ellipsis;
+    font-weight: 400;
+    border-radius: 4px;
+    padding: 4px 8px;
+    display: inline-block;
+  }
+
+  .field-feedback.success {
+    color: #155724;
+    background: #d4edda;
+    border: 1px solid #c3e6cb;
+  }
+
+  .field-feedback.error {
+    color: #721c24;
+    background: #f8d7da;
+    border: 1px solid #f5c6cb;
+  }
+
+  .deadline-visual {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border-radius: 20px !important;
+    font-size: 12px;
+    transition: background .3s, color .3s, border-color .3s;
+    width: 130px !important;
+    height: 30px !important;
+    border: 1.5px solid transparent;
+    background: transparent;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .deadline-visual:focus {
+    outline: none;
+    box-shadow: 0 0 0 2px rgba(55, 111, 208, 0.2);
+  }
+
+  .deadline-empty {
+    border-color: #d1d5db !important;
+    background: #ffffff !important;
+    color: #6b7280 !important;
+    font-weight: 500;
+  }
+
+  .deadline-empty-icon {
+    font-size: 18px;
+    line-height: 1;
+  }
+
+  .deadline-empty-text {
+    line-height: 1;
+  }
+
+  .deadline-diff-display {
+    font-weight: bold;
+  }
+
+  .deadline-green {
+    background: rgb(131, 176, 244) !important;
+    color: #ffffff !important;
+    border: 1.5px solid rgb(131, 176, 244) !important;
+    font-weight: bold;
+  }
+
+  .deadline-yellow {
+    background: #fffbe6 !important;
+    color: #b59f00 !important;
+    border: 1.5px solid #b59f00 !important;
+    font-weight: bold;
+  }
+
+  .deadline-red {
+    background: #ffdddd !important;
+    color: #b71c1c !important;
+    border: 1.5px solid #b71c1c !important;
+    font-weight: bold;
+  }
+
+  .deadline-diff {
+    font-size: 12px;
+    color: #007bff;
+    margin-top: 4px;
+  }
+
+  .readonly-field {
+    background-color: #f0f0f0 !important;
+    color: #888 !important;
+    cursor: not-allowed !important;
+    border-style: dashed !important;
+    opacity: 1 !important;
+  }
+
+  .formatted-text-wrapper {
+    width: 100%;
+  }
+
+  .toolbar {
+    margin-bottom: 0;
+    display: flex;
+    gap: 6px;
+    background: #f8f9fa;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px 6px 0 0;
+    padding: 6px 8px 4px 8px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+  }
+
+  .toolbar button {
+    background: #fff;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 3px 10px;
+    cursor: pointer;
+    font-size: 15px;
+    color: #333;
+    transition: background 0.2s, border 0.2s;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.01);
+    display: flex;
+    align-items: center;
+    gap: 2px;
+  }
+
+  .toolbar button:hover,
+  .toolbar button:focus {
+    background: #e3eafc;
+    border-color: #90b4f8;
+    color: #1a237e;
+  }
+
+  .toolbar button:active {
+    background: #dbeafe;
+    border-color: #60a5fa;
+  }
+
+  .rich-text-input {
+    max-width: 100%;
+    overflow-x: auto;
+    word-break: break-word;
+    box-sizing: border-box;
+    min-height: 100px;
+    padding: 8px;
+    border: 1px solid var(--text-input-border);
+    border-radius: 4px;
+    background-color: var(--text-input-bg);
+    color: #787878;
+    font-size: 0.845rem;
+    letter-spacing: 0px;
+    text-overflow: ellipsis;
+    white-space: pre-wrap;
+    transition: background .3s, border-color .3s, color .3s;
+    outline: none !important;
+  }
+
+  .rich-text-input:focus {
+    border-color: var(--text-input-border-focus);
+    background-color: #ffffff;
+    color: #787878;
+  }
+
+  .rich-text-input[data-placeholder]:empty::before {
+    content: attr(data-placeholder);
+    color: var(--placeholder-color, #787878);
+    opacity: 1;
+    pointer-events: none;
+  }
+
+  .rich-text-input img,
+  .rich-text-input table,
+  .rich-text-input iframe {
+    max-width: 100%;
+    height: auto;
+    box-sizing: border-box;
+    display: block;
+  }
+
+  .rich-text-input table {
+    width: 100% !important;
+    table-layout: auto;
+    overflow-x: auto;
+    display: block;
+  }
+
+  .toolbar {
+    border-bottom-left-radius: 0 !important;
+    border-bottom-right-radius: 0 !important;
+  }
+
+  .toolbar .material-symbols-outlined {
+    font-size: 18px !important;
+    color: rgb(105, 157, 140) !important;
+    vertical-align: middle;
+  }
+
+  @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined');
+
+  .color-btn {
+    position: relative;
+    background: #fff;
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 3px 10px;
+    cursor: pointer;
+    font-size: 15px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s, border 0.2s;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.01);
+    margin-left: 2px;
+  }
+
+  .color-btn:hover,
+  .color-btn:focus {
+    background: #e3eafc;
+    border-color: #90b4f8;
+    color: #1a237e;
+  }
+
+  .color-input {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  .dropdown-search-wrapper {
+    position: relative;
+    width: 96%;
+    margin: 10px auto 10px auto;
+    display: flex;
+    align-items: center;
+    background-color: #FFFFFF !important;
+  }
+
+  .dropdown-search-wrapper .search-icon {
+    position: absolute;
+    right: 12px;
+    font-size: 20px;
+    color: #bdbdbd;
+    pointer-events: none;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .list-search-input {
+    border: 1.5px solid #bdbdbd !important;
+    border-radius: 20px;
+    padding: 7px 38px 7px 12px;
+    font-size: 0.845rem;
+    letter-spacing: 0px;
+    text-overflow: ellipsis;
+    width: 100%;
+    box-sizing: border-box;
+    background: #f8f9fa;
+    transition: border 0.2s;
+    outline: none;
+  }
+
+  .list-search-input:focus,
+  .list-search-input:active,
+  .list-search-input:hover {
+    border-color: #bdbdbd !important;
+    background: #fff;
+  }
+
+  .custom-dropdown-wrapper {
+    position: relative;
+    width: 100%;
+  }
+
+  .custom-dropdown-selected {
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 6px 12px;
+    background: #fff;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 34px;
+    font-size: 0.845rem;
+    letter-spacing: 0px;
+    text-overflow: ellipsis;
+    transition: border .2s;
+    color: #787878 !important;
+  }
+
+  .custom-dropdown-selected.open {
+    border-color: #699d8c;
+    box-shadow: 0 2px 8px rgba(105, 157, 140, 0.08);
+  }
+
+  .custom-dropdown-selected.error {
+    border-color: #ff0000;
+    box-shadow: 0 0 0 1px #ff0000;
+  }
+
+  .custom-dropdown-selected.readonly-field {
+    background: #f0f0f0;
+    color: #888;
+    cursor: not-allowed;
+    border-style: dashed;
+  }
+
+  .custom-dropdown-list {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background: #fff;
+    border: 1px solid #d1d5db;
+    border-radius: 0 0 6px 6px;
+    box-shadow: 0 4px 16px rgba(105, 157, 140, 0.10);
+    z-index: 100;
+    max-height: 320px;
+    min-width: 180px;
+    overflow-y: auto;
+    margin-top: 2px;
+    padding-bottom: 4px;
+  }
+
+  .custom-dropdown-option {
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 0.845rem;
+    letter-spacing: 0px;
+    text-overflow: ellipsis;
+    transition: background 0.15s;
+  }
+
+  .custom-dropdown-option.selected {
+    background: #e3eafc;
+    color: #699d8c;
+    font-weight: bold;
+  }
+
+  .custom-dropdown-option:hover {
+    background: #f5f5f5;
+  }
+
+  .custom-dropdown-no-options {
+    padding: 8px 12px;
+    color: #888;
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .custom-dropdown-selected .dropdown-arrow {
+    font-size: 20px;
+    color: #bdbdbd;
+    margin-left: 8px;
+  }
+
+  .custom-dropdown-selected .placeholder {
+    color: var(--placeholder-color, #787878);
+  }
+
+  .custom-dropdown-list.open-up {
+    top: auto !important;
+    bottom: 100%;
+    border-radius: 6px 6px 0 0;
+    box-shadow: 0 -4px 16px rgba(105, 157, 140, 0.10);
+    margin-top: 0;
+    margin-bottom: 2px;
+  }
+
+  .field-component-loading {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    margin-bottom: 5px;
+  }
+
+  .loading-placeholder {
+    height: 34px;
+    background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+    background-size: 200% 100%;
+    animation: loading 1.5s infinite;
+    border-radius: 4px;
+    margin-top: 4px;
+  }
+
+  @keyframes loading {
+    0% {
+      background-position: 200% 0;
+    }
+
+    100% {
+      background-position: -200% 0;
+    }
+  }
+</style>

--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -703,7 +703,7 @@ export default {
             if (trigger && dropdown) {
               const scrollParent = this.getScrollParent(trigger);
               const triggerRect = trigger.getBoundingClientRect();
-              const dropdownHeight = 220; // max-height do dropdown
+          const dropdownHeight = 320; // max-height do dropdown
               let spaceBelow;
               if (scrollParent === document.body) {
                 spaceBelow = window.innerHeight - triggerRect.bottom;
@@ -1380,7 +1380,8 @@ export default {
     border-radius: 0 0 6px 6px;
     box-shadow: 0 4px 16px rgba(105, 157, 140, 0.10);
     z-index: 100;
-    max-height: 220px;
+    max-height: 320px;
+    min-width: 180px;
     overflow-y: auto;
     margin-top: 2px;
     padding-bottom: 4px;


### PR DESCRIPTION
## Summary
- align the FormBuilder FieldComponent markup and behaviours with FormRender, covering deadline countdowns, formatted text tooling, and shared validation feedback
- reuse the renderer’s styling tokens inside the builder so inputs share the same visual treatment and dropdown popups obey the 180px minimum width/320px maximum height limits
- update the FormRender dropdown height constant to match the new popup dimensions for consistent behaviour between components

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de65dc79808330a2b3b7bcf5dcbf32