### PR TITLE
Refactor form builder header to built-in layout

### DIFF
--- a/Project/FormBuilder/Component/AI.md
+++ b/Project/FormBuilder/Component/AI.md
@@ -25,6 +25,7 @@ This component provides a complete form building system that combines available 
 - Real-time state updates as fields are moved or modified
 - Field search functionality for available fields
 - Grid layout for available fields for better organization
+- Fixed form header with styled title input and empty select fields for priority, categories, assignment, and status
 - Sections can be dragged and reordered but cannot be nested within other sections
 - Sections cannot be dragged outside the form builder container
 - Action buttons are always visible when fields are in the form builder
@@ -39,7 +40,6 @@ This component provides a complete form building system that combines available 
 ***Properties:***
 - availableFieldsTitle: string - Custom heading for the available fields container
 - formBuilderTitle: string - Custom heading for the form builder container
-- cabecalhoHtml: string - HTML content displayed inside the form header
 - fieldsJson: string - JSON string containing field definitions
 - defaultFields: array - Default fields to show when no JSON is provided
 - formJson: string - JSON string containing form definition with sections

--- a/Project/FormBuilder/Component/ww-config.js
+++ b/Project/FormBuilder/Component/ww-config.js
@@ -54,22 +54,6 @@ export default {
         }
         /* wwEditor:end */
         },
-        cabecalhoHtml: {
-            label: { en: 'Header HTML' },
-            type: 'Text',
-            section: 'settings',
-            bindable: true,
-            defaultValue: '',
-            /* wwEditor:start */
-            bindingValidation: {
-            type: 'string',
-            tooltip: 'HTML content to display inside the form header'
-            },
-            propertyHelp: {
-            tooltip: 'Custom HTML markup for the header area of the form builder'
-            }
-            /* wwEditor:end */
-        },
         fieldsJson: {
         label: { en: 'Fields JSON' },
         type: 'Text',

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -53,9 +53,51 @@ v-for="field in filteredAvailableFields"
 
 <!-- Form Builder Section -->
 <div class="form-builder">
-<div v-if="content.showCabecalhoFormBuilder" class="cabecalhoFormBuilder" v-html="content.cabecalhoHtml">
-
-</div>
+    <div v-if="content.showCabecalhoFormBuilder" class="cabecalhoFormBuilder">
+      <div class="inputCabecalhoDiv">
+        <input
+          type="text"
+          class="inputCabecalho"
+          v-model="headerTitle"
+          :placeholder="translateText('Insert text')"
+        />
+      </div>
+      <div class="status-header-display">
+        <div class="status-tags">
+          <div class="tag-select-group">
+            <label class="tag-label">{{ translateText('Select priority') }}</label>
+            <select class="tag-select" v-model="headerPriority"></select>
+          </div>
+          <div class="tag-select-group">
+            <label class="tag-label">{{ translateText('Category') }}</label>
+            <select class="tag-select" v-model="headerCategory"></select>
+          </div>
+          <div class="tag-select-group">
+            <label class="tag-label">{{ translateText('Subcategory') }}</label>
+            <select class="tag-select" v-model="headerSubcategory"></select>
+          </div>
+          <div class="tag-select-group">
+            <label class="tag-label">{{ translateText('Third-level category') }}</label>
+            <select class="tag-select" v-model="headerThirdLevelCategory"></select>
+          </div>
+        </div>
+        <div class="status-user">
+          <div class="user-info">
+            <span class="user-icon">
+              <i class="material-symbols-outlined">{{ translateText('person') }}</i>
+            </span>
+            <div class="user-select-group">
+              <label class="user-label">{{ translateText('Assign') }}</label>
+              <select class="user-select" v-model="headerAssignee"></select>
+            </div>
+          </div>
+          <div class="status-select-group">
+            <label class="status-label-text">{{ translateText('Status') }}</label>
+            <select class="status-select" v-model="headerStatus"></select>
+          </div>
+        </div>
+      </div>
+    </div>
 <div style="display: flex; width:100%; justify-content:end; align-items:end; height:50px; padding:12px">
 <button 
 v-if="!isEditing" 
@@ -210,6 +252,15 @@ const isNewSection = ref(false);
 const searchQuery = ref('');
 const selectedFieldForProperties = ref(null);
 const forceUpdate = ref(0);
+
+// Form header state
+const headerTitle = ref('');
+const headerPriority = ref('');
+const headerCategory = ref('');
+const headerSubcategory = ref('');
+const headerThirdLevelCategory = ref('');
+const headerAssignee = ref('');
+const headerStatus = ref('');
 
 // Track used field IDs to disable them in the available fields list
 const usedFieldIds = computed(() => {
@@ -1248,6 +1299,13 @@ onRemoveField,
 handleRemoveSection,
 updateFieldInUse,
 orderedSections,
+headerTitle,
+headerPriority,
+headerCategory,
+headerSubcategory,
+headerThirdLevelCategory,
+headerAssignee,
+headerStatus,
 translateText,
 showTranslatedMessage,
 handleFieldValueChange
@@ -1583,14 +1641,34 @@ width: 255px;
   gap: 8px;
 }
 
-:deep(.tag) {
+:deep(.tag-select-group) {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 140px;
+}
+
+:deep(.tag-label) {
+  font-size: 12px;
+  color: #5f6368;
+  font-weight: 500;
+}
+
+:deep(.tag-select) {
   border: 1px solid #c0c0c0;
   border-radius: 999px;
-  padding: 4px 12px;
+  padding: 6px 12px;
   background-color: #f7f8fa;
   color: #333;
-  white-space: nowrap;
   font-size: 13px;
+  appearance: none;
+  min-height: 32px;
+}
+
+:deep(.tag-select:focus) {
+  outline: none;
+  border-color: #5c74a4;
+  box-shadow: 0 0 0 2px rgba(92, 116, 164, 0.2);
 }
 
 :deep(.status-user) {
@@ -1605,6 +1683,36 @@ width: 255px;
   gap: 6px;
   color: #2f2f2f;
   font-size: 14px;
+}
+
+:deep(.user-select-group) {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+:deep(.user-label) {
+  font-size: 12px;
+  color: #5f6368;
+  font-weight: 500;
+}
+
+:deep(.user-select) {
+  border: 1px solid #c0c0c0;
+  border-radius: 999px;
+  padding: 6px 12px;
+  background-color: #f7f8fa;
+  color: #333;
+  font-size: 13px;
+  appearance: none;
+  min-width: 160px;
+  min-height: 32px;
+}
+
+:deep(.user-select:focus) {
+  outline: none;
+  border-color: #5c74a4;
+  box-shadow: 0 0 0 2px rgba(92, 116, 164, 0.2);
 }
 
 :deep(.user-icon) {
@@ -1626,6 +1734,35 @@ width: 255px;
   border-radius: 6px;
   font-size: 13px;
   font-weight: bold;
+}
+
+:deep(.status-select-group) {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+:deep(.status-label-text) {
+  font-size: 12px;
+  color: #5f6368;
+  font-weight: 500;
+}
+
+:deep(.status-select) {
+  border: 1px solid #c0c0c0;
+  border-radius: 999px;
+  padding: 6px 16px;
+  background-color: #5c74a4;
+  color: #fff;
+  font-size: 13px;
+  appearance: none;
+  min-width: 120px;
+  min-height: 32px;
+}
+
+:deep(.status-select:focus) {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(92, 116, 164, 0.2);
 }
 
 .debug-panel {

--- a/Project/FormBuilderCadastros/Component/AI.md
+++ b/Project/FormBuilderCadastros/Component/AI.md
@@ -25,6 +25,7 @@ This component provides a complete form building system that combines available 
 - Real-time state updates as fields are moved or modified
 - Field search functionality for available fields
 - Grid layout for available fields for better organization
+- Fixed form header with styled title input and empty select fields for priority, categories, assignment, and status
 - Sections can be dragged and reordered but cannot be nested within other sections
 - Sections cannot be dragged outside the form builder container
 - Action buttons are always visible when fields are in the form builder
@@ -39,7 +40,6 @@ This component provides a complete form building system that combines available 
 ***Properties:***
 - availableFieldsTitle: string - Custom heading for the available fields container
 - formBuilderTitle: string - Custom heading for the form builder container
-- cabecalhoHtml: string - HTML content displayed inside the form header
 - fieldsJson: string - JSON string containing field definitions
 - defaultFields: array - Default fields to show when no JSON is provided
 - formJson: string - JSON string containing form definition with sections

--- a/Project/FormBuilderCadastros/Component/ww-config.js
+++ b/Project/FormBuilderCadastros/Component/ww-config.js
@@ -54,22 +54,6 @@ export default {
         }
         /* wwEditor:end */
         },
-        cabecalhoHtml: {
-            label: { en: 'Header HTML' },
-            type: 'Text',
-            section: 'settings',
-            bindable: true,
-            defaultValue: '',
-            /* wwEditor:start */
-            bindingValidation: {
-            type: 'string',
-            tooltip: 'HTML content to display inside the form header'
-            },
-            propertyHelp: {
-            tooltip: 'Custom HTML markup for the header area of the form builder'
-            }
-            /* wwEditor:end */
-        },
         fieldsJson: {
         label: { en: 'Fields JSON' },
         type: 'Text',

--- a/Project/FormBuilderCadastros/Component/wwElement.vue
+++ b/Project/FormBuilderCadastros/Component/wwElement.vue
@@ -54,22 +54,6 @@ export default {
         }
         /* wwEditor:end */
         },
-        cabecalhoHtml: {
-            label: { en: 'Header HTML' },
-            type: 'Text',
-            section: 'settings',
-            bindable: true,
-            defaultValue: '',
-            /* wwEditor:start */
-            bindingValidation: {
-            type: 'string',
-            tooltip: 'HTML content to display inside the form header'
-            },
-            propertyHelp: {
-            tooltip: 'Custom HTML markup for the header area of the form builder'
-            }
-            /* wwEditor:end */
-        },
         fieldsJson: {
         label: { en: 'Fields JSON' },
         type: 'Text',


### PR DESCRIPTION
## Summary
- replace the dynamic HTML header slot with a fixed header layout containing the title field and empty select inputs for priority, categories, assignee, and status
- add component state to back the new header fields and refresh the accompanying styles to match the previous visual design
- remove the now-unused `cabecalhoHtml` property from the component configurations and update the documentation accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3bf5cf4a083308f8cc2c68f839f62