### PR TITLE
Honor FieldInUseOnForm while keeping existing selection logic

### DIFF
--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -424,21 +424,45 @@ const computeSelectWidthStyle = (value, fallbackLabel = '') => {
 
 // Track used field IDs to disable them in the available fields list
 const usedFieldIds = computed(() => {
-// Collect all field IDs that are currently used in the form
-const usedIds = new Set();
+  // Collect all field IDs that are currently used in the form
+  const usedIds = new Set();
 
-formSections.value.forEach(section => {
-if (section.fields && Array.isArray(section.fields)) {
-section.fields.forEach(field => {
-// Add the original field ID to the set of used IDs
-if (field.field_id) {
-usedIds.add(field.field_id);
-}
-});
-}
-});
+  const addIdToSet = (value) => {
+    if (value === undefined || value === null || value === '') {
+      return;
+    }
 
-return usedIds;
+    usedIds.add(value);
+
+    if (typeof value !== 'string') {
+      usedIds.add(String(value));
+    }
+  };
+
+  formSections.value.forEach(section => {
+    if (section.fields && Array.isArray(section.fields)) {
+      section.fields.forEach(field => {
+        // Add the original field ID to the set of used IDs
+        addIdToSet(field.field_id ?? field.fieldId ?? field.id ?? field.ID ?? field.Id);
+      });
+    }
+  });
+
+  availableFields.value.forEach(field => {
+    const rawFlag = field?.FieldInUseOnForm ?? field?.field_in_use_on_form ?? field?.fieldInUseOnForm;
+
+    const normalizedFlag =
+      rawFlag === true ||
+      rawFlag === 1 ||
+      rawFlag === '1' ||
+      (typeof rawFlag === 'string' && rawFlag.toLowerCase() === 'true');
+
+    if (normalizedFlag) {
+      addIdToSet(field.ID ?? field.Id ?? field.id ?? field.field_id ?? field.fieldId);
+    }
+  });
+
+  return usedIds;
 });
 
 // Computed


### PR DESCRIPTION
## Summary
- restore the original section-based used-field tracking so draggable selections behave as before
- extend the used identifiers set with fields flagged by FieldInUseOnForm, handling boolean and numeric markers

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e420aae8c4833099c538fb20bc5828