### PR TITLE
Fix runtime errors when loading FormBuilder data sources

### DIFF
--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -235,12 +235,19 @@
 
 <script>
 import CustomDatePicker from './CustomDatePicker.vue';
-import {
+import dataSourceUtils, {
   LIST_FIELD_TYPES,
   normalizeFieldDataSource,
   fetchDataSourceOptions,
-  hasFetchableDataSource
+  hasFetchableDataSource as rawHasFetchableDataSource
 } from '../utils/dataSource';
+
+const hasFetchableDataSource =
+  typeof rawHasFetchableDataSource === 'function'
+    ? rawHasFetchableDataSource
+    : typeof (dataSourceUtils && dataSourceUtils.hasFetchableDataSource) === 'function'
+      ? dataSourceUtils.hasFetchableDataSource.bind(dataSourceUtils)
+      : () => false;
 
 const TRUE_VALUES = new Set(['true', '1', 1, true, 'yes', 'sim']);
 const FALSE_VALUES = new Set(['false', '0', 0, false, 'no', 'nao', 'não']);

--- a/Project/FormBuilder/Component/components/FormSection.vue
+++ b/Project/FormBuilder/Component/components/FormSection.vue
@@ -62,12 +62,19 @@ v-for="field in sectionFields"
 import { computed, ref, onMounted, watch, nextTick } from 'vue';
 import Sortable from 'sortablejs';
 import DraggableField from './DraggableField.vue';
-import {
+import dataSourceUtils, {
   LIST_FIELD_TYPES,
   normalizeFieldDataSource,
   fetchDataSourceOptions,
-  hasFetchableDataSource
+  hasFetchableDataSource as rawHasFetchableDataSource
 } from '../utils/dataSource';
+
+const hasFetchableDataSource =
+  typeof rawHasFetchableDataSource === 'function'
+    ? rawHasFetchableDataSource
+    : typeof (dataSourceUtils && dataSourceUtils.hasFetchableDataSource) === 'function'
+      ? dataSourceUtils.hasFetchableDataSource.bind(dataSourceUtils)
+      : () => false;
 
 export default {
 name: 'FormSection',

--- a/Project/FormBuilder/Component/utils/dataSource.js
+++ b/Project/FormBuilder/Component/utils/dataSource.js
@@ -278,3 +278,15 @@ export function shouldLoadDataSource(field) {
   if (!field) return false;
   return LIST_FIELD_TYPES.includes(field.fieldType) && hasFetchableDataSource(field);
 }
+
+export default {
+  LIST_FIELD_TYPES,
+  normalizeFieldDataSource,
+  hasFetchableDataSource,
+  combineUrl,
+  extractArrayFromResponse,
+  mapOptionsFromData,
+  getPlatformContext,
+  fetchDataSourceOptions,
+  shouldLoadDataSource
+};


### PR DESCRIPTION
## Summary
- add a default export for the data source utility module so both default and named imports expose the helper functions
- safeguard FormBuilder components with a runtime fallback when resolving hasFetchableDataSource to avoid undefined access

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e503a1a07c8330bd503cbaca451a77