### PR TITLE
Preserve list field metadata when dragging into sections

### DIFF
--- a/Project/FormBuilder/Component/components/DraggableField.vue
+++ b/Project/FormBuilder/Component/components/DraggableField.vue
@@ -133,28 +133,47 @@ const el = document.querySelector(selector);
 
 if (el) {
 // Store a complete copy of the field data to ensure all properties are available during drag
-const fieldData = JSON.parse(JSON.stringify(props.field));
+        const fieldData = JSON.parse(JSON.stringify(props.field));
 
-// Make sure the field data has all required properties
-fieldData.ID = fieldData.ID || fieldData.field_id;
-fieldData.Name = fieldData.Name || 'Unnamed Field';
-fieldData.fieldType = fieldData.fieldType || 'text';
-fieldData.columns = parseInt(fieldData.columns) || 1;
+        // Make sure the field data has all required properties
+        const normalizedId =
+          fieldData.ID || fieldData.id || fieldData.field_id || fieldData.FieldId;
+        const normalizedFieldId =
+          fieldData.field_id || fieldData.FieldId || normalizedId || fieldData.id;
+        const normalizedName =
+          fieldData.Name || fieldData.name || fieldData.Title || 'Unnamed Field';
+        const normalizedFieldType =
+          fieldData.fieldType || fieldData.FieldType || fieldData.type || 'text';
+        const normalizedColumns =
+          parseInt(fieldData.columns ?? fieldData.Columns ?? 1, 10) || 1;
 
-// Store the data on the element
-el.__draggableField__ = fieldData;
+        fieldData.ID = normalizedId;
+        fieldData.id = fieldData.id || normalizedId;
+        fieldData.field_id = normalizedFieldId;
+        fieldData.FieldId = fieldData.FieldId || normalizedFieldId;
+        fieldData.Name = normalizedName;
+        fieldData.name = fieldData.name || normalizedName;
+        fieldData.fieldType = normalizedFieldType;
+        fieldData.FieldType = fieldData.FieldType || normalizedFieldType;
+        fieldData.columns = normalizedColumns;
+        fieldData.Columns = fieldData.Columns || normalizedColumns;
 
-// Add a unique identifier to help with drag operations
-el.setAttribute('data-unique-id', uniqueId);
+        // Store the data on the element
+        el.__draggableField__ = fieldData;
 
-// Ensure all necessary data attributes are set
-el.dataset.fieldId = fieldData.ID;
-el.dataset.fieldType = fieldData.fieldType;
-el.dataset.fieldName = fieldData.Name;
-el.dataset.columns = fieldData.columns;
-} else {
-console.warn('Element not found for selector:', selector);
-}
+        // Add a unique identifier to help with drag operations
+        el.setAttribute('data-unique-id', uniqueId);
+
+        // Ensure all necessary data attributes are set
+        if (normalizedId) {
+          el.dataset.fieldId = normalizedId;
+        }
+        el.dataset.fieldType = normalizedFieldType;
+        el.dataset.fieldName = normalizedName;
+        el.dataset.columns = String(normalizedColumns);
+      } else {
+        console.warn('Element not found for selector:', selector);
+      }
 } catch (error) {
 console.error('Error setting draggable field data:', error);
 }

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -531,23 +531,54 @@ if (!evt || !evt.item) return;
 
 try {
 const originalFieldEl = evt.item;
-const originalField = originalFieldEl.__draggableField__;
+          const originalField = originalFieldEl.__draggableField__;
 
-if (originalField) {
-const clonedField = JSON.parse(JSON.stringify(originalField));
-clonedField.id = null;
-clonedField.field_id = originalField.ID;
+          if (originalField) {
+            const clonedField = JSON.parse(JSON.stringify(originalField));
+            const normalizedFieldId =
+              originalField.field_id ||
+              originalField.FieldId ||
+              originalField.ID ||
+              originalField.id ||
+              null;
+            const normalizedFieldType =
+              originalField.fieldType ||
+              originalField.FieldType ||
+              originalField.type ||
+              'text';
+            const normalizedName =
+              originalField.name ||
+              originalField.Name ||
+              originalField.title ||
+              'Unnamed Field';
+            const normalizedColumns =
+              parseInt(
+                originalField.columns ?? originalField.Columns ?? originalField.colspan ?? 1,
+                10
+              ) || 1;
 
-if (evt.clone) {
-evt.clone.__draggableField__ = clonedField;
+            clonedField.id = null;
+            clonedField.field_id = normalizedFieldId;
+            clonedField.FieldId = clonedField.FieldId || normalizedFieldId;
+            clonedField.fieldType = normalizedFieldType;
+            clonedField.FieldType = clonedField.FieldType || normalizedFieldType;
+            clonedField.name = clonedField.name || normalizedName;
+            clonedField.Name = clonedField.Name || normalizedName;
+            clonedField.columns = normalizedColumns;
+            clonedField.Columns = clonedField.Columns || normalizedColumns;
 
-evt.clone.dataset.fieldId = clonedField.field_id;
-evt.clone.dataset.fieldType = clonedField.fieldType || 'text';
-evt.clone.dataset.fieldName = clonedField.name;
-evt.clone.dataset.columns = clonedField.columns || '1';
+            if (evt.clone) {
+              evt.clone.__draggableField__ = clonedField;
 
-evt.clone.setAttribute('data-unique-id', `field-${clonedField.field_id}-${Date.now()}`);
-}
+              if (normalizedFieldId != null) {
+                evt.clone.dataset.fieldId = normalizedFieldId;
+              }
+              evt.clone.dataset.fieldType = normalizedFieldType;
+              evt.clone.dataset.fieldName = normalizedName;
+              evt.clone.dataset.columns = String(normalizedColumns);
+
+              evt.clone.setAttribute('data-unique-id', `field-${clonedField.field_id}-${Date.now()}`);
+            }
 
 // Encontra a seção de destino
 const targetSection = evt.to.closest('.form-section');
@@ -573,30 +604,59 @@ firstSection.fields.push(clonedField);
 
 updateFormState();
 
-const index = availableFields.value.findIndex(f => f.ID === originalField.ID);
-if (index !== -1) {
-availableFields.value.splice(index, 1);
-}
+            const sourceFieldId =
+              normalizedFieldId ||
+              originalField.ID ||
+              originalField.id ||
+              originalField.field_id ||
+              originalField.FieldId ||
+              null;
+            if (sourceFieldId != null) {
+              const index = availableFields.value.findIndex(candidate => {
+                const candidateId =
+                  candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+                return candidateId != null && String(candidateId) === String(sourceFieldId);
+              });
+              if (index !== -1) {
+                availableFields.value.splice(index, 1);
+              }
+            }
 } else {
 
 const fieldId = originalFieldEl.dataset.fieldId;
-if (fieldId && evt.clone) {
-Object.keys(originalFieldEl.dataset).forEach(key => {
-evt.clone.dataset[key] = originalFieldEl.dataset[key];
-});
+            if (fieldId && evt.clone) {
+              Object.keys(originalFieldEl.dataset).forEach(key => {
+                evt.clone.dataset[key] = originalFieldEl.dataset[key];
+              });
 
-evt.clone.__draggableField__ = {
-ID: fieldId,
-field_id: fieldId,
-name: originalFieldEl.dataset.fieldName || 'Unnamed Field',
-fieldType: originalFieldEl.dataset.fieldType || 'text',
-columns: parseInt(originalFieldEl.dataset.columns || '1'),
-is_mandatory: false,
-is_readonly: false,
-is_hide_legend: false
-};
-}
-}
+              const fallbackFieldType =
+                originalFieldEl.dataset.fieldType ||
+                originalFieldEl.__draggableField__?.fieldType ||
+                originalFieldEl.__draggableField__?.FieldType ||
+                'text';
+              const fallbackName =
+                originalFieldEl.dataset.fieldName ||
+                originalFieldEl.__draggableField__?.name ||
+                originalFieldEl.__draggableField__?.Name ||
+                'Unnamed Field';
+              const fallbackColumns = parseInt(originalFieldEl.dataset.columns || '1', 10) || 1;
+
+              evt.clone.__draggableField__ = {
+                ID: fieldId,
+                field_id: fieldId,
+                FieldId: fieldId,
+                name: fallbackName,
+                Name: fallbackName,
+                fieldType: fallbackFieldType,
+                FieldType: fallbackFieldType,
+                columns: fallbackColumns,
+                Columns: fallbackColumns,
+                is_mandatory: false,
+                is_readonly: false,
+                is_hide_legend: false
+              };
+            }
+          }
 
 } catch (error) {
 alert('Error in onClone handler:', error);
@@ -748,8 +808,169 @@ const initFieldsContainers = () => {
 
           if (originalField) {
             const clonedField = JSON.parse(JSON.stringify(originalField));
+            const normalizedFieldId =
+              originalField.field_id ||
+              originalField.FieldId ||
+              originalField.ID ||
+              originalField.id ||
+              null;
+            const normalizedFieldType =
+              originalField.fieldType ||
+              originalField.FieldType ||
+              originalField.type ||
+              'text';
+            const normalizedName =
+              originalField.name ||
+              originalField.Name ||
+              originalField.title ||
+              'Unnamed Field';
+            const normalizedColumns =
+              parseInt(
+                originalField.columns ?? originalField.Columns ?? originalField.colspan ?? 1,
+                10
+              ) || 1;
+
             clonedField.id = null;
-            clonedField.field_id = originalField.ID;
+            clonedField.field_id = normalizedFieldId;
+            clonedField.FieldId = clonedField.FieldId || normalizedFieldId;
+            clonedField.fieldType = normalizedFieldType;
+            clonedField.FieldType = clonedField.FieldType || normalizedFieldType;
+            clonedField.name = clonedField.name || normalizedName;
+            clonedField.Name = clonedField.Name || normalizedName;
+            clonedField.columns = normalizedColumns;
+            clonedField.Columns = clonedField.Columns || normalizedColumns;
+
+            const extractRawOptions = source => {
+              if (!source || typeof source !== 'object') {
+                return null;
+              }
+
+              if (
+                Object.prototype.hasOwnProperty.call(source, 'list_options') ||
+                Object.prototype.hasOwnProperty.call(source, 'listOptions') ||
+                Object.prototype.hasOwnProperty.call(source, 'ListOptions')
+              ) {
+                return (
+                  source.list_options ??
+                  source.listOptions ??
+                  source.ListOptions ??
+                  null
+                );
+              }
+
+              return null;
+            };
+
+            const toOptionObject = option => {
+              if (option == null) {
+                return null;
+              }
+
+              if (typeof option !== 'object') {
+                const label = String(option);
+                return { value: option, label };
+              }
+
+              const value =
+                option.value ??
+                option.Value ??
+                option.id ??
+                option.ID ??
+                option.key ??
+                option.Key ??
+                option.slug ??
+                option.Slug ??
+                null;
+
+              const label =
+                option.label ??
+                option.Label ??
+                option.name ??
+                option.Name ??
+                (value != null ? String(value) : null);
+
+              if (value == null && label == null) {
+                return null;
+              }
+
+              return {
+                value: value == null ? label : value,
+                label: label == null ? String(value) : String(label)
+              };
+            };
+
+            const normalizeOptions = rawOptions => {
+              if (rawOptions == null) {
+                return [];
+              }
+
+              if (Array.isArray(rawOptions)) {
+                return rawOptions
+                  .map(toOptionObject)
+                  .filter(option => option !== null)
+                  .map(option => ({ ...option }));
+              }
+
+              if (typeof rawOptions === 'string') {
+                const trimmed = rawOptions.trim();
+                if (!trimmed) {
+                  return [];
+                }
+
+                try {
+                  const parsed = JSON.parse(trimmed);
+                  if (Array.isArray(parsed)) {
+                    return parsed
+                      .map(toOptionObject)
+                      .filter(option => option !== null)
+                      .map(option => ({ ...option }));
+                  }
+                } catch (error) {
+                  // Ignore JSON parse error and fallback to comma separated values
+                }
+
+                return trimmed
+                  .split(',')
+                  .map(value => value.trim())
+                  .filter(value => value.length > 0)
+                  .map(value => ({ value, label: value }));
+              }
+
+              if (typeof rawOptions === 'object') {
+                const option = toOptionObject(rawOptions);
+                return option ? [{ ...option }] : [];
+              }
+
+              return [];
+            };
+
+            const rawOptionsFromField =
+              originalField.list_options ??
+              originalField.listOptions ??
+              originalField.ListOptions ??
+              null;
+
+            const rawOptionsFromDataSource = extractRawOptions(
+              originalField.dataSource ?? originalField.DataSource ?? null
+            );
+
+            const normalizedOptions = normalizeOptions(
+              rawOptionsFromField != null ? rawOptionsFromField : rawOptionsFromDataSource
+            );
+
+            if (normalizedOptions.length) {
+              const clonedOptions = normalizedOptions.map(option => ({ ...option }));
+              clonedField.options = clonedOptions;
+              clonedField.list_options = clonedOptions.map(option => ({ ...option }));
+              clonedField.listOptions = clonedOptions.map(option => ({ ...option }));
+            }
+
+            const normalizedDataSource =
+              originalField.dataSource ?? originalField.DataSource ?? null;
+            if (normalizedDataSource) {
+              clonedField.dataSource = normalizedDataSource;
+              clonedField.DataSource = normalizedDataSource;
+            }
 
             if (!section.fields) {
               section.fields = [];
@@ -770,9 +991,22 @@ const initFieldsContainers = () => {
 
             updateFormState();
 
-            const index = availableFields.value.findIndex(f => f.ID === originalField.ID);
-            if (index !== -1) {
-              availableFields.value.splice(index, 1);
+            const sourceFieldId =
+              normalizedFieldId ||
+              originalField.ID ||
+              originalField.id ||
+              originalField.field_id ||
+              originalField.FieldId ||
+              null;
+            if (sourceFieldId != null) {
+              const index = availableFields.value.findIndex(candidate => {
+                const candidateId =
+                  candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+                return candidateId != null && String(candidateId) === String(sourceFieldId);
+              });
+              if (index !== -1) {
+                availableFields.value.splice(index, 1);
+              }
             }
           }
         } catch (error) {
@@ -992,7 +1226,11 @@ field.columns = Math.min(Math.max(parseInt(field.columns) || 1, 1), 4);
 if (isNewField.value) {
 availableFields.value.push(field);
 } else {
-const index = availableFields.value.findIndex(f => f.ID === field.ID);
+const index = availableFields.value.findIndex(candidate => {
+  const candidateId = candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+  const fieldId = field.ID || field.id || field.field_id || field.FieldId;
+  return candidateId != null && fieldId != null && String(candidateId) === String(fieldId);
+});
 if (index !== -1) {
 availableFields.value[index] = field;
 }
@@ -1001,7 +1239,11 @@ updateFieldsState();
 };
 
 const removeAvailableField = (field) => {
-const index = availableFields.value.findIndex(f => f.ID === field.ID);
+const index = availableFields.value.findIndex(candidate => {
+  const candidateId = candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+  const fieldId = field.ID || field.id || field.field_id || field.FieldId;
+  return candidateId != null && fieldId != null && String(candidateId) === String(fieldId);
+});
 if (index !== -1) {
 availableFields.value.splice(index, 1);
 updateFieldsState();
@@ -1112,18 +1354,42 @@ if (fieldIndex === -1) {
 const removedField = section.fields.splice(fieldIndex, 1)[0];
 
 // Adicionar o campo de volta à lista de campos disponíveis
+const normalizedFieldId =
+  removedField.field_id ||
+  removedField.FieldId ||
+  removedField.ID ||
+  removedField.id ||
+  null;
+const normalizedFieldName =
+  removedField.Name ||
+  removedField.name ||
+  removedField.title ||
+  'Unnamed Field';
+const normalizedFieldType =
+  removedField.fieldType ||
+  removedField.FieldType ||
+  removedField.type ||
+  'text';
+const normalizedColumns =
+  parseInt(removedField.columns ?? removedField.Columns ?? 1, 10) || 1;
+
 const fieldToAdd = {
-  ID: removedField.field_id || removedField.ID,
-  Name: removedField.Name || removedField.name,
-  fieldType: removedField.fieldType || 'text',
-  columns: parseInt(removedField.columns) || 1,
+  ID: normalizedFieldId,
+  Name: normalizedFieldName,
+  fieldType: normalizedFieldType,
+  FieldType: normalizedFieldType,
+  columns: normalizedColumns,
+  Columns: normalizedColumns,
   is_mandatory: Boolean(removedField.is_mandatory),
   is_readonly: Boolean(removedField.is_readonly),
   is_hide_legend: Boolean(removedField.is_hide_legend)
 };
 
 // Verificar se o campo já existe na lista de campos disponíveis
-const existingFieldIndex = availableFields.value.findIndex(f => f.ID === fieldToAdd.ID);
+const existingFieldIndex = availableFields.value.findIndex(f => {
+  const candidateId = f.ID || f.id || f.field_id || f.FieldId;
+  return candidateId != null && fieldToAdd.ID != null && String(candidateId) === String(fieldToAdd.ID);
+});
 
 if (existingFieldIndex === -1) {
   availableFields.value.push(fieldToAdd);


### PR DESCRIPTION
## Summary
- normalize dragged field metadata so IDs, names, types, and column sizes persist when cloning
- use consistent ID comparisons when removing or restoring fields to keep list field options intact after drops

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e516b83e98833090cc2af41c9de121