### PR TITLE
Fix list field metadata during drag-and-drop

### DIFF
--- a/Project/FormBuilder/Component/components/DraggableField.vue
+++ b/Project/FormBuilder/Component/components/DraggableField.vue
@@ -132,28 +132,41 @@ const selector = `[data-field-id="${fieldId}"][data-section-field-id="${sectionF
 const el = document.querySelector(selector);
 
 if (el) {
-// Store a complete copy of the field data to ensure all properties are available during drag
-const fieldData = JSON.parse(JSON.stringify(props.field));
+  // Store a complete copy of the field data to ensure all properties are available during drag
+  const fieldData = JSON.parse(JSON.stringify(props.field));
 
-// Make sure the field data has all required properties
-fieldData.ID = fieldData.ID || fieldData.field_id;
-fieldData.Name = fieldData.Name || 'Unnamed Field';
-fieldData.fieldType = fieldData.fieldType || 'text';
-fieldData.columns = parseInt(fieldData.columns) || 1;
+  // Make sure the field data has all required properties without
+  // overriding any existing metadata that may contain list options
+  // or data source information.
+  const normalizedId = fieldData.ID || fieldData.id || fieldData.field_id;
+  const normalizedName = fieldData.Name || fieldData.name || 'Unnamed Field';
+  const normalizedFieldType = fieldData.fieldType || fieldData.FieldType || 'text';
+  const normalizedColumns = parseInt(fieldData.columns ?? fieldData.Columns, 10) || 1;
 
-// Store the data on the element
-el.__draggableField__ = fieldData;
+  fieldData.ID = normalizedId;
+  fieldData.id = fieldData.id || normalizedId;
+  fieldData.field_id = fieldData.field_id || normalizedId;
+  fieldData.FieldId = fieldData.FieldId || fieldData.field_id;
+  fieldData.Name = normalizedName;
+  fieldData.name = fieldData.name || normalizedName;
+  fieldData.fieldType = normalizedFieldType;
+  fieldData.FieldType = fieldData.FieldType || normalizedFieldType;
+  fieldData.columns = normalizedColumns;
+  fieldData.Columns = fieldData.Columns || normalizedColumns;
 
-// Add a unique identifier to help with drag operations
-el.setAttribute('data-unique-id', uniqueId);
+  // Store the data on the element
+  el.__draggableField__ = fieldData;
 
-// Ensure all necessary data attributes are set
-el.dataset.fieldId = fieldData.ID;
-el.dataset.fieldType = fieldData.fieldType;
-el.dataset.fieldName = fieldData.Name;
-el.dataset.columns = fieldData.columns;
+  // Add a unique identifier to help with drag operations
+  el.setAttribute('data-unique-id', uniqueId);
+
+  // Ensure all necessary data attributes are set
+  el.dataset.fieldId = String(fieldData.field_id || fieldData.ID || '');
+  el.dataset.fieldType = fieldData.fieldType;
+  el.dataset.fieldName = fieldData.Name;
+  el.dataset.columns = String(fieldData.columns);
 } else {
-console.warn('Element not found for selector:', selector);
+  console.warn('Element not found for selector:', selector);
 }
 } catch (error) {
 console.error('Error setting draggable field data:', error);


### PR DESCRIPTION
## Summary
- preserve full list field metadata when storing draggable field data so options and data sources remain intact during drag operations
- deep clone available field definitions when cloning into sections and keep SIMPLE_LIST options synchronised while updating available field state
- restore removed list fields to the available palette with their original metadata so they can be re-used without losing list values

## Testing
- npm install *(fails: registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e516b83e98833090cc2af41c9de121