### PR TITLE
Cache field definitions to retain list metadata

### DIFF
--- a/Project/FormBuilder/Component/components/DraggableField.vue
+++ b/Project/FormBuilder/Component/components/DraggableField.vue
@@ -132,28 +132,41 @@ const selector = `[data-field-id="${fieldId}"][data-section-field-id="${sectionF
 const el = document.querySelector(selector);
 
 if (el) {
-// Store a complete copy of the field data to ensure all properties are available during drag
-const fieldData = JSON.parse(JSON.stringify(props.field));
+  // Store a complete copy of the field data to ensure all properties are available during drag
+  const fieldData = JSON.parse(JSON.stringify(props.field));
 
-// Make sure the field data has all required properties
-fieldData.ID = fieldData.ID || fieldData.field_id;
-fieldData.Name = fieldData.Name || 'Unnamed Field';
-fieldData.fieldType = fieldData.fieldType || 'text';
-fieldData.columns = parseInt(fieldData.columns) || 1;
+  // Make sure the field data has all required properties without
+  // overriding any existing metadata that may contain list options
+  // or data source information.
+  const normalizedId = fieldData.ID || fieldData.id || fieldData.field_id;
+  const normalizedName = fieldData.Name || fieldData.name || 'Unnamed Field';
+  const normalizedFieldType = fieldData.fieldType || fieldData.FieldType || 'text';
+  const normalizedColumns = parseInt(fieldData.columns ?? fieldData.Columns, 10) || 1;
 
-// Store the data on the element
-el.__draggableField__ = fieldData;
+  fieldData.ID = normalizedId;
+  fieldData.id = fieldData.id || normalizedId;
+  fieldData.field_id = fieldData.field_id || normalizedId;
+  fieldData.FieldId = fieldData.FieldId || fieldData.field_id;
+  fieldData.Name = normalizedName;
+  fieldData.name = fieldData.name || normalizedName;
+  fieldData.fieldType = normalizedFieldType;
+  fieldData.FieldType = fieldData.FieldType || normalizedFieldType;
+  fieldData.columns = normalizedColumns;
+  fieldData.Columns = fieldData.Columns || normalizedColumns;
 
-// Add a unique identifier to help with drag operations
-el.setAttribute('data-unique-id', uniqueId);
+  // Store the data on the element
+  el.__draggableField__ = fieldData;
 
-// Ensure all necessary data attributes are set
-el.dataset.fieldId = fieldData.ID;
-el.dataset.fieldType = fieldData.fieldType;
-el.dataset.fieldName = fieldData.Name;
-el.dataset.columns = fieldData.columns;
+  // Add a unique identifier to help with drag operations
+  el.setAttribute('data-unique-id', uniqueId);
+
+  // Ensure all necessary data attributes are set
+  el.dataset.fieldId = String(fieldData.field_id || fieldData.ID || '');
+  el.dataset.fieldType = fieldData.fieldType;
+  el.dataset.fieldName = fieldData.Name;
+  el.dataset.columns = String(fieldData.columns);
 } else {
-console.warn('Element not found for selector:', selector);
+  console.warn('Element not found for selector:', selector);
 }
 } catch (error) {
 console.error('Error setting draggable field data:', error);

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -283,6 +283,7 @@ const cloneDeep = (value) => {
 // State
 const availableFields = ref([]);
 const formSections = ref([]);
+const fieldDefinitionCache = new Map();
 const availableFieldsContainer = ref(null);
 const formSectionsContainer = ref(null);
 const fieldModalVisible = ref(false);
@@ -294,6 +295,66 @@ const isNewSection = ref(false);
 const searchQuery = ref('');
 const selectedFieldForProperties = ref(null);
 const forceUpdate = ref(0);
+
+const cloneFieldDefinition = (field) => {
+  if (!field || typeof field !== 'object') {
+    return null;
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(field));
+  } catch (error) {
+    console.warn('Failed to clone field definition for cache', error);
+    return { ...field };
+  }
+};
+
+const getFieldCacheKey = (field) => {
+  if (!field || typeof field !== 'object') {
+    return null;
+  }
+
+  const rawId =
+    field.ID ||
+    field.id ||
+    field.field_id ||
+    field.FieldId ||
+    null;
+
+  if (rawId == null) {
+    return null;
+  }
+
+  return String(rawId);
+};
+
+const rememberFieldDefinition = (field) => {
+  const cacheKey = getFieldCacheKey(field);
+  if (!cacheKey) {
+    return;
+  }
+
+  const cloned = cloneFieldDefinition(field);
+  if (cloned) {
+    fieldDefinitionCache.set(cacheKey, cloned);
+  }
+};
+
+const rememberFieldDefinitions = (fields) => {
+  if (!Array.isArray(fields)) {
+    return;
+  }
+
+  fields.forEach(field => rememberFieldDefinition(field));
+};
+
+const getCachedFieldDefinition = (fieldId) => {
+  if (fieldId == null) {
+    return null;
+  }
+
+  return fieldDefinitionCache.get(String(fieldId)) || null;
+};
 
 // Form header state
 const headerTitle = ref('');
@@ -526,83 +587,70 @@ if (evt && evt.item && evt.item.parentNode) {
 updateFormState();
 }
 },
-onClone: (evt) => {
-if (!evt || !evt.item) return;
+      onClone: (evt) => {
+        if (!evt || !evt.item || !evt.clone) {
+          return;
+        }
 
-try {
-const originalFieldEl = evt.item;
-const originalField = originalFieldEl.__draggableField__;
+        try {
+          const originalFieldEl = evt.item;
+          const elementFieldId = originalFieldEl.dataset?.fieldId || null;
+          const storedField = originalFieldEl.__draggableField__ || null;
 
-if (originalField) {
-const clonedField = JSON.parse(JSON.stringify(originalField));
-clonedField.id = null;
-clonedField.field_id = originalField.ID;
+          const findFieldById = (id) => {
+            if (!id) return null;
+            return (
+              availableFields.value.find(candidate => {
+                const candidateId =
+                  candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+                return candidateId != null && String(candidateId) === String(id);
+              }) || null
+            );
+          };
 
-if (evt.clone) {
-evt.clone.__draggableField__ = clonedField;
+          const sourceField = storedField || findFieldById(elementFieldId);
+          if (!sourceField) {
+            return;
+          }
 
-evt.clone.dataset.fieldId = clonedField.field_id;
-evt.clone.dataset.fieldType = clonedField.fieldType || 'text';
-evt.clone.dataset.fieldName = clonedField.name;
-evt.clone.dataset.columns = clonedField.columns || '1';
+          const clonedField = JSON.parse(JSON.stringify(sourceField));
 
-evt.clone.setAttribute('data-unique-id', `field-${clonedField.field_id}-${Date.now()}`);
-}
+          const normalizedId =
+            clonedField.field_id ||
+            clonedField.FieldId ||
+            clonedField.ID ||
+            clonedField.id ||
+            elementFieldId ||
+            null;
+          const normalizedName =
+            clonedField.Name || clonedField.name || clonedField.title || 'Unnamed Field';
+          const normalizedFieldType =
+            clonedField.fieldType || clonedField.FieldType || clonedField.type || 'text';
+          const normalizedColumns =
+            parseInt(clonedField.columns ?? clonedField.Columns ?? 1, 10) || 1;
 
-// Encontra a seção de destino
-const targetSection = evt.to.closest('.form-section');
-if (targetSection) {
-const sectionId = targetSection.querySelector('.section-title')?.dataset.sectionId;
-const section = formSections.value.find(s => s.id === sectionId);
-if (section) {
-if (!section.fields) {
-section.fields = [];
-}
+          clonedField.ID = normalizedId;
+          clonedField.id = clonedField.id || normalizedId;
+          clonedField.field_id = clonedField.field_id || normalizedId;
+          clonedField.FieldId = clonedField.FieldId || clonedField.field_id;
+          clonedField.Name = normalizedName;
+          clonedField.name = clonedField.name || normalizedName;
+          clonedField.fieldType = normalizedFieldType;
+          clonedField.FieldType = clonedField.FieldType || normalizedFieldType;
+          clonedField.columns = normalizedColumns;
+          clonedField.Columns = clonedField.Columns || normalizedColumns;
 
-// Adiciona o campo à seção
-section.fields.push(clonedField);
-} else if (formSections.value.length > 0) {
-// Fallback: adiciona à primeira seção se não encontrar a seção de destino
-const firstSection = formSections.value[0];
-if (!firstSection.fields) {
-firstSection.fields = [];
-}
-firstSection.fields.push(clonedField);
-}
-}
-
-updateFormState();
-
-const index = availableFields.value.findIndex(f => f.ID === originalField.ID);
-if (index !== -1) {
-availableFields.value.splice(index, 1);
-}
-} else {
-
-const fieldId = originalFieldEl.dataset.fieldId;
-if (fieldId && evt.clone) {
-Object.keys(originalFieldEl.dataset).forEach(key => {
-evt.clone.dataset[key] = originalFieldEl.dataset[key];
-});
-
-evt.clone.__draggableField__ = {
-ID: fieldId,
-field_id: fieldId,
-name: originalFieldEl.dataset.fieldName || 'Unnamed Field',
-fieldType: originalFieldEl.dataset.fieldType || 'text',
-columns: parseInt(originalFieldEl.dataset.columns || '1'),
-is_mandatory: false,
-is_readonly: false,
-is_hide_legend: false
-};
-}
-}
-
-} catch (error) {
-alert('Error in onClone handler:', error);
-}
-}
-});
+          evt.clone.__draggableField__ = clonedField;
+          evt.clone.dataset.fieldId = normalizedId != null ? String(normalizedId) : '';
+          evt.clone.dataset.fieldType = normalizedFieldType;
+          evt.clone.dataset.fieldName = normalizedName;
+          evt.clone.dataset.columns = String(normalizedColumns);
+          evt.clone.setAttribute('data-unique-id', `field-${normalizedId ?? 'temp'}-${Date.now()}`);
+        } catch (error) {
+          console.error('Error preparing cloned field metadata:', error);
+        }
+      }
+    });
 } else {
 }
 } catch (error) {
@@ -748,8 +796,110 @@ const initFieldsContainers = () => {
 
           if (originalField) {
             const clonedField = JSON.parse(JSON.stringify(originalField));
+            const normalizedSourceId =
+              originalField.field_id ||
+              originalField.FieldId ||
+              originalField.ID ||
+              originalField.id ||
+              originalFieldEl.dataset?.fieldId ||
+              null;
+            const cachedDefinition = getCachedFieldDefinition(normalizedSourceId);
+            if (cachedDefinition) {
+              let clonedCached;
+              try {
+                clonedCached = JSON.parse(JSON.stringify(cachedDefinition));
+              } catch (cacheError) {
+                console.warn('Failed to clone cached field definition', cacheError);
+                clonedCached = { ...cachedDefinition };
+              }
+
+              if (clonedField.dataSource == null && clonedCached) {
+                clonedField.dataSource = clonedCached.dataSource ?? clonedCached.DataSource ?? clonedField.dataSource;
+              }
+
+              if (clonedField.DataSource == null && clonedCached) {
+                clonedField.DataSource = clonedCached.DataSource ?? clonedCached.dataSource ?? clonedField.DataSource;
+              }
+
+              if (clonedField.list_options == null && clonedCached?.list_options != null) {
+                clonedField.list_options = Array.isArray(clonedCached.list_options)
+                  ? clonedCached.list_options.map(option =>
+                      option && typeof option === 'object' ? { ...option } : option
+                    )
+                  : clonedCached.list_options;
+              }
+
+              if (clonedField.listOptions == null && clonedCached?.listOptions != null) {
+                clonedField.listOptions = Array.isArray(clonedCached.listOptions)
+                  ? clonedCached.listOptions.map(option =>
+                      option && typeof option === 'object' ? { ...option } : option
+                    )
+                  : clonedCached.listOptions;
+              }
+
+              if (clonedField.options == null && clonedCached?.options != null) {
+                clonedField.options = Array.isArray(clonedCached.options)
+                  ? clonedCached.options.map(option =>
+                      option && typeof option === 'object' ? { ...option } : option
+                    )
+                  : clonedCached.options;
+              }
+
+              if (clonedField.default_value === undefined && clonedCached?.default_value !== undefined) {
+                clonedField.default_value = clonedCached.default_value;
+              }
+
+              if (clonedField.defaultValue === undefined && clonedCached?.defaultValue !== undefined) {
+                clonedField.defaultValue = clonedCached.defaultValue;
+              }
+
+              if (clonedField.value === undefined && clonedCached?.value !== undefined) {
+                clonedField.value = clonedCached.value;
+              }
+            }
+            const normalizedFieldType =
+              originalField.fieldType || originalField.FieldType || 'text';
+            const normalizedName =
+              originalField.Name || originalField.name || 'Unnamed Field';
+            const normalizedColumns =
+              parseInt(originalField.columns ?? originalField.Columns ?? 1, 10) || 1;
+
             clonedField.id = null;
-            clonedField.field_id = originalField.ID;
+            clonedField.ID = normalizedSourceId;
+            clonedField.field_id = normalizedSourceId;
+            clonedField.FieldId = originalField.FieldId || normalizedSourceId;
+            clonedField.fieldType = normalizedFieldType;
+            clonedField.FieldType = originalField.FieldType || normalizedFieldType;
+            clonedField.Name = normalizedName;
+            clonedField.name = originalField.name || normalizedName;
+            clonedField.columns = normalizedColumns;
+            clonedField.Columns = originalField.Columns || normalizedColumns;
+            if (clonedField.dataSource && !clonedField.DataSource) {
+              clonedField.DataSource = clonedField.dataSource;
+            }
+            if (clonedField.DataSource && !clonedField.dataSource) {
+              clonedField.dataSource = clonedField.DataSource;
+            }
+
+            // Preserve list options metadata for SIMPLE_LIST fields
+            if (
+              clonedField.fieldType === 'SIMPLE_LIST' &&
+              clonedField.list_options == null &&
+              clonedField.listOptions == null &&
+              Array.isArray(clonedField.options)
+            ) {
+              const optionsClone = clonedField.options.map(option => ({ ...option }));
+              clonedField.list_options = optionsClone;
+              clonedField.listOptions = optionsClone;
+            }
+
+            if (
+              clonedField.fieldType === 'SIMPLE_LIST' &&
+              clonedField.options == null &&
+              Array.isArray(clonedField.list_options)
+            ) {
+              clonedField.options = clonedField.list_options.map(option => ({ ...option }));
+            }
 
             if (!section.fields) {
               section.fields = [];
@@ -770,9 +920,18 @@ const initFieldsContainers = () => {
 
             updateFormState();
 
-            const index = availableFields.value.findIndex(f => f.ID === originalField.ID);
+            const index = availableFields.value.findIndex(candidate => {
+              const candidateId =
+                candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+              return (
+                candidateId != null &&
+                normalizedSourceId != null &&
+                String(candidateId) === String(normalizedSourceId)
+              );
+            });
             if (index !== -1) {
               availableFields.value.splice(index, 1);
+              updateFieldsState();
             }
           }
         } catch (error) {
@@ -896,6 +1055,7 @@ const loadFieldsData = () => {
     }
 
     availableFields.value = Array.isArray(data) ? data : [];
+    rememberFieldDefinitions(availableFields.value);
     setFieldsData(availableFields.value);
   } catch (error) {
     console.error('Error loading fields data:', error);
@@ -958,6 +1118,15 @@ if (typeof window !== 'undefined') {
 
 // Convert sections array to the format expected by the component
     formSections.value = cloneDeep(data.sections || []);
+    const formSectionFields = [];
+    formSections.value.forEach(section => {
+      if (section && Array.isArray(section.fields)) {
+        section.fields.forEach(field => {
+          formSectionFields.push(field);
+        });
+      }
+    });
+    rememberFieldDefinitions(formSectionFields);
     setFormData(cloneDeep(data));
   } catch (error) {
     console.error('Error loading form data:', error);
@@ -991,17 +1160,29 @@ field.columns = Math.min(Math.max(parseInt(field.columns) || 1, 1), 4);
 
 if (isNewField.value) {
 availableFields.value.push(field);
+rememberFieldDefinition(field);
 } else {
-const index = availableFields.value.findIndex(f => f.ID === field.ID);
+const index = availableFields.value.findIndex(candidate => {
+  const candidateId =
+    candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+  const fieldId = field.ID || field.id || field.field_id || field.FieldId;
+  return candidateId != null && fieldId != null && String(candidateId) === String(fieldId);
+});
 if (index !== -1) {
 availableFields.value[index] = field;
+rememberFieldDefinition(field);
 }
 }
 updateFieldsState();
 };
 
 const removeAvailableField = (field) => {
-const index = availableFields.value.findIndex(f => f.ID === field.ID);
+const index = availableFields.value.findIndex(candidate => {
+  const candidateId =
+    candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+  const fieldId = field.ID || field.id || field.field_id || field.FieldId;
+  return candidateId != null && fieldId != null && String(candidateId) === String(fieldId);
+});
 if (index !== -1) {
 availableFields.value.splice(index, 1);
 updateFieldsState();
@@ -1009,6 +1190,7 @@ updateFieldsState();
 };
 
 const updateFieldsState = () => {
+rememberFieldDefinitions(availableFields.value);
 setFieldsData([...availableFields.value]);
 emit('trigger-event', {
 name: 'fieldsUpdated',
@@ -1112,21 +1294,68 @@ if (fieldIndex === -1) {
 const removedField = section.fields.splice(fieldIndex, 1)[0];
 
 // Adicionar o campo de volta à lista de campos disponíveis
+const normalizedRemovedId =
+  removedField.field_id ||
+  removedField.FieldId ||
+  removedField.ID ||
+  removedField.id ||
+  null;
+
 const fieldToAdd = {
-  ID: removedField.field_id || removedField.ID,
+  ...JSON.parse(JSON.stringify(removedField)),
+  ID: normalizedRemovedId,
+  field_id: normalizedRemovedId,
+  FieldId: removedField.FieldId || normalizedRemovedId,
   Name: removedField.Name || removedField.name,
-  fieldType: removedField.fieldType || 'text',
-  columns: parseInt(removedField.columns) || 1,
-  is_mandatory: Boolean(removedField.is_mandatory),
-  is_readonly: Boolean(removedField.is_readonly),
-  is_hide_legend: Boolean(removedField.is_hide_legend)
+  name: removedField.name || removedField.Name,
+  fieldType: removedField.fieldType || removedField.FieldType || 'text',
+  FieldType: removedField.FieldType || removedField.fieldType || 'text',
+  columns: parseInt(removedField.columns ?? removedField.Columns ?? 1, 10) || 1,
+  Columns: removedField.Columns || parseInt(removedField.columns ?? 1, 10) || 1,
+  is_mandatory: Boolean(removedField.is_mandatory ?? removedField.IsMandatory),
+  is_readonly: Boolean(removedField.is_readonly ?? removedField.IsReadOnly),
+  is_hide_legend: Boolean(removedField.is_hide_legend ?? removedField.IsHideLegend)
 };
 
+if (fieldToAdd.dataSource && !fieldToAdd.DataSource) {
+  fieldToAdd.DataSource = fieldToAdd.dataSource;
+}
+if (fieldToAdd.DataSource && !fieldToAdd.dataSource) {
+  fieldToAdd.dataSource = fieldToAdd.DataSource;
+}
+
+if (
+  fieldToAdd.fieldType === 'SIMPLE_LIST' &&
+  Array.isArray(fieldToAdd.list_options) &&
+  !fieldToAdd.options
+) {
+  fieldToAdd.options = fieldToAdd.list_options.map(option => ({ ...option }));
+}
+
+if (
+  fieldToAdd.fieldType === 'SIMPLE_LIST' &&
+  !fieldToAdd.list_options &&
+  Array.isArray(fieldToAdd.options)
+) {
+  const optionsClone = fieldToAdd.options.map(option => ({ ...option }));
+  fieldToAdd.list_options = optionsClone;
+  fieldToAdd.listOptions = optionsClone;
+}
+
 // Verificar se o campo já existe na lista de campos disponíveis
-const existingFieldIndex = availableFields.value.findIndex(f => f.ID === fieldToAdd.ID);
+const existingFieldIndex = availableFields.value.findIndex(candidate => {
+  const candidateId =
+    candidate.ID || candidate.id || candidate.field_id || candidate.FieldId;
+  return (
+    candidateId != null &&
+    fieldToAdd.ID != null &&
+    String(candidateId) === String(fieldToAdd.ID)
+  );
+});
 
 if (existingFieldIndex === -1) {
   availableFields.value.push(fieldToAdd);
+  rememberFieldDefinition(fieldToAdd);
   updateFieldsState();
 }
 


### PR DESCRIPTION
## Summary
- cache deep copies of available field definitions and section fields to preserve list metadata
- refresh the cache whenever available fields change or form sections load so dropped list fields keep options and data sources
- hydrate dragged fields from the cached definitions before inserting them into sections to keep simple and controlled lists populated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e516b83e98833090cc2af41c9de121