### PR TITLE
Improve list field detection when adding fields to sections

### DIFF
--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -356,7 +356,10 @@ export default {
       return normalizeFieldDataSource(this.field);
     },
     isListField() {
-      return LIST_FIELD_TYPES.includes(this.field.fieldType);
+      const rawType =
+        this.field?.fieldType ?? this.field?.FieldType ?? this.field?.type ?? '';
+      const normalizedType = String(rawType).trim().toUpperCase();
+      return LIST_FIELD_TYPES.includes(normalizedType);
     },
     dropdownPlaceholder() {
       return (

--- a/Project/FormBuilder/Component/components/FormSection.vue
+++ b/Project/FormBuilder/Component/components/FormSection.vue
@@ -119,6 +119,16 @@ setup(props, { emit }) {
     const fieldOptionSignatureMap = new Map();
     const pendingDataSourceLoads = new Map();
 
+    const normalizeFieldType = type => String(type ?? '').trim().toUpperCase();
+    const getFieldTypeValue = field =>
+      field?.fieldType ?? field?.FieldType ?? field?.type ?? null;
+    const isListFieldType = candidate =>
+      LIST_FIELD_TYPES.includes(
+        normalizeFieldType(
+          typeof candidate === 'object' ? getFieldTypeValue(candidate) : candidate
+        )
+      );
+
     const getFieldKey = field => field?.id || field?.field_id || field?.ID || null;
 
     const getRawListOptionsCandidate = source => {
@@ -295,8 +305,9 @@ setup(props, { emit }) {
       }
 
       const resolvedDataSource = normalizedDataSource || normalizeFieldDataSource(field);
+      const normalizedFieldType = getFieldTypeValue(field);
 
-      if (!resolvedDataSource || !LIST_FIELD_TYPES.includes(field?.fieldType)) {
+      if (!resolvedDataSource || !isListFieldType(normalizedFieldType)) {
         fieldOptionSignatureMap.delete(fieldKey);
         pendingDataSourceLoads.delete(fieldKey);
         return undefined;
@@ -358,7 +369,7 @@ setup(props, { emit }) {
       () => (props.section.fields || []).map(field => ({
         key: getFieldKey(field),
         dataSource: normalizeFieldDataSource(field),
-        fieldType: field?.fieldType
+        fieldType: normalizeFieldType(getFieldTypeValue(field))
       })),
       descriptors => {
         const activeKeys = new Set();
@@ -376,7 +387,7 @@ setup(props, { emit }) {
             return;
           }
 
-          if (!dataSource || !LIST_FIELD_TYPES.includes(fieldType)) {
+          if (!dataSource || !isListFieldType(fieldType)) {
             fieldOptionSignatureMap.delete(key);
             pendingDataSourceLoads.delete(key);
             return;
@@ -690,6 +701,9 @@ setup(props, { emit }) {
                 : Array.isArray(clonedFieldData.Options)
                   ? normalizeOptionList(clonedFieldData.Options)
                   : null;
+              const normalizedFieldTypeValue = normalizeFieldType(
+                getFieldTypeValue(clonedFieldData) || 'text'
+              );
               const resolvedDefaultValue = clonedFieldData.default_value !== undefined
                 ? clonedFieldData.default_value
                 : clonedFieldData.defaultValue !== undefined
@@ -721,7 +735,9 @@ setup(props, { emit }) {
                 tip_translations: clonedFieldData.tip_translations || { [currentLang.value]: clonedFieldData.tip || '' },
                 deleted: false,
                 name: clonedFieldData.name || clonedFieldData.Name,
-                fieldType: clonedFieldData.fieldType || clonedFieldData.FieldType || 'text',
+                fieldType: normalizedFieldTypeValue,
+                FieldType: normalizedFieldTypeValue,
+                type: normalizedFieldTypeValue,
                 default_value: resolvedDefaultValue,
                 defaultValue: resolvedDefaultValue,
                 value: clonedFieldData.value !== undefined ? clonedFieldData.value : resolvedDefaultValue,

--- a/Project/FormBuilder/Component/utils/dataSource.js
+++ b/Project/FormBuilder/Component/utils/dataSource.js
@@ -4,8 +4,15 @@ export function normalizeFieldDataSource(fieldOrSource) {
   if (!fieldOrSource) return null;
 
   const rawDataSource =
-    fieldOrSource.dataSource !== undefined || fieldOrSource.DataSource !== undefined
-      ? fieldOrSource.dataSource ?? fieldOrSource.DataSource ?? null
+    fieldOrSource.dataSource !== undefined ||
+    fieldOrSource.DataSource !== undefined ||
+    fieldOrSource.data_source !== undefined ||
+    fieldOrSource.Data_Source !== undefined
+      ? fieldOrSource.dataSource ??
+        fieldOrSource.DataSource ??
+        fieldOrSource.data_source ??
+        fieldOrSource.Data_Source ??
+        null
       : fieldOrSource;
 
   if (!rawDataSource) return null;
@@ -274,15 +281,36 @@ export async function fetchDataSourceOptions(rawDataSource, context) {
   });
 }
 
+export function normalizeFieldType(value) {
+  return String(value ?? '').trim().toUpperCase();
+}
+
+export function getFieldType(field) {
+  if (!field || typeof field !== 'object') {
+    return null;
+  }
+
+  return (
+    field.fieldType ??
+    field.FieldType ??
+    field.type ??
+    field.Type ??
+    null
+  );
+}
+
 export function shouldLoadDataSource(field) {
   if (!field) return false;
-  return LIST_FIELD_TYPES.includes(field.fieldType) && hasFetchableDataSource(field);
+  const normalizedType = normalizeFieldType(getFieldType(field));
+  return LIST_FIELD_TYPES.includes(normalizedType) && hasFetchableDataSource(field);
 }
 
 export default {
   LIST_FIELD_TYPES,
   normalizeFieldDataSource,
   hasFetchableDataSource,
+  normalizeFieldType,
+  getFieldType,
   combineUrl,
   extractArrayFromResponse,
   mapOptionsFromData,


### PR DESCRIPTION
## Summary
- trim and normalize field type detection in the form section so list sources are recognised even when the type only exists as FieldType/type
- persist the normalized type on newly added fields so option preloaders and consumers can act on list fields immediately
- expand data source normalisation to accept additional casing variants and expose helpers for consistent list field checks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e599da22ec8330835906dcff6ebde8