### PR TITLE
Fix propagation of field value changes in FormBuilder

### DIFF
--- a/Project/FormBuilder/Component/components/DraggableField.vue
+++ b/Project/FormBuilder/Component/components/DraggableField.vue
@@ -21,7 +21,7 @@ class="draggable-field single-draggable"
 </div>
 
 <template v-if="showFieldComponent || isInFormSection">
-<FieldComponent :field="field" />
+  <FieldComponent :field="field" @field-value-change="onFieldValueChange" />
 </template>
 <template v-else>
 <i class="material-symbols-outlined" style="padding-right:10px; ">{{iconType}}</i>
@@ -75,7 +75,7 @@ type: Boolean,
 default: false
 }
 },
-emits: ['edit-field', 'remove-field', 'click'],
+emits: ['edit-field', 'remove-field', 'click', 'field-value-change'],
 setup(props, { emit }) {
 const fieldName = computed(() => {
 // Try to get the name from different possible properties
@@ -187,11 +187,16 @@ const onRemoveClick = (event) => {
   emit('remove-field', fieldToRemove);
 };
 
+const onFieldValueChange = (payload) => {
+  emit('field-value-change', payload);
+};
+
 return {
 fieldName,
 onFieldClick,
 iconType,
-onRemoveClick
+onRemoveClick,
+onFieldValueChange
 };
 }
 };


### PR DESCRIPTION
## Summary
- forward field value change events from DraggableField to its parent section
- ensure text inputs can persist default values by triggering the existing section handler

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68e6544463b0833088abc13bde206852