### PR TITLE
fix(anexosgenerico): regenerate signed URL when downloading attachments

### DIFF
--- a/Project/AnexosGenerico/src/wwElement.vue
+++ b/Project/AnexosGenerico/src/wwElement.vue
@@ -717,7 +717,7 @@ export default {
 
         const resolveFileUrl = async (file, { download = false } = {}) => {
             if (!file) return null;
-            if (file.url) return file.url;
+            if (!download && file.url) return file.url;
             const localFile = file instanceof File ? file : file?.file;
             if (localFile instanceof File) return URL.createObjectURL(localFile);
             const supabase = getSupabase();
@@ -728,11 +728,14 @@ export default {
             if (file?.isImage && !download) options.transform = { width: 400, resize: 'contain' };
             const { data, error } = await supabase.storage.from(bucket).createSignedUrl(storagePath, 3600, options);
             if (error) return null;
-            file.url = data?.signedUrl || null;
-            file.previewUrl = file.url;
+            const signedUrl = data?.signedUrl || null;
+            if (!download) {
+                file.url = signedUrl;
+                file.previewUrl = signedUrl;
+            }
             file.bucket = bucket;
             file.storagePath = storagePath;
-            return file.url;
+            return signedUrl;
         };
 
         const previewUnavailableMessage = computed(() => translatePhrase('Preview not available for this file type.'));


### PR DESCRIPTION
### Motivation
- Corrigir falhas no download de anexos não-imagem (ex: `.xls`) garantindo que o componente gere uma signed URL específica para download em vez de reutilizar uma URL de preview possivelmente expirada ou sem o parâmetro de `download`.

### Description
- Atualiza `resolveFileUrl` em `Project/AnexosGenerico/src/wwElement.vue` para só reutilizar `file.url` quando **não** for download, passar `options.download` ao criar a signed URL para downloads, não sobrescrever `file.url`/`file.previewUrl` durante o fluxo de download e retornar a `signedUrl` gerada.

### Testing
- Executados comandos automatizados de investigação e validação: pesquisa com `rg`, patch aplicado via script Python, inspeção do arquivo com `nl`/`sed`, verificação com `git status` e `git diff`, e commit com `git commit`, todos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce5bc954f083309ecc11d844d2e403)