### PR TITLE
feat(treeComponent): add action to clear selected node

### DIFF
--- a/Project/treeComponent/src/wwElement.vue
+++ b/Project/treeComponent/src/wwElement.vue
@@ -134,6 +134,9 @@ import { translatePhrase } from './translation';
             selectNodeById(id) {
                 this.selectNodeById(id);
             },
+            clearSelectedNode() {
+                this.clearSelectedNode();
+            },
         },
     },
     data() {
@@ -604,6 +607,11 @@ import { translatePhrase } from './translation';
                 if (!row) return;
                 this.onNodeClick(row);
             });
+        },
+        clearSelectedNode() {
+            this.contextNodeId = null;
+            this.selectedNodeId = null;
+            this.setSelectedItemId?.(null);
         },
         onNodeClick(row) {
         if (this.isEditingAnyNode && this.editingNodeId !== row?.id) {

--- a/Project/treeComponent/ww-config.js
+++ b/Project/treeComponent/ww-config.js
@@ -15,15 +15,20 @@ export default {
     },
     actions: [
         {
-            label: { en: 'Select node by ID' },
+            label: { en: 'Select node by ID', pt: 'Selecionar nó por ID' },
             action: 'selectNodeById',
             args: [
                 {
                     name: 'id',
                     type: 'text',
-                    label: { en: 'Node ID' },
+                    label: { en: 'Node ID', pt: 'ID do nó' },
                 },
             ],
+        },
+        {
+            label: { en: 'Clear selected node', pt: 'Limpar seleção do nó' },
+            action: 'clearSelectedNode',
+            args: [],
         },
     ],
     properties: {


### PR DESCRIPTION
### Motivation
- Expose a component action to programmatically clear the current tree selection so the component can be left with no node selected and any public selection variable is reset.

### Description
- Added a `clearSelectedNode` action to `wwEditor.actions` in `Project/treeComponent/src/wwElement.vue` that calls the new `clearSelectedNode()` method.
- Implemented `clearSelectedNode()` in `Project/treeComponent/src/wwElement.vue` to set `contextNodeId` and `selectedNodeId` to `null` and call the public setter `setSelectedItemId?.(null)`.
- Exposed the action in `Project/treeComponent/ww-config.js` with English and Portuguese labels and added PT translations for the existing `selectNodeById` action.

### Testing
- Ran repository checks with `git diff --check` which produced no issues.
- Verified the modified files (`Project/treeComponent/src/wwElement.vue` and `Project/treeComponent/ww-config.js`) were updated as intended and no lint/diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc30b8b64c8330af8e90ab6f7a7aec)