### PR TITLE
GridViewSimples: set Inter 12px as default font

### DIFF
--- a/Project/GridViewSimples/src/components/ActionCellRenderer.vue
+++ b/Project/GridViewSimples/src/components/ActionCellRenderer.vue
@@ -42,15 +42,18 @@ export default {
 }
 .datagrid-btn {
     background-color: var(--ww-data-grid_action-backgroundColor, unset);
+    font-family: "Inter", sans-serif;
+    font-size: 12px;
     color: var(--ww-data-grid_action-color, unset);
     padding: var(--ww-data-grid_action-padding, unset);
     border: var(--ww-data-grid_action-border, unset);
     &.with-font {
-        font: var(--ww-data-grid_action-font);
+        font-family: "Inter", sans-serif;
+        font-size: 12px;
     }
     &.without-font {
-        font-size: var(--ww-data-grid_action-fontSize);
-        font-family: var(--ww-data-grid_action-fontFamily);
+        font-size: var(--ww-data-grid_action-fontSize, 12px);
+        font-family: var(--ww-data-grid_action-fontFamily, "Inter", sans-serif);
         font-weight: var(--ww-data-grid_action-fontWeight);
         font-style: var(--ww-data-grid_action-fontStyle);
         line-height: var(--ww-data-grid_action-lineHeight, normal);

--- a/Project/GridViewSimples/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewSimples/src/components/DateTimeCellEditor.js
@@ -5,7 +5,8 @@ export default class DateTimeCellEditor {
     input.type = 'datetime-local';
     input.style.width = '100%';
     input.style.height = '100%';
-    input.style.fontSize = '13px';
+    input.style.fontSize = '12px';
+    input.style.fontFamily = 'Inter, sans-serif';
     input.style.borderRadius = '6px';
     input.style.padding = '4px';
 

--- a/Project/GridViewSimples/src/components/list-filter.css
+++ b/Project/GridViewSimples/src/components/list-filter.css
@@ -7,8 +7,8 @@
   border: 1px solid #ffffff;
   border-radius: 15px;
   box-shadow: 0 2px 8px rgba(255, 255, 255, 0.067);
-  font-size: 15px;
-  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
   overflow: hidden; /* Garante que nada "vaze" para fora da borda arredondada */
   position: relative;
 }
@@ -48,8 +48,8 @@
 .list-filter .filter-list,
 .list-filter .filter-item,
 .list-filter .filter-label {
-  font-family: Roboto, Arial, sans-serif;
-  font-size: 13px;
+  font-family: Inter, sans-serif;
+  font-size: 12px;
 }
 .list-filter .filter-header {
   margin-bottom: 10px;
@@ -64,8 +64,8 @@
   padding: 7px 36px 7px 13px;
   border: 1px solid #ddd;
   border-radius: 20px;
-  font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
   outline: none;
   background: #fff;
   color: #444;
@@ -74,8 +74,8 @@
 
 .list-filter .search-input::placeholder {
   color: #aaa;
-  font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
 }
 
 .list-filter .search-icon {
@@ -115,8 +115,8 @@
   margin-bottom: 12px;
   padding-bottom: 8px;
   border-bottom: 1px solid #e0e0e0;
-  font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
   color: #444;
   gap: 8px;
 }
@@ -152,8 +152,8 @@
   display: flex;
   align-items: center;
   padding: 6px 0 6px 0;
-  font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
   cursor: pointer;
   gap: 8px;
   border-radius: 8px;
@@ -196,8 +196,8 @@
   max-width: 180px;
   display: inline-block;
   color: #444;
-  font-size: 13px;
-  font-family: Roboto, Arial, sans-serif;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
 }
 .list-filter .filter-actions {
   display: flex;

--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -625,13 +625,13 @@ export default {
       return themeQuartz.withParams({
         headerBackgroundColor: this.content.headerBackgroundColor,
         headerTextColor: this.content.headerTextColor,
-        headerFontSize: this.content.headerFontSize,
-        headerFontFamily: this.content.headerFontFamily,
+        headerFontSize: "12px",
+        headerFontFamily: "Inter, sans-serif",
         headerFontWeight: this.content.headerFontWeight,
         borderColor: this.content.borderColor,
         cellTextColor: this.content.cellColor,
-        cellFontFamily: this.content.cellFontFamily,
-        dataFontSize: this.content.cellFontSize,
+        cellFontFamily: "Inter, sans-serif",
+        dataFontSize: "12px",
         oddRowBackgroundColor: this.content.rowAlternateColor,
         backgroundColor: this.content.rowBackgroundColor,
         rowHoverColor: this.content.rowHoverColor,
@@ -899,6 +899,18 @@ export default {
 
     /* wwEditor:end */
 
+
+    :deep(.ag-root-wrapper),
+    :deep(.ag-header),
+    :deep(.ag-header-cell-text),
+    :deep(.ag-cell),
+    :deep(.ag-paging-panel),
+    :deep(.ag-menu),
+    :deep(.ag-input-field-input) {
+      font-family: "Inter", sans-serif !important;
+      font-size: 12px !important;
+    }
+
     :deep(.ag-header-cell .ag-header-cell-menu-button),
     :deep(.ag-header-cell .ag-header-cell-menu-button-wrapper),
     :deep(.ag-header-cell .ag-header-icon) {
@@ -995,6 +1007,8 @@ export default {
     min-width: 200px;
     max-height: 300px;
     overflow-y: auto;
+    font-family: "Inter", sans-serif;
+    font-size: 12px;
   }
 
   .list-filter .filter-header {
@@ -1007,6 +1021,7 @@ export default {
     border: 1px solid #ccc;
     border-radius: 3px;
     font-size: 12px;
+    font-family: "Inter", sans-serif;
   }
 
   .list-filter .filter-list {
@@ -1020,6 +1035,7 @@ export default {
     align-items: center;
     padding: 3px 0;
     font-size: 12px;
+    font-family: "Inter", sans-serif;
     cursor: pointer;
   }
 
@@ -1044,7 +1060,8 @@ export default {
     border-radius: 3px;
     background: #fff;
     cursor: pointer;
-    font-size: 11px;
+    font-size: 12px;
+    font-family: "Inter", sans-serif;
   }
 
   .list-filter .apply-btn:hover {


### PR DESCRIPTION
### Motivation
- Padronizar a tipografia do componente `GridViewSimples` para `Inter` 12px visando consistência visual entre cabeçalho, células, botões de ação e controles de filtro/edição.

### Description
- Atualiza `Project/GridViewSimples/src/wwElement.vue` para aplicar ao tema AG Grid os parâmetros `headerFontSize`, `headerFontFamily`, `cellFontFamily` e `dataFontSize` como `Inter 12px` e adiciona overrides CSS `:deep(...)` para forçar `Inter 12px` em elementos internos do grid (header, células, paginação, menu e inputs).
- Ajusta `Project/GridViewSimples/src/components/list-filter.css` para usar `Inter, sans-serif` e `12px` em todas as regras relevantes do filtro customizado.
- Modifica `Project/GridViewSimples/src/components/ActionCellRenderer.vue` para garantir que o botão de ação use `Inter 12px` tanto no caso `with-font` quanto no fallback `without-font`.
- Atualiza `Project/GridViewSimples/src/components/DateTimeCellEditor.js` para definir `input.style.fontSize = '12px'` e `input.style.fontFamily = 'Inter, sans-serif'`.

### Testing
- Não foram executados testes automatizados, pois a alteração é estritamente visual/estilística.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de2cd3aecc8330a07b016c1b1dedc8)