### PR TITLE
Fix Avatar fallback initial rendering and rounded image styling

### DIFF
--- a/Project/Avatar/src/wwElement.vue
+++ b/Project/Avatar/src/wwElement.vue
@@ -35,13 +35,20 @@ export default {
     setup(props, { emit }) {
         const fileInput = ref(null);
 
-        const nameValue = computed(() => String(props.content?.NameValue || '').trim());
+        const nameValue = computed(() => {
+            const value = props.content?.NameValue ?? props.content?.nameValue ?? '';
+            return String(value).trim();
+        });
         const initialValue = computed(() => {
-            const value = props.content?.initialValue;
+            const value = props.content?.initialValue ?? props.content?.InitialValue;
             return typeof value === 'string' ? value.trim() : '';
         });
 
-        const hasInitialImage = computed(() => !!initialValue.value);
+        const hasInitialImage = computed(() => {
+            if (!initialValue.value) return false;
+            const normalized = initialValue.value.toLowerCase();
+            return normalized !== 'null' && normalized !== 'undefined';
+        });
         const initialLetter = computed(() => (nameValue.value ? nameValue.value.charAt(0).toUpperCase() : '?'));
 
         const avatarStyle = computed(() => ({
@@ -107,9 +114,11 @@ export default {
 }
 
 .ww-avatar__image {
+    display: block;
     width: 100%;
     height: 100%;
     object-fit: cover;
+    border-radius: inherit;
 }
 
 .ww-avatar__initial {


### PR DESCRIPTION
### Motivation
- Fix two Avatar regressions where the first-letter fallback did not show when `initialValue` was null/empty and avatar images did not render as rounded with the component border.
- Make the component more resilient to variant property names coming from different data sources (e.g. `NameValue`/`nameValue`, `initialValue`/`InitialValue`).

### Description
- Accept both `NameValue` and `nameValue` when computing the display name via the `nameValue` computed property.
- Accept both `initialValue` and `InitialValue` and normalize the value so strings like `'null'`, `'undefined'`, or empty values are treated as no image and fall back to the initial letter.
- Ensure avatar images respect the circular shape and border by adding `display: block;` and `border-radius: inherit;` to `.ww-avatar__image`.

### Testing
- Ran `git diff --check` and there were no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de3dffca288330a9e6af4824f5b7ee)