### PR TITLE
feat(avatar): add read-only mode for avatar uploads

### DIFF
--- a/Project/Avatar/src/wwElement.vue
+++ b/Project/Avatar/src/wwElement.vue
@@ -1,10 +1,12 @@
 <template>
     <div
         class="ww-avatar"
+        :class="{ 'ww-avatar--readonly': isReadOnly }"
         :style="avatarStyle"
         :title="nameValue"
-        role="button"
-        tabindex="0"
+        :role="isReadOnly ? undefined : 'button'"
+        :tabindex="isReadOnly ? -1 : 0"
+        :aria-disabled="isReadOnly ? 'true' : 'false'"
         :aria-label="nameValue || 'Avatar'"
         @click="openFilePicker"
         @keydown.enter.prevent="openFilePicker"
@@ -40,6 +42,7 @@ export default {
             const value = props.content?.NameValue ?? props.content?.nameValue ?? '';
             return String(value).trim();
         });
+        const isReadOnly = computed(() => props.content?.readOnly === true);
         const initialValue = computed(() => {
             const value = props.content?.initialValue ?? props.content?.InitialValue;
             return typeof value === 'string' ? value.trim() : '';
@@ -58,6 +61,7 @@ export default {
         }));
 
         const openFilePicker = () => {
+            if (isReadOnly.value) return;
             fileInput.value?.click();
         };
 
@@ -92,6 +96,7 @@ export default {
         return {
             fileInput,
             nameValue,
+            isReadOnly,
             initialValue,
             displayImage,
             hasDisplayImage,
@@ -127,6 +132,10 @@ export default {
     overflow: hidden;
     cursor: pointer;
     transition: 0.45s;
+}
+
+.ww-avatar--readonly {
+    cursor: default;
 }
 
 .ww-avatar__image {

--- a/Project/Avatar/ww-config.js
+++ b/Project/Avatar/ww-config.js
@@ -3,7 +3,7 @@ export default {
         label: 'Avatar',
         icon: 'user',
         bubble: { icon: 'user' },
-        customSettingsPropertiesOrder: ['NameValue', 'initialValue'],
+        customSettingsPropertiesOrder: ['NameValue', 'initialValue', 'readOnly'],
         customStylePropertiesOrder: [
             {
                 label: 'Avatar',
@@ -58,6 +58,13 @@ export default {
                 tooltip: 'When filled, must be an image URL shown inside the avatar.',
             },
             /* wwEditor:end */
+        },
+        readOnly: {
+            label: { en: 'Read only' },
+            type: 'OnOff',
+            section: 'settings',
+            defaultValue: false,
+            bindable: true,
         },
         initialLetterColor: {
             label: { en: 'Initial letter color' },


### PR DESCRIPTION
### Motivation
- Permitir que o componente Avatar seja configurado como somente leitura para evitar abrir o seletor de arquivos quando não for editável.
- Ajustar indicações visuais e de acessibilidade para refletir o estado somente leitura (cursor e foco).

### Description
- Adicionada propriedade `readOnly` (tipo `OnOff`, bindable, default `false`) à configuração do componente em `Project/Avatar/ww-config.js` e incluída em `customSettingsPropertiesOrder`.
- Implementado `isReadOnly` em `Project/Avatar/src/wwElement.vue` para detectar `props.content.readOnly === true` e impedir interações de upload quando ativo.
- Atualizados atributos e classes no template para o modo somente leitura: adicionada classe `ww-avatar--readonly`, `:role`, `:tabindex`, e `aria-disabled` para remover comportamento de botão e tirar foco do elemento.
- Ajustado estilo para usar cursor padrão (`cursor: default`) quando `ww-avatar--readonly` estiver presente.

### Testing
- Nenhuma suíte de testes automatizados estava disponível no repositório, portanto nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de47083bc8833098d15e3e73f1f93f)