### PR TITLE
feat(avatar): armazenar arquivo selecionado em variável de componente

### DIFF
--- a/Project/Avatar/src/wwElement.vue
+++ b/Project/Avatar/src/wwElement.vue
@@ -37,6 +37,13 @@ export default {
     setup(props, { emit }) {
         const fileInput = ref(null);
         const selectedImageUrl = ref('');
+        const { setValue: setSelectedFile } = wwLib.wwVariable.useComponentVariable({
+            uid: props.uid,
+            name: 'value',
+            defaultValue: null,
+            type: 'file',
+            componentType: 'element',
+        });
 
         const nameValue = computed(() => {
             const value = props.content?.NameValue ?? props.content?.nameValue ?? '';
@@ -76,6 +83,8 @@ export default {
             if (file && file.type?.startsWith('image/')) {
                 selectedImageUrl.value = URL.createObjectURL(file);
             }
+
+            setSelectedFile(file || null);
 
             emit('trigger-event', {
                 name: 'change',


### PR DESCRIPTION
### Motivation
- Permitir que o componente `Avatar` exponha o `File` selecionado para workflows e variáveis, alinhando seu comportamento ao do `AnexosGenerico` para possibilitar leitura de metadados do anexo em fluxos automatizados.

### Description
- Adicionada uma component variable usando `wwLib.wwVariable.useComponentVariable` em `Project/Avatar/src/wwElement.vue` com `name: 'value'` e `type: 'file'` para persistir o arquivo selecionado; o setter é armazenado em `setSelectedFile`.
- No handler de seleção (`handleFileChange`) o `File` anexado (ou `null`) é salvo chamando `setSelectedFile(file || null)` e o evento `change` continua sendo emitido com `{ file }`.

### Testing
- Nenhum teste automatizado foi executado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8e09b40c8330adcebbb59d700e1b)