### PR TITLE
Add markRow action and configurable selected row color to GridViewSimples

### DIFF
--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -3,6 +3,7 @@
     <ag-grid-vue :key="gridKey" :rowData="rowData" :columnDefs="columnDefs" :defaultColDef="defaultColDef"
       :domLayout="content.layout === 'auto' ? 'autoHeight' : 'normal'" :style="style" :rowSelection="rowSelection"
       :selection-column-def="{ pinned: true }" :theme="theme" :getRowId="getRowId" :pagination="content.pagination"
+      :getRowStyle="getRowStyle"
       :paginationPageSize="content.paginationPageSize || 10" :paginationPageSizeSelector="false"
       :suppressColumnMoveAnimation="true"
       :suppressMovableColumns="!content.movableColumns" :columnHoverHighlight="content.columnHoverHighlight"
@@ -348,6 +349,7 @@ export default {
   data() {
     return {
       pendingEnterEdit: null,
+      markedRowId: null,
     };
   },
   computed: {
@@ -774,6 +776,31 @@ export default {
       if (this.gridApi) {
         this.gridApi.deselectAll();
       }
+    },
+    markRow(rowId) {
+      if (rowId === undefined || rowId === null || rowId === "") {
+        this.markedRowId = null;
+      } else {
+        this.markedRowId = String(rowId);
+      }
+
+      if (this.gridApi?.redrawRows) {
+        this.gridApi.redrawRows();
+      }
+    },
+    getRowStyle(params) {
+      if (!this.content.selectedActionRowColor || this.markedRowId === null) {
+        return null;
+      }
+
+      const rowId = this.getRowId({ data: params?.data });
+      if (String(rowId) !== this.markedRowId) {
+        return null;
+      }
+
+      return {
+        backgroundColor: this.content.selectedActionRowColor,
+      };
     },
     /* wwEditor:start */
     generateColumns() {

--- a/Project/GridViewSimples/ww-config.js
+++ b/Project/GridViewSimples/ww-config.js
@@ -51,6 +51,7 @@ export default {
         "actionFontWeight",
         "actionFontStyle",
         "actionLineHeight",
+        "selectedActionRowColor",
       ],
     ],
     customSettingsPropertiesOrder: [
@@ -142,6 +143,17 @@ export default {
       action: "remountGrid",
       label: { en: "Remount Grid" },
       args: [],
+    },
+    {
+      action: "markRow",
+      label: { en: "Mark Row", pt: "Marcar linha" },
+      args: [
+        {
+          name: "rowId",
+          type: "text",
+          label: { en: "Row id", pt: "ID da linha" },
+        },
+      ],
     },
   ],
   properties: {
@@ -816,6 +828,17 @@ export default {
         type: "string",
         cssSupports: "line-height",
       },
+    },
+    selectedActionRowColor: {
+      type: "Color",
+      label: "Selected Row Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
     },
     rowData: {
       label: { en: "Data" },


### PR DESCRIPTION
### Motivation
- Provide a programmatic action to mark a specific row by id and visually highlight it in the GridViewSimples component.
- Allow editors to choose the highlight color via a new style property so the marked row matches design requirements.

### Description
- Added a new component action `markRow` (accepts `rowId`) in `Project/GridViewSimples/ww-config.js` so the grid can be marked programmatically from the editor or runtime actions.
- Introduced a new style property `selectedActionRowColor` (labelled "Selected Row Color") in `Project/GridViewSimples/ww-config.js` and included it in the action style group so editors can configure the highlight color.
- Wired AG Grid `:getRowStyle=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d16600148330bb3d1e6f5b33214d)