### PR TITLE
Oculta dropzone e input em AnexosGenerico quando em modo readonly

### DIFF
--- a/Project/AnexosGenerico/src/wwElement.vue
+++ b/Project/AnexosGenerico/src/wwElement.vue
@@ -14,7 +14,13 @@
         aria-label="File upload area"
     >
         <!-- Main upload area -->
-        <div ref="dropzoneEl" class="ww-file-upload__dropzone" @click="openFileExplorer" @mousemove="handleMouseMove">
+        <div
+            v-if="!isReadonly"
+            ref="dropzoneEl"
+            class="ww-file-upload__dropzone"
+            @click="openFileExplorer"
+            @mousemove="handleMouseMove"
+        >
             <div
                 v-if="isDragging && !isDisabled && !isReadonly && enableCircleAnimation"
                 ref="circleEl"
@@ -70,6 +76,7 @@
 
         <!-- Hidden file input -->
         <input
+            v-if="!isReadonly"
             ref="fileInput"
             type="file"
             class="ww-file-upload__input"


### PR DESCRIPTION
### Motivation
- Garantir que, quando o componente `AnexosGenerico` estiver em modo leitura (`readonly`), a UI de envio (caixa de arrastar/adicionar e o input de arquivo) não seja exibida, mostrando apenas a lista de anexos já existentes.

### Description
- Adicionado `v-if="!isReadonly"` no container da dropzone para não renderizar a área de upload quando estiver em `readonly`.
- Adicionado `v-if="!isReadonly"` no input de arquivo oculto para impedir exposição do controle de seleção de arquivos em `readonly`.
- A exibição da lista de anexos (`<FileList v-if="hasFiles" />`) permaneceu inalterada para que anexos iniciais/atualizados continuem visíveis em modo leitura.

### Testing
- Executados os checks locais `git diff --check` e `git -C /workspace/NewCode status --short`, ambos concluídos sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0d58617608330b523b50e7662956d)