### PR TITLE
SearchBox: ícone configurável, posição (left/right) e autocomplete desativado

### DIFF
--- a/Project/SearchBox/ww-config.js
+++ b/Project/SearchBox/ww-config.js
@@ -14,7 +14,7 @@ export default {
             'placeholder',
             'readonly',
             'required',
-            'autocomplete',
+            ['searchIcon', 'searchIconPosition'],
             'debounce',
             'debounceDelay',
         ],
@@ -250,6 +250,33 @@ export default {
             },
             /* wwEditor:end */
         },
+        searchIcon: {
+            label: { en: 'Search icon' },
+            type: 'Text',
+            section: 'settings',
+            defaultValue: '🔍',
+            bindable: true,
+            hidden: content => content.type !== 'search',
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'A string displayed as the search icon, for example: `"🔍"`',
+            },
+            /* wwEditor:end */
+        },
+        searchIconPosition: {
+            label: { en: 'Icon position' },
+            type: 'TextSelect',
+            section: 'settings',
+            options: {
+                options: [
+                    { value: 'left', label: { en: 'Left' } },
+                    { value: 'right', label: { en: 'Right' } },
+                ],
+            },
+            defaultValue: 'left',
+            hidden: content => content.type !== 'search',
+        },
         rows: {
             label: { en: 'Rows', fr: 'Rows' },
             type: 'Number',
@@ -364,6 +391,7 @@ export default {
             section: 'settings',
             defaultValue: false,
             bindable: true,
+            hidden: () => true,
             /* wwEditor:start */
             bindingValidation: {
                 type: 'boolean',

--- a/Project/SearchBox/wwElement.vue
+++ b/Project/SearchBox/wwElement.vue
@@ -50,6 +50,24 @@
         @blur="onBlur"
         @keyup.enter="onEnter"
     />
+    <div
+        v-else-if="content.type == 'search'"
+        class="search-input-wrapper"
+        :class="`icon-${searchIconPosition}`"
+        @click="focusInput"
+    >
+        <span v-if="searchIcon" class="search-icon">{{ searchIcon }}</span>
+        <input
+            ref="inputRef"
+            v-bind="inputBindings"
+            class="ww-input-basic search-input"
+            :class="[inputClasses]"
+            @input="handleManualInput"
+            @blur="onBlur"
+            @focus="isReallyFocused = true"
+            @keyup.enter="onEnter"
+        />
+    </div>
     <input
         v-else
         ref="inputRef"
@@ -502,7 +520,7 @@ export default {
             name: props.wwElementState.name,
             readonly: isReadonly.value || isEditing.value,
             required: props.content.required,
-            autocomplete: props.content.autocomplete ? 'on' : 'off',
+            autocomplete: 'off',
             placeholder: wwLib.wwLang.getText(props.content.placeholder),
             style: style.value,
             min: min.value,
@@ -517,10 +535,16 @@ export default {
             name: props.wwElementState.name,
             readonly: isReadonly.value || isEditing.value,
             required: props.content.required,
+            autocomplete: 'off',
             placeholder: wwLib.wwLang.getText(props.content.placeholder),
             rows: props.content.rows,
             style: [style.value, { resize: props.content.resize ? '' : 'none' }],
         }));
+
+        const searchIcon = computed(() => props.content.searchIcon || '🔍');
+        const searchIconPosition = computed(() =>
+            props.content.searchIconPosition === 'right' ? 'right' : 'left'
+        );
 
         const inputClasses = computed(() => ({
             hideArrows: props.content.hideArrows && inputType.value === 'number',
@@ -643,6 +667,8 @@ export default {
             inputClasses,
             onEnter,
             handleColorInputClick,
+            searchIcon,
+            searchIconPosition,
             // Currency-related
             handleCurrencyInput,
             handleCurrencyKeydown,
@@ -730,6 +756,21 @@ export default {
 
     &.currency-type {
         background-color: transparent;
+        width: 100%;
+    }
+}
+
+.search-input-wrapper {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 0.5em;
+
+    &.icon-right {
+        flex-direction: row-reverse;
+    }
+
+    .search-input {
         width: 100%;
     }
 }


### PR DESCRIPTION
### Motivation
- Transformar o `SearchBox` em um verdadeiro componente de busca permitindo ícone customizável e posicionamento do ícone à esquerda ou direita.
- Garantir que o componente nunca utilize autocomplete do navegador para evitar interferência em casos de busca.

### Description
- Adicionadas as propriedades `searchIcon` e `searchIconPosition` ao `ww-config` para permitir definir o ícone e sua posição (`left`/`right`) quando `type === 'search'`.
- Renderização específica para `type === 'search'` em `Project/SearchBox/wwElement.vue` com um wrapper `.search-input-wrapper` que exibe o ícone e posiciona-o conforme `searchIconPosition`.
- Forçado `autocomplete: 'off'` em `inputBindings` e `textareaBindings` para garantir que o componente nunca ative autocomplete, e a propriedade de editor `autocomplete` foi escondida para evitar conflito.
- Estilos SCSS adicionados para `.search-input-wrapper` e suporte a `icon-right` para inversão do layout do ícone.

### Testing
- Nenhum teste automatizado específico do projeto foi executado para esta alteração; validações locais foram feitas com checagens estáticas (por exemplo `git diff --check`) e revisão do template e bindings, sem erros detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62af2a168833086b986aca83e1a54)