### PR TITLE
Corrige renderização do SearchBox e habilita seleção de ícone da biblioteca WeWeb

### DIFF
--- a/Project/SearchBox/src/wwElement.vue
+++ b/Project/SearchBox/src/wwElement.vue
@@ -56,7 +56,7 @@
         :class="`icon-${searchIconPosition}`"
         @click="focusInput"
     >
-        <span v-if="searchIcon" class="search-icon">{{ searchIcon }}</span>
+        <div v-if="searchIcon" class="search-icon" v-html="searchIconHtml"></div>
         <input
             ref="inputRef"
             v-bind="inputBindings"
@@ -110,6 +110,7 @@ export default {
         'update:sidepanel-content',
     ],
     setup(props, { emit }) {
+        const { getIcon } = wwLib.useIcons();
         const isEditing = computed(() => {
             /* wwEditor:start */
             return props.wwEditorState.editMode === wwLib.wwEditorHelper.EDIT_MODES.EDITION;
@@ -541,9 +542,25 @@ export default {
             style: [style.value, { resize: props.content.resize ? '' : 'none' }],
         }));
 
-        const searchIcon = computed(() => props.content.searchIcon || '🔍');
+        const searchIcon = computed(() => props.content.searchIcon || 'search');
+        const searchIconHtml = ref('');
         const searchIconPosition = computed(() =>
             props.content.searchIconPosition === 'right' ? 'right' : 'left'
+        );
+        watch(
+            searchIcon,
+            async newIcon => {
+                if (!newIcon) {
+                    searchIconHtml.value = '';
+                    return;
+                }
+                try {
+                    searchIconHtml.value = (await getIcon(newIcon)) || '';
+                } catch (error) {
+                    searchIconHtml.value = '';
+                }
+            },
+            { immediate: true }
         );
 
         const inputClasses = computed(() => ({
@@ -668,6 +685,7 @@ export default {
             onEnter,
             handleColorInputClick,
             searchIcon,
+            searchIconHtml,
             searchIconPosition,
             // Currency-related
             handleCurrencyInput,
@@ -772,6 +790,13 @@ export default {
 
     .search-input {
         width: 100%;
+    }
+
+    .search-icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;
     }
 }
 </style>

--- a/Project/SearchBox/ww-config.js
+++ b/Project/SearchBox/ww-config.js
@@ -252,15 +252,15 @@ export default {
         },
         searchIcon: {
             label: { en: 'Search icon' },
-            type: 'Text',
+            type: 'SystemIcon',
             section: 'settings',
-            defaultValue: '🔍',
+            defaultValue: 'search',
             bindable: true,
             hidden: content => content.type !== 'search',
             /* wwEditor:start */
             bindingValidation: {
                 type: 'string',
-                tooltip: 'A string displayed as the search icon, for example: `"🔍"`',
+                tooltip: 'A string that defines the search icon code',
             },
             /* wwEditor:end */
         },


### PR DESCRIPTION
### Motivation
- O componente `SearchBox` não estava sendo exibido corretamente no editor e o ícone era tratado como texto, impedindo seleção via biblioteca de ícones do WeWeb.
- É necessário permitir escolher ícones da biblioteca do editor para garantir renderização consistente e edição visual no painel lateral.

### Description
- Alterado `Project/SearchBox/ww-config.js` para usar `type: 'SystemIcon'` na propriedade `searchIcon`, com `defaultValue: 'search'` e tooltip atualizado para refletir que é um código de ícone.
- Modificado `Project/SearchBox/src/wwElement.vue` para renderizar o ícone usando a API de ícones do WeWeb (`wwLib.useIcons().getIcon`) e inserir o resultado com `v-html` em uma `div` `.search-icon` ao invés de imprimir texto bruto.
- Adicionada reatividade: `searchIconHtml` é atualizada por um `watch` sobre `searchIcon` com fallback seguro para valores vazios/inválidos.
- Incluída pequena estilização `.search-icon` para manter alinhamento visual e evitar problemas de layout no editor.

### Testing
- Executado `node --check Project/SearchBox/ww-config.js` e a checagem retornou sem erros (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62d97bfac8330926675fe29720a85)