### PR TITLE
SearchBox: support system icons and HTML icon rendering; update config

### DIFF
--- a/Project/SearchBox/src/wwElement.vue
+++ b/Project/SearchBox/src/wwElement.vue
@@ -56,12 +56,16 @@
         :class="`icon-${searchIconPosition}`"
         @click="focusInput"
     >
-        <span v-if="searchIcon" class="search-icon">{{ searchIcon }}</span>
+        <div v-if="searchIcon" class="search-icon">
+            <div v-if="searchIconHtml" v-html="searchIconHtml"></div>
+            <span v-else class="material-symbols-outlined">{{ searchIcon }}</span>
+        </div>
         <input
             ref="inputRef"
             v-bind="inputBindings"
             class="ww-input-basic search-input"
             :class="[inputClasses]"
+            :style="searchInputStyle"
             @input="handleManualInput"
             @blur="onBlur"
             @focus="isReallyFocused = true"
@@ -110,6 +114,7 @@ export default {
         'update:sidepanel-content',
     ],
     setup(props, { emit }) {
+        const { getIcon } = wwLib.useIcons();
         const isEditing = computed(() => {
             /* wwEditor:start */
             return props.wwEditorState.editMode === wwLib.wwEditorHelper.EDIT_MODES.EDITION;
@@ -541,10 +546,30 @@ export default {
             style: [style.value, { resize: props.content.resize ? '' : 'none' }],
         }));
 
-        const searchIcon = computed(() => props.content.searchIcon || '🔍');
+        const searchIcon = computed(() => props.content.searchIcon || 'search');
+        const searchIconHtml = ref('');
         const searchIconPosition = computed(() =>
             props.content.searchIconPosition === 'right' ? 'right' : 'left'
         );
+        watch(
+            searchIcon,
+            async newIcon => {
+                if (!newIcon) {
+                    searchIconHtml.value = '';
+                    return;
+                }
+                try {
+                    searchIconHtml.value = (await getIcon(newIcon)) || '';
+                } catch (error) {
+                    searchIconHtml.value = '';
+                }
+            },
+            { immediate: true }
+        );
+        const searchInputStyle = computed(() => {
+            if (!searchIcon.value) return {};
+            return searchIconPosition.value === 'right' ? { paddingRight: '2.2em' } : { paddingLeft: '2.2em' };
+        });
 
         const inputClasses = computed(() => ({
             hideArrows: props.content.hideArrows && inputType.value === 'number',
@@ -668,7 +693,9 @@ export default {
             onEnter,
             handleColorInputClick,
             searchIcon,
+            searchIconHtml,
             searchIconPosition,
+            searchInputStyle,
             // Currency-related
             handleCurrencyInput,
             handleCurrencyKeydown,
@@ -761,17 +788,35 @@ export default {
 }
 
 .search-input-wrapper {
-    display: flex;
-    align-items: center;
+    position: relative;
     width: 100%;
-    gap: 0.5em;
 
     &.icon-right {
-        flex-direction: row-reverse;
+        .search-icon {
+            right: 0.7em;
+            left: auto;
+        }
     }
 
     .search-input {
         width: 100%;
+    }
+
+    .search-icon {
+        position: absolute;
+        left: 0.7em;
+        top: 50%;
+        transform: translateY(-50%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        line-height: 0;
+        pointer-events: none;
+        z-index: 1;
+    }
+
+    .material-symbols-outlined {
+        font-size: 1.1em;
     }
 }
 </style>

--- a/Project/SearchBox/ww-config.js
+++ b/Project/SearchBox/ww-config.js
@@ -252,15 +252,15 @@ export default {
         },
         searchIcon: {
             label: { en: 'Search icon' },
-            type: 'Text',
+            type: 'SystemIcon',
             section: 'settings',
-            defaultValue: '🔍',
+            defaultValue: 'search',
             bindable: true,
             hidden: content => content.type !== 'search',
             /* wwEditor:start */
             bindingValidation: {
                 type: 'string',
-                tooltip: 'A string displayed as the search icon, for example: `"🔍"`',
+                tooltip: 'A string that defines the search icon code',
             },
             /* wwEditor:end */
         },


### PR DESCRIPTION
### Motivation
- Replace the previous hard-coded emoji search icon with a pluggable system icon so the search input can use icon fonts/SVGs consistently.
- Allow icon HTML to be injected when available and automatically adjust input padding based on icon position.

### Description
- Replace the simple `span` icon with a `div` that renders either `searchIconHtml` via `v-html` or a fallback `span` with the `material-symbols-outlined` class. 
- Add `getIcon` usage via `wwLib.useIcons()`, a `searchIconHtml` ref, and a `watch` on `searchIcon` to fetch and store HTML for system icons. 
- Change `searchIcon` default value from the emoji `🔍` to the system icon key `'search'` and compute `searchInputStyle` to add left/right padding when an icon is present. 
- Update styles to position the icon absolutely inside `.search-input-wrapper`, add support for right-positioned icons, and style `.material-symbols-outlined`. 
- Update `ww-config.js` for the SearchBox: change `searchIcon` field `type` to `SystemIcon`, update its `defaultValue` to `'search'`, and revise the editor tooltip.

### Testing
- Ran the project build (`npm run build`) and the component/unit test suite (`npm test`) locally, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62d97bfac8330926675fe29720a85)