### PR TITLE
Fix SearchBox custom SVG icon visibility

### DIFF
--- a/Project/SearchBox/src/wwElement.vue
+++ b/Project/SearchBox/src/wwElement.vue
@@ -810,9 +810,20 @@ export default {
         display: flex;
         align-items: center;
         justify-content: center;
+        color: var(--placeholder-color, #000000ad);
         line-height: 0;
         pointer-events: none;
         z-index: 1;
+
+        :deep(svg) {
+            display: block;
+            width: 1.1em;
+            height: 1.1em;
+        }
+
+        :deep(path) {
+            fill: currentColor;
+        }
     }
 
     .material-symbols-outlined {


### PR DESCRIPTION
### Motivation
- Usuário relatou que ícone selecionado no `SearchBox` não aparecia quando posicionado à direita; a intenção é garantir que ícones SVG injetados via `v-html` sejam visíveis, dimensionados e herdem a cor correta.

### Description
- Adicionei cor padrão ao container `.search-icon` para herdar `--placeholder-color` e garantir visibilidade dos ícones.
- Adicionei regras scoped `:deep(svg)` para forçar dimensões previsíveis dos SVGs inseridos via `v-html` (`1.1em` x `1.1em`).
- Adicionei `:deep(path) { fill: currentColor; }` para que paths dentro dos SVGs utilizem a cor do contêiner e não fiquem invisíveis.

### Testing
- Não foram executados testes automatizados para este ajuste de estilo.
- Verificação manual do arquivo `Project/SearchBox/src/wwElement.vue` confirmou a presença das novas regras CSS e o diff esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6501f1f348330ad55921578a05097)