### PR TITLE
feat(SearchBox): adicionar propriedade de cor para ícone de busca

### DIFF
--- a/Project/SearchBox/src/wwElement.vue
+++ b/Project/SearchBox/src/wwElement.vue
@@ -56,7 +56,7 @@
         :class="`icon-${searchIconPosition}`"
         @click="focusInput"
     >
-        <div v-if="searchIcon" class="search-icon">
+        <div v-if="searchIcon" class="search-icon" :style="searchIconStyle">
             <div v-if="searchIconHtml" v-html="searchIconHtml"></div>
             <span v-else class="material-symbols-outlined">{{ searchIcon }}</span>
         </div>
@@ -570,6 +570,7 @@ export default {
             if (!searchIcon.value) return {};
             return searchIconPosition.value === 'right' ? { paddingRight: '2.2em' } : { paddingLeft: '2.2em' };
         });
+        const searchIconStyle = computed(() => ({ color: props.content.searchIconColor || undefined }));
 
         const inputClasses = computed(() => ({
             hideArrows: props.content.hideArrows && inputType.value === 'number',
@@ -695,6 +696,7 @@ export default {
             searchIcon,
             searchIconHtml,
             searchIconPosition,
+            searchIconStyle,
             searchInputStyle,
             // Currency-related
             handleCurrencyInput,

--- a/Project/SearchBox/ww-config.js
+++ b/Project/SearchBox/ww-config.js
@@ -14,7 +14,7 @@ export default {
             'placeholder',
             'readonly',
             'required',
-            ['searchIcon', 'searchIconPosition'],
+            ['searchIcon', 'searchIconPosition', 'searchIconColor'],
             'debounce',
             'debounceDelay',
         ],
@@ -276,6 +276,23 @@ export default {
             },
             defaultValue: 'left',
             hidden: content => content.type !== 'search',
+        },
+        searchIconColor: {
+            label: { en: 'Icon color' },
+            type: 'Color',
+            section: 'settings',
+            options: {
+                nullable: true,
+            },
+            bindable: true,
+            hidden: content => content.type !== 'search',
+            /* wwEditor:start */
+            bindingValidation: {
+                cssSupports: 'color',
+                type: 'string',
+                tooltip: 'A string that represents a color code: `"rebeccapurple" | "#00ff00" | "rgb(214, 122, 127)"`',
+            },
+            /* wwEditor:end */
         },
         rows: {
             label: { en: 'Rows', fr: 'Rows' },


### PR DESCRIPTION
### Motivation
- Permitir configurar a cor do ícone do modo `search` no componente `SearchBox` para melhor controle visual em temas e estilos.

### Description
- Adiciona a propriedade `searchIconColor` (tipo `Color`, `bindable`, visível somente quando `type === 'search'`) em `Project/SearchBox/ww-config.js`, inclui a propriedade na ordem de exibição das configurações do editor, e aplica a cor no componente via a computed `searchIconStyle` ligada ao elemento com `:style="searchIconStyle"` em `Project/SearchBox/src/wwElement.vue`.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e678837aa4833086701c8dea36a95f)