### PR TITLE
fix(gridviewsimples): not-allowed cursor for disabled row selection checkboxes

### DIFF
--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -938,6 +938,13 @@ export default {
       font-size: 12px !important;
     }
 
+
+    :deep(.ag-selection-checkbox .ag-checkbox-input-wrapper.ag-disabled),
+    :deep(.ag-selection-checkbox .ag-checkbox-input-wrapper.ag-disabled *),
+    :deep(.ag-selection-checkbox input[type="checkbox"]:disabled) {
+      cursor: not-allowed !important;
+    }
+
     :deep(.ag-header-cell .ag-header-cell-menu-button),
     :deep(.ag-header-cell .ag-header-cell-menu-button-wrapper),
     :deep(.ag-header-cell .ag-header-icon) {


### PR DESCRIPTION
### Motivation
- The row-selection checkbox in `GridViewSimples` showed a `pointer` cursor even when disabled, which is misleading and should indicate a disabled state with `not-allowed`.

### Description
- Added scoped CSS to `Project/GridViewSimples/src/wwElement.vue` that forces `cursor: not-allowed` for disabled selection checkbox wrappers and disabled checkbox inputs using the selectors `.ag-selection-checkbox .ag-checkbox-input-wrapper.ag-disabled`, `.ag-selection-checkbox .ag-checkbox-input-wrapper.ag-disabled *`, and `.ag-selection-checkbox input[type="checkbox"]:disabled`.

### Testing
- Ran `git diff --check` which returned no issues, and the change is CSS-only (visual adjustment only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8bdef4f808330870f3eab768f9921)