### PR TITLE
feat(GridViewDinamica): add component action to refresh dropdown option sources

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1781,6 +1781,87 @@ function applyExternalSortAndSync() {
     columnOptions.value = result;
   };
 
+  const refreshAllDropdownOptions = async () => {
+    if (!props.content || !Array.isArray(props.content.columns)) {
+      return { refreshedColumns: 0, refreshedKeys: 0 };
+    }
+
+    const rows = wwLib.wwUtils.getDataFromCollection(props.content.rowData) || [];
+    const columns = props.content.columns.filter(col => isListLikeColumn(col));
+    if (!columns.length) {
+      return { refreshedColumns: 0, refreshedKeys: 0 };
+    }
+
+    responsibleUserCache = null;
+    const nextOptions = { ...(columnOptions.value || {}) };
+    let refreshedKeys = 0;
+
+    for (const col of columns) {
+      const fieldKey = col.id || col.field;
+      if (!fieldKey) continue;
+
+      nextOptions[fieldKey] = {};
+
+      const shouldUseTicket = usesTicketId(col);
+      const ticketKeys = shouldUseTicket
+        ? Array.from(
+            new Set(
+              rows
+                .map(row => row?.TicketID)
+                .filter(ticketId => ticketId != null && ticketId !== '')
+            )
+          )
+        : [undefined];
+
+      if (!ticketKeys.length) {
+        ticketKeys.push(undefined);
+      }
+
+      for (const ticketKey of ticketKeys) {
+        const cacheKey = getOptionsCacheKey(col, shouldUseTicket ? ticketKey : undefined);
+        const opts = await getColumnOptions(
+          col,
+          shouldUseTicket ? ticketKey : undefined,
+          { force: true }
+        );
+        nextOptions[fieldKey][cacheKey] = Array.isArray(opts) ? opts : [];
+        refreshedKeys += 1;
+      }
+    }
+
+    columnOptions.value = nextOptions;
+
+    if (gridApi.value) {
+      const columnIds = columns
+        .map(col => col.id || col.field)
+        .filter(Boolean);
+
+      if (columnIds.length && typeof gridApi.value.refreshCells === 'function') {
+        gridApi.value.refreshCells({ force: true, columns: columnIds });
+      }
+
+      if (typeof gridApi.value.refreshHeader === 'function') {
+        gridApi.value.refreshHeader();
+      }
+
+      if (typeof gridApi.value.destroyFilter === 'function') {
+        columnIds.forEach(colId => {
+          try {
+            gridApi.value.destroyFilter(colId);
+          } catch (error) {
+            noopConsole('[GridViewDinamica] Failed to destroy filter for column', colId, error);
+          }
+        });
+      }
+
+      if (typeof gridApi.value.onFilterChanged === 'function') {
+        gridApi.value.onFilterChanged();
+      }
+    }
+
+    return { refreshedColumns: columns.length, refreshedKeys };
+  };
+
   // Reaplica a ordem das colunas baseada na propriedade PositionInGrid
   const applyColumnOrderFromPosition = () => {
     const colApi = getColApi();
@@ -2469,6 +2550,7 @@ setTimeout(() => {
       refreshRowListOptions,
       shouldLazyLoadStatus,
       buildLazyStatusFallbackOptions,
+      refreshAllDropdownOptions,
       getRowMetadataHash,
       waitForRowHydration,
       getColumnOptions,
@@ -3427,6 +3509,11 @@ setTimeout(() => {
   resetFilters() {
     if (this.gridApi) {
       this.gridApi.setFilterModel(null);
+    }
+  },
+  async refreshDropdownOptions() {
+    if (typeof this.refreshAllDropdownOptions === "function") {
+      await this.refreshAllDropdownOptions();
     }
   },
   setSort(sortInput) {

--- a/Project/GridViewDinamica/ww-config.js
+++ b/Project/GridViewDinamica/ww-config.js
@@ -183,6 +183,11 @@ export default {
     label: { en: 'Reset Column Positions' },
     args: []
   },
+  {
+    action: 'refreshDropdownOptions',
+    label: { en: 'Refresh Dropdown Options' },
+    args: []
+  },
     {
       action: 'setFilters',
       label: { en: 'Set Filters' },


### PR DESCRIPTION
### Motivation
- List-type editors and filter dropdowns could hold stale option values when their underlying collections (e.g. cities) are updated, so a deterministic way to refresh all dropdown/list sources from the Grid is required.

### Description
- Added `refreshAllDropdownOptions` to `Project/GridViewDinamica/src/wwElement.vue`, which invalidates caches, resets `responsibleUserCache`, and re-fetches options for all list-like columns (including per-`TicketID` contexts) using existing helpers like `getColumnOptions`, `usesTicketId`, and `getOptionsCacheKey` and forces fresh fetches via `{ force: true }`.
- After re-fetching, the routine updates `columnOptions.value` and forces UI refreshes by calling grid methods to refresh cells/headers and recreate/destroy filters so filter dropdowns reflect new values; it returns a summary object with counts of refreshed columns/keys.
- Exposed the routine in the component `setup` return and added an instance method `refreshDropdownOptions()` that invokes it, making it callable as a component action via the public `methods` API.
- Registered a new component action `refreshDropdownOptions` in `Project/GridViewDinamica/ww-config.js` so workflows can trigger the refresh from the editor or runtime actions list.

### Testing
- Performed repository diff and status verification to confirm the intended files were modified and the new function and action were added (`Project/GridViewDinamica/src/wwElement.vue` and `Project/GridViewDinamica/ww-config.js`).
- Verified the changes were staged and persisted to the repository (commit recorded); these verification steps succeeded.
- No unit/integration test suite was executed in this rollout, and no build/lint step was run as part of these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4113d9c08330a1483749fc71f643)