### PR TITLE
Resolve responsible-user dropdown options from live collection on refresh

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1702,22 +1702,48 @@ function applyExternalSortAndSync() {
   };
 
   const loadResponsibleUserOptions = async () => {
+    const normalizeOptions = source => {
+      const items = asArray(source);
+      return items.filter(item => item?.istecnical === true);
+    };
+
+    try {
+      const fallbackCollectionId = '0e41f029-e1c3-4302-82ca-16aceccdadb1';
+      const datasourceBinding = props.content?.userDatasource;
+
+      const candidates = [
+        datasourceBinding,
+        datasourceBinding?.id,
+        datasourceBinding?.collection,
+        datasourceBinding?._id,
+        fallbackCollectionId,
+      ].filter(Boolean);
+
+      for (const candidate of candidates) {
         try {
-          const data = wwLib.wwCollection.getCollection("0e41f029-e1c3-4302-82ca-16aceccdadb1").data.filter(item => item.istecnical === true);
-          return asArray(
-            Array.isArray(data)
-              ? data
-              : data?.data || data?.result || data?.results
-          );
-        } catch (e) {
-          // Fallback: props.content.userDatasource
-          const ds = props.content?.userDatasource;
-          if (Array.isArray(ds)) return ds;
-          if (ds && typeof ds === 'object') return asArray(ds.data || ds.result || ds.results);
-          
-          return [];
+          const liveData = wwLib.wwUtils.getDataFromCollection(candidate);
+          const normalizedLiveData = normalizeOptions(liveData);
+          if (normalizedLiveData.length) return normalizedLiveData;
+
+          const collectionRef =
+            typeof candidate === 'string' ? wwLib.wwCollection.getCollection(candidate) : candidate;
+          const normalizedRefData = normalizeOptions(collectionRef?.data);
+          if (normalizedRefData.length) return normalizedRefData;
+        } catch (collectionError) {
+          noopConsole('[GridViewDinamica] Failed to resolve responsible users from collection candidate', candidate, collectionError);
         }
-      };
+      }
+    } catch (e) {
+      noopConsole('[GridViewDinamica] Failed to load responsible users from collection', e);
+    }
+
+    // Fallback: inline datasource object/array
+    const ds = props.content?.userDatasource;
+    if (Array.isArray(ds)) return normalizeOptions(ds);
+    if (ds && typeof ds === 'object') return normalizeOptions(ds.data || ds.result || ds.results);
+
+    return [];
+  };
 
   let responsibleUserCache = null;
 


### PR DESCRIPTION
### Motivation
- The Refresh Dropdown Options action could return stale responsible-user entries because `loadResponsibleUserOptions` read a hardcoded collection `.data` instead of resolving current datasource bindings and live collection data.
- The change aims to make the dropdown reflect the latest collection state and handle different datasource binding shapes used by the component.

### Description
- Rewrote `loadResponsibleUserOptions` to centralize normalization and filtering (only return items with `istecnical === true`).
- Resolve candidates from `props.content.userDatasource` (including `id`, `collection`, `_id`) and a legacy hardcoded collection id, and for each candidate attempt to read live data via `wwLib.wwUtils.getDataFromCollection(...)`.
- Fall back to reading `wwLib.wwCollection.getCollection(candidate).data` when appropriate, and to inline datasource payloads (array/object) if no collection reference yields results.
- Added defensive `noopConsole` logging when collection resolution fails to aid debugging while preserving the existing `responsibleUserCache` usage.

### Testing
- No automated tests were executed for this change; recommend running the app and triggering the **Refresh Dropdown Options** action to validate runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb49806a4083309a5f993be03147ed)