### PR TITLE
fix(datagrid): preserve filters when refreshing dropdown options

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1858,6 +1858,10 @@ function applyExternalSortAndSync() {
     columnOptions.value = nextOptions;
 
     if (gridApi.value) {
+      const previousFilterModel =
+        typeof gridApi.value.getFilterModel === 'function'
+          ? gridApi.value.getFilterModel()
+          : null;
       const columnIds = columns
         .map(col => col.id || col.field)
         .filter(Boolean);
@@ -1878,6 +1882,14 @@ function applyExternalSortAndSync() {
             noopConsole('[GridViewDinamica] Failed to destroy filter for column', colId, error);
           }
         });
+      }
+
+      if (
+        previousFilterModel &&
+        typeof previousFilterModel === 'object' &&
+        typeof gridApi.value.setFilterModel === 'function'
+      ) {
+        gridApi.value.setFilterModel(previousFilterModel);
       }
 
       if (typeof gridApi.value.onFilterChanged === 'function') {


### PR DESCRIPTION
### Motivation
- A ação de componente `Refresh Dropdown Options` estava removendo os filtros ativos da grid porque os filtros das colunas eram destruídos sem reaplicar o `filterModel` atual.
- É necessário manter os filtros do usuário ao atualizar as opções de dropdown para evitar perda de contexto e resultados inesperados.

### Description
- No `Project/GridViewDinamica/src/wwElement.vue` dentro de `refreshAllDropdownOptions` capturei o `previousFilterModel` via `gridApi.getFilterModel()` antes de destruir os filtros de coluna.
- Após recriar/atualizar `columnOptions.value` e chamar `destroyFilter` para cada coluna, reapliquei o modelo com `gridApi.setFilterModel(previousFilterModel)` quando disponível.
- Mantive a chamada existente a `gridApi.onFilterChanged()` para preservar a sincronização de UI e eventos.

### Testing
- Procurei e analisei trechos relevantes com `rg` e `sed` para validar o fluxo e local do código modificado, e os comandos executados retornaram os trechos esperados com sucesso. 
- Apliquei a modificação e verifiquei o diff com `git status`/`git diff`, e o commit foi criado com sucesso. 
- O patch foi gerado e o arquivo modificado (`Project/GridViewDinamica/src/wwElement.vue`) contém as inserções esperadas; todas as verificações automatizadas realizadas durante a rollout concluíram sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb4f5aa8d0833087d8a5f8618c07dd)