### PR TITLE
Preserve dropdown option metadata on refresh in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1682,7 +1682,11 @@ function applyExternalSortAndSync() {
             let value = item[ds.transform?.value] ?? item.id;
             let label = item[ds.transform?.label] ?? item.name;
             if (value === undefined || label === undefined) return null;
-            return { value, label };
+            return {
+              ...(item && typeof item === 'object' ? item : {}),
+              value,
+              label,
+            };
           })
           .filter(v => v);
       }
@@ -1692,7 +1696,11 @@ function applyExternalSortAndSync() {
           const value = item[ds.valueField || 'id'];
           const label = item[ds.labelField || 'name'];
           if (value === undefined || label === undefined) return null;
-          return { value, label };
+          return {
+            ...(item && typeof item === 'object' ? item : {}),
+            value,
+            label,
+          };
         })
         .filter(v => v);
     } catch (e) {


### PR DESCRIPTION
### Motivation
- Dropdown options fetched from an API were being normalized to plain `{ value, label }`, which dropped other fields used by custom formatters and caused newly inserted records to render without expected formatting.

### Description
- Updated `loadApiOptions` in `Project/GridViewDinamica/src/wwElement.vue` to preserve the original item object when mapping API results and still normalize `value` and `label`.
- Applied the preservation in both the `ds.transform` branch and the default mapping branch so all API-loaded options retain their metadata.
- This ensures components and formatters that rely on extra fields in option objects continue to work after `refreshDropdownOptions`/option refresh flows.

### Testing
- Verified the changed lines are present in `Project/GridViewDinamica/src/wwElement.vue` using file content inspection commands (`nl`/`sed`), which showed the new object spread and `value`/`label` assignments as expected and succeeded.
- Used code search (`rg`) to confirm the option load and refresh codepaths (`loadApiOptions`, `refreshAllDropdownOptions`) remain connected to the places that consume options, and the search succeeded.
- No unit tests were modified in this change and there is no project test suite run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb59bd98c08330a6643a9b47162432)