### PR TITLE
Improve Refresh Dropdown Options performance in GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -1828,11 +1828,19 @@ function applyExternalSortAndSync() {
 
     responsibleUserCache = null;
     const nextOptions = { ...(columnOptions.value || {}) };
-    let refreshedKeys = 0;
+    const refreshTasks = [];
 
     for (const col of columns) {
       const fieldKey = col.id || col.field;
       if (!fieldKey) continue;
+
+      const hasDynamicSource = !!(col.dataSource?.functionName || col.dataSource?.dataSource?.functionName);
+      const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+      const identifier = (col.FieldDB || '').toUpperCase();
+      const isResponsibleUser = tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+      if (!hasDynamicSource && !isResponsibleUser) {
+        continue;
+      }
 
       nextOptions[fieldKey] = {};
 
@@ -1853,14 +1861,31 @@ function applyExternalSortAndSync() {
 
       for (const ticketKey of ticketKeys) {
         const cacheKey = getOptionsCacheKey(col, shouldUseTicket ? ticketKey : undefined);
-        const opts = await getColumnOptions(
-          col,
-          shouldUseTicket ? ticketKey : undefined,
-          { force: true }
+        refreshTasks.push(
+          getColumnOptions(
+            col,
+            shouldUseTicket ? ticketKey : undefined,
+            { force: true }
+          )
+            .then(opts => {
+              if (!nextOptions[fieldKey]) {
+                nextOptions[fieldKey] = {};
+              }
+              nextOptions[fieldKey][cacheKey] = Array.isArray(opts) ? opts : [];
+            })
+            .catch(error => {
+              noopConsole('[GridViewDinamica] Failed to refresh dropdown options for column', fieldKey, error);
+              if (!nextOptions[fieldKey]) {
+                nextOptions[fieldKey] = {};
+              }
+              nextOptions[fieldKey][cacheKey] = [];
+            })
         );
-        nextOptions[fieldKey][cacheKey] = Array.isArray(opts) ? opts : [];
-        refreshedKeys += 1;
       }
+    }
+
+    if (refreshTasks.length) {
+      await Promise.all(refreshTasks);
     }
 
     columnOptions.value = nextOptions;
@@ -1905,7 +1930,7 @@ function applyExternalSortAndSync() {
       }
     }
 
-    return { refreshedColumns: columns.length, refreshedKeys };
+    return { refreshedColumns: columns.length, refreshedKeys: refreshTasks.length };
   };
 
   // Reaplica a ordem das colunas baseada na propriedade PositionInGrid


### PR DESCRIPTION
### Motivation
- Users experienced long delays when running the `Refresh Dropdown Options` action after new Supabase records were added because the previous implementation fetched each column/ticket key sequentially.
- The change aims to reduce wait time by parallelizing remote option loads and avoiding unnecessary refresh work for static-only lists.

### Description
- Reworked `refreshAllDropdownOptions` in `Project/GridViewDinamica/src/wwElement.vue` to collect per-column/per-ticket fetches into a `refreshTasks` array and run them in parallel with `Promise.all` instead of awaiting each request sequentially.
- Added a guard to skip columns that only have static `listOptions` by detecting dynamic sources via `col.dataSource?.functionName` (including nested `dataSource.dataSource.functionName`) while still allowing the `RESPONSIBLEUSERID` special-case to be refreshed.
- Implemented per-task error handling that logs failures via `noopConsole` and writes an empty array for failed keys to avoid a single failure blocking the full refresh.
- Updated the returned payload to report `refreshedKeys` based on the number of tasks executed (`refreshTasks.length`) and ensured `columnOptions.value` is applied only after all tasks complete.

### Testing
- No automated unit or integration tests were available for this component, so no automated tests were executed against the change.
- Verified the change by inspecting the produced diff and confirming only `Project/GridViewDinamica/src/wwElement.vue` was modified and that the new `refreshTasks`/`Promise.all` flow is present in the file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb5bda50fc83309ed80d67c4bceff2)