### PR TITLE
feat: adiciona componente AnexosHibrido (visual Anexos + fluxo local AnexosGenerico)

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -1,0 +1,407 @@
+<template>
+    <li
+        class="ww-file-item"
+        :class="{ 'ww-file-item--disabled': isDisabled }"
+        :style="fileItemStyles"
+        role="listitem"
+        :aria-label="`File: ${file.name}, Size: ${formattedSize}`"
+    >
+        <div
+            v-if="status && status.uploadProgress !== undefined"
+            class="ww-file-item__progress"
+            :style="{
+                width: `${Math.min(100, Math.round(status.uploadProgress))}%`,
+                backgroundColor: content.progressBarColor || '#EEEEEE',
+            }"
+        ></div>
+        <div class="ww-file-item__info">
+            <button
+                type="button"
+                class="ww-file-item__preview"
+                :disabled="isDisabled"
+                @click="$emit('preview')"
+                :aria-label="`Preview ${file.name}`"
+                :title="previewHint || null"
+                :class="{ 'ww-file-item__preview--not-allowed': !canPreview }"
+            >
+                <img v-if="isImage && previewUrl" :src="previewUrl" alt="" class="ww-file-item__thumb" />
+                <i v-else :class=['ww-file-item__file-icon', fileIcon]></i>
+            </button>
+            <div class="ww-file-item__meta">
+                <div class="ww-file-item__name" :style="fileNameStyles">{{ file.name }}</div>
+                <div class="ww-file-item__details" :style="fileDetailsStyles" v-if="showFileInfo">
+                    <span>{{ formattedSize }}</span>
+                    <span v-if="status && status.uploadProgress !== undefined">
+                        • {{ `${Math.round(status.uploadProgress)}%` }}
+                    </span>
+                </div>
+            </div>
+        </div>
+        <div class="ww-file-item__actions">
+            <button
+                type="button"
+                class="ww-file-item__btn"
+                :disabled="isDisabled"
+                @click="$emit('download')"
+                :style="actionButtonStyles"
+                aria-label="Download file"
+            >
+                <span class="material-symbols-outlined">download</span>
+            </button>
+            <button
+                v-if="!isReadonly"
+                type="button"
+                class="ww-file-item__btn ww-file-item__btn--remove"
+                :disabled="isDisabled || isReadonly"
+                @click="$emit('remove')"
+                :style="actionButtonStyles"
+                aria-label="Remove file"
+            >
+                <div class="icon" v-html="removeIcon"></div>
+            </button>
+        </div>
+    </li>
+</template>
+
+<script>
+import { computed, inject, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+
+export default {
+    props: {
+        file: {
+            type: Object,
+            required: true,
+        },
+        status: {
+            type: Object,
+            required: true,
+        },
+        index: {
+            type: Number,
+            required: true,
+        },
+        isReadonly: {
+            type: Boolean,
+            default: false,
+        },
+        isDisabled: {
+            type: Boolean,
+            default: false,
+        },
+        canPreview: {
+            type: Boolean,
+            default: true,
+        },
+        previewHint: {
+            type: String,
+            default: '',
+        },
+    },
+    emits: ['remove', 'download', 'preview'],
+    setup(props) {
+        const fileUpload = inject('_wwFileUpload', {
+            files: computed(() => []),
+            content: computed(() => ({})),
+            isDisabled: computed(() => false),
+            isReadonly: computed(() => false),
+            isSingleMode: computed(() => true),
+            acceptedTypes: computed(() => ''),
+        });
+
+        const filesCount = computed(() => fileUpload.files.value.length);
+        const content = computed(() => fileUpload.content?.value || {});
+        const showFileInfo = computed(() => content.value?.showFileInfo);
+
+        const fileItemStyles = computed(() => ({
+            backgroundColor: content.value?.fileItemBackground || '#fff',
+            borderColor: content.value?.fileItemBorderColor || '#eee',
+            borderRadius: content.value?.fileItemBorderRadius || '6px',
+            padding: content.value?.fileItemPadding || '12px',
+            margin: content.value?.fileItemMargin || '0 0 8px 0',
+            boxShadow: content.value?.fileItemShadow || '0 2px 4px rgba(0, 0, 0, 0.05)',
+            position: 'relative',
+            overflow: 'hidden',
+        }));
+
+        const fileNameStyles = computed(() => ({
+            fontFamily: content.value?.fileNameFontFamily || 'inherit',
+            fontSize: content.value?.fileNameFontSize || '14px',
+            fontWeight: content.value?.fileNameFontWeight || 500,
+            color: content.value?.fileNameColor || 'inherit',
+        }));
+
+        const fileDetailsStyles = computed(() => ({
+            fontFamily: content.value?.fileDetailsFontFamily || 'inherit',
+            fontSize: content.value?.fileDetailsFontSize || '12px',
+            fontWeight: content.value?.fileDetailsFontWeight || 'normal',
+            color: content.value?.fileDetailsColor || '#888',
+        }));
+
+        const actionButtonStyles = computed(() => ({
+            width: content.value?.actionButtonSize || '28px',
+            height: content.value?.actionButtonSize || '28px',
+            backgroundColor: content.value?.actionButtonBackground || '#fff',
+            color: content.value?.actionButtonColor || '#666',
+            borderRadius: content.value?.actionButtonBorderRadius || '4px',
+            margin: content.value?.actionButtonMargin || '0 0 0 4px',
+        }));
+
+        const formattedSize = computed(() => {
+            const fileSizeInBytes = props.file.size || 0;
+
+            if (fileSizeInBytes === 0) return '0 B';
+
+            const sizes = ['B', 'KB', 'MB', 'GB', 'TB'];
+            const i = Math.floor(Math.log(fileSizeInBytes) / Math.log(1024));
+            return `${(fileSizeInBytes / Math.pow(1024, i)).toFixed(2)} ${sizes[i]}`;
+        });
+        const isImage = computed(() => {
+            const type = (props.file?.type || props.file?.mimeType || props.file?.contentType || '').toLowerCase();
+            if (type.startsWith('image/')) return true;
+            const ext = (props.file?.name || '').split('.').pop()?.toLowerCase();
+            return ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'].includes(ext);
+        });
+
+        const previewUrl = ref(null);
+
+        const updatePreviewUrl = () => {
+            const currentValue = props.file?.previewUrl || props.file?.url || null;
+            if (currentValue) {
+                previewUrl.value = currentValue;
+                return;
+            }
+            const localFile = props.file instanceof File ? props.file : props.file?.file;
+            if (localFile instanceof File && isImage.value) {
+                previewUrl.value = URL.createObjectURL(localFile);
+                return;
+            }
+            previewUrl.value = null;
+        };
+
+        const fileIcon = computed(() => {
+            const ext = (props.file?.name || '').split('.').pop()?.toLowerCase();
+            if (ext === 'pdf') return 'fa-solid fa-file-pdf';
+            if (['doc', 'docx'].includes(ext)) return 'fa-solid fa-file-word';
+            if (['xls', 'xlsx', 'csv'].includes(ext)) return 'fa-solid fa-file-excel';
+            if (['ppt', 'pptx'].includes(ext)) return 'fa-solid fa-file-powerpoint';
+            if (['txt', 'log'].includes(ext)) return 'fa-solid fa-file-lines';
+            return 'fa-solid fa-file';
+        });
+
+        const { getIcon } = wwLib.useIcons();
+        const removeIcon = ref(null);
+
+        onMounted(async () => {
+            try {
+                removeIcon.value = await getIcon('lucide/trash');
+            } catch (e) {
+                removeIcon.value = null;
+            }
+            updatePreviewUrl();
+        });
+
+        watch(
+            () => [props.file?.previewUrl, props.file?.url, props.file?.name, props.file?.type],
+            () => updatePreviewUrl(),
+            { immediate: true }
+        );
+
+        onBeforeUnmount(() => {
+            if (previewUrl.value && previewUrl.value.startsWith('blob:')) {
+                URL.revokeObjectURL(previewUrl.value);
+            }
+        });
+
+        return {
+            formattedSize,
+            filesCount,
+            fileItemStyles,
+            fileNameStyles,
+            fileDetailsStyles,
+            actionButtonStyles,
+            content,
+            showFileInfo,
+            removeIcon,
+            isImage,
+            previewUrl,
+            fileIcon,
+        };
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined');
+
+.ww-file-item {
+    display: flex;
+    align-items: center;
+    padding: v-bind('content?.fileItemPadding || "12px"');
+    border: 1px solid v-bind('content?.fileItemBorderColor || "#eee"');
+    border-radius: v-bind('content?.fileItemBorderRadius || "6px"');
+    margin-bottom: v-bind('(content?.fileItemMargin || "0 0 8px 0").split(" ")[2] || "8px"');
+    background-color: v-bind('content?.fileItemBackground || "#fff"');
+    transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+    transform-origin: center;
+    position: relative;
+    z-index: 1;
+    backface-visibility: hidden;
+    will-change: transform, opacity;
+    overflow: hidden;
+
+    &__progress {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        z-index: 0;
+        transition: width 1.2s ease;
+        opacity: 0.2;
+    }
+
+    &:hover {
+        border-color: v-bind('content?.fileItemHoverBorderColor || content?.fileItemBorderColor || "#ddd"');
+        background-color: v-bind('content?.fileItemHoverBackground || content?.fileItemBackground || "#fff"');
+        box-shadow: v-bind(
+            'content?.fileItemHoverShadow || content?.fileItemShadow || "0 2px 4px rgba(0, 0, 0, 0.05)"'
+        );
+    }
+
+    &--disabled {
+        opacity: 0.6;
+        pointer-events: none;
+    }
+
+    &__info {
+        flex: 1;
+        min-width: 0;
+        position: relative;
+        z-index: 1;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    &__preview {
+        width: 48px;
+        height: 48px;
+        border: 1px solid #e5e7eb;
+        border-radius: 6px;
+        background: #f8fafc;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        cursor: pointer;
+
+        &:disabled {
+            opacity: 0.7;
+            cursor: not-allowed;
+        }
+    }
+
+    &__preview--not-allowed {
+        cursor: not-allowed;
+    }
+    &__meta {
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+    }
+    &__thumb {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 6px;
+    }
+    &__file-icon {
+        font-family: 'Material Symbols Outlined';
+        font-size: 24px;
+        color: #64748b;
+    }
+
+    &__name {
+        font-size: v-bind('content?.fileNameFontSize || "14px"');
+        font-weight: v-bind('content?.fileNameFontWeight || 500');
+        margin-bottom: 4px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: v-bind('content?.fileNameColor || "inherit"');
+    }
+
+    &__details {
+        font-size: v-bind('content?.fileDetailsFontSize || "12px"');
+        color: v-bind('content?.fileDetailsColor || "#888"');
+    }
+
+    &__actions {
+        display: flex;
+        align-items: center;
+        margin-left: 12px;
+        opacity: 0.7;
+        transition: opacity 0.2s ease;
+        position: relative;
+        z-index: 1;
+    }
+
+    &:hover &__actions {
+        opacity: 1;
+    }
+
+    &__btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: v-bind('content?.actionButtonSize || "28px"');
+        height: v-bind('content?.actionButtonSize || "28px"');
+        border-radius: v-bind('content?.actionButtonBorderRadius || "4px"');
+        border: 1px solid v-bind('content?.actionButtonBorderColor || content?.fileItemBorderColor || "#eee"');
+        background-color: v-bind('content?.actionButtonBackground || "#fff"');
+        color: v-bind('content?.actionButtonColor || "#666"');
+        margin-left: v-bind('(content?.actionButtonMargin || "0 0 0 4px").split(" ")[3] || "4px"');
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        &:hover:not(:disabled) {
+            border-color: v-bind(
+                'content?.actionButtonHoverBorderColor || content?.fileItemHoverBorderColor || "#ddd"'
+            );
+            background-color: v-bind('content?.actionButtonHoverBackground || "#f8f8f8"');
+            transform: scale(1.05);
+        }
+
+        &:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        &--remove:hover:not(:disabled) {
+            color: v-bind('content?.actionButtonRemoveHoverColor || content?.progressBarColor || "#999"');
+            border-color: v-bind('content?.actionButtonRemoveHoverColor || content?.progressBarColor || "#999"');
+        }
+
+        .icon {
+            width: 50%;
+            height: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            :deep(svg) {
+                width: 100% !important;
+                height: 100% !important;
+                display: block;
+            }
+        }
+    }
+}
+</style>
+
+
+<style scoped>
+.ww-file-item__file-icon.fa-file-pdf { color: #e53935; }
+.ww-file-item__file-icon.fa-file-word { color: #3b73b9; }
+.ww-file-item__file-icon.fa-file-excel { color: #2e7d32; }
+.ww-file-item__file-icon.fa-file-powerpoint { color: #d84315; }
+.ww-file-item__file-icon.fa-file-lines { color: #546e7a; }
+</style>

--- a/Project/AnexosHibrido/src/components/FileList.vue
+++ b/Project/AnexosHibrido/src/components/FileList.vue
@@ -1,0 +1,108 @@
+<template>
+    <div class="ww-file-list" role="list" aria-label="Uploaded files">
+        <transition-group name="file-list-transition" tag="div" class="ww-file-list__inner">
+            <FileItem
+                v-for="(file, index) in files"
+                :key="file.id || `file-${index}-${file.name}-${file.size}`"
+                :file="file"
+                :status="getFileStatus(file)"
+                :index="index"
+                :is-readonly="isReadonly"
+                :is-disabled="isDisabled"
+                :can-preview="canPreview(file)"
+                :preview-hint="getPreviewHint(file)"
+                @remove="$emit('remove', index)"
+                @download="$emit('download', index)"
+                @preview="$emit('preview', index)"
+            />
+        </transition-group>
+    </div>
+</template>
+
+<script>
+import FileItem from './FileItem.vue';
+
+export default {
+    name: 'FileList',
+    components: {
+        FileItem,
+    },
+    props: {
+        files: {
+            type: Array,
+            required: true,
+        },
+        status: {
+            type: Object,
+            required: true,
+        },
+        type: {
+            type: String,
+            default: 'single',
+            validator: value => ['single', 'multi'].includes(value),
+        },
+        isReadonly: {
+            type: Boolean,
+            default: false,
+        },
+        isDisabled: {
+            type: Boolean,
+            default: false,
+        },
+        canPreview: {
+            type: Function,
+            default: () => true,
+        },
+        getPreviewHint: {
+            type: Function,
+            default: () => '',
+        },
+    },
+    emits: ['remove', 'download', 'preview'],
+    setup(props) {
+        const getFileStatus = file => {
+            if (!file?.name || !props.status) return {};
+            return props.status[file.name] || {};
+        };
+
+        return {
+            getFileStatus,
+        };
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+.ww-file-list {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+
+    &__inner {
+        position: relative;
+        min-height: 0;
+        will-change: transform;
+    }
+}
+
+.file-list-transition-enter-active {
+    transition: all 0.5s cubic-bezier(0.25, 0.8, 0.25, 1);
+    transition-delay: 0.05s;
+}
+
+.file-list-transition-enter-from {
+    opacity: 0;
+    transform: translateY(20px);
+}
+
+.file-list-transition-move {
+    transition: transform 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+}
+
+.file-list-transition-leave-active {
+    transition: all 0.15s cubic-bezier(0.25, 0.8, 0.25, 1);
+    position: absolute;
+    width: 100%;
+    opacity: 0;
+}
+</style>

--- a/Project/AnexosHibrido/src/composables/useDragAnimation.js
+++ b/Project/AnexosHibrido/src/composables/useDragAnimation.js
@@ -1,0 +1,225 @@
+import { ref, onBeforeUnmount } from 'vue';
+import anime from 'animejs/lib/anime.es.js';
+
+function debounce(func, wait = 5) {
+    let timeout;
+    return function (...args) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => func.apply(this, args), wait);
+    };
+}
+
+export function useDragAnimation({
+    dropzoneRef,
+    circleRef,
+    isDisabled,
+    isReadonly,
+    dropEnabled,
+    circleOpacity,
+    animationSpeed = 0.5,
+    isEditing,
+}) {
+    const isDragging = ref(false);
+    const mouseX = ref(0);
+    const mouseY = ref(0);
+    const targetX = ref(0);
+    const targetY = ref(0);
+    const isAnimating = ref(false);
+    let animationFrameId = null;
+    let lastMoveTime = 0;
+
+    const startAnimationLoop = () => {
+        if (isAnimating.value) return;
+
+        isAnimating.value = true;
+        const springStrength = 0.12 * animationSpeed.value;
+        const damping = 0.82 + (1 - animationSpeed.value) * 0.1;
+
+        let velocityX = 0;
+        let velocityY = 0;
+        let prevTargetX = targetX.value;
+        let prevTargetY = targetY.value;
+
+        const updatePosition = () => {
+            if (!isDragging.value) {
+                isAnimating.value = false;
+                return;
+            }
+
+            prevTargetX = prevTargetX + (targetX.value - prevTargetX) * 0.3;
+            prevTargetY = prevTargetY + (targetY.value - prevTargetY) * 0.3;
+
+            const dx = prevTargetX - mouseX.value;
+            const dy = prevTargetY - mouseY.value;
+
+            velocityX = velocityX * damping + dx * springStrength;
+            velocityY = velocityY * damping + dy * springStrength;
+
+            mouseX.value += velocityX;
+            mouseY.value += velocityY;
+
+            animationFrameId = requestAnimationFrame(updatePosition);
+        };
+
+        animationFrameId = requestAnimationFrame(updatePosition);
+    };
+
+    const handleDragOver = event => {
+        if (isDisabled.value || isReadonly.value || !dropEnabled.value || isEditing.value) return;
+
+        const now = Date.now();
+        if (now - lastMoveTime < 16) return;
+        lastMoveTime = now;
+
+        event.stopPropagation();
+
+        if (dropzoneRef.value) {
+            const rect = dropzoneRef.value.getBoundingClientRect();
+            targetX.value = event.clientX - rect.left;
+            targetY.value = event.clientY - rect.top;
+        }
+
+        if (!isDragging.value) {
+            isDragging.value = true;
+
+            if (dropzoneRef.value) {
+                const rect = dropzoneRef.value.getBoundingClientRect();
+                const entryOffset = 120;
+
+                // Determine entry point from closest edge
+                const distToLeftEdge = targetX.value;
+                const distToRightEdge = rect.width - targetX.value;
+                const distToTopEdge = targetY.value;
+                const distToBottomEdge = rect.height - targetY.value;
+                const minDist = Math.min(distToLeftEdge, distToRightEdge, distToTopEdge, distToBottomEdge);
+
+                if (minDist === distToLeftEdge) {
+                    mouseX.value = -entryOffset;
+                    mouseY.value = targetY.value;
+                } else if (minDist === distToRightEdge) {
+                    mouseX.value = rect.width + entryOffset;
+                    mouseY.value = targetY.value;
+                } else if (minDist === distToTopEdge) {
+                    mouseX.value = targetX.value;
+                    mouseY.value = -entryOffset;
+                } else {
+                    mouseX.value = targetX.value;
+                    mouseY.value = rect.height + entryOffset;
+                }
+
+                if (circleRef.value) {
+                    anime({
+                        targets: circleRef.value,
+                        opacity: [0, circleOpacity.value],
+                        scale: [0.4, 1],
+                        duration: 300 / animationSpeed.value,
+                        easing: 'easeOutCubic',
+                    });
+                }
+
+                startAnimationLoop();
+            }
+        }
+    };
+
+    const handleDragLeave = event => {
+        if (dropzoneRef.value && dropzoneRef.value.contains(event.relatedTarget)) {
+            return;
+        }
+
+        if (circleRef.value && isDragging.value) {
+            anime({
+                targets: circleRef.value,
+                opacity: [circleOpacity.value, 0],
+                scale: [1, 0.4],
+                duration: 200 / animationSpeed.value,
+                easing: 'easeOutQuad',
+                complete: () => {
+                    isDragging.value = false;
+                    isAnimating.value = false;
+                },
+            });
+        } else {
+            isDragging.value = false;
+            isAnimating.value = false;
+        }
+
+        if (animationFrameId) {
+            cancelAnimationFrame(animationFrameId);
+            animationFrameId = null;
+        }
+    };
+
+    const handleDrop = event => {
+        if (isDisabled.value || isReadonly.value || !dropEnabled.value || isEditing.value) return false;
+
+        if (dropzoneRef.value) {
+            const rect = dropzoneRef.value.getBoundingClientRect();
+            mouseX.value = event.clientX - rect.left;
+            mouseY.value = event.clientY - rect.top;
+            targetX.value = mouseX.value;
+            targetY.value = mouseY.value;
+        }
+
+        if (circleRef.value) {
+            isAnimating.value = false;
+            if (animationFrameId) {
+                cancelAnimationFrame(animationFrameId);
+                animationFrameId = null;
+            }
+
+            anime({
+                targets: circleRef.value,
+                scale: [1, 35],
+                opacity: [circleOpacity.value, circleOpacity.value],
+                duration: 700,
+                easing: 'easeOutCubic',
+                complete: function () {
+                    anime({
+                        targets: circleRef.value,
+                        opacity: [circleOpacity.value, 0],
+                        duration: 300,
+                        easing: 'linear',
+                        complete: function () {
+                            isDragging.value = false;
+                        },
+                    });
+                },
+            });
+        } else {
+            isDragging.value = false;
+        }
+
+        return true;
+    };
+
+    const handleMouseMove = debounce(event => {
+        if (!isDragging.value) return;
+
+        if (dropzoneRef.value) {
+            const rect = dropzoneRef.value.getBoundingClientRect();
+            targetX.value = event.clientX - rect.left;
+            targetY.value = event.clientY - rect.top;
+        }
+    }, Math.max(5, 16 / animationSpeed.value));
+
+    onBeforeUnmount(() => {
+        if (animationFrameId) {
+            cancelAnimationFrame(animationFrameId);
+            animationFrameId = null;
+        }
+    });
+
+    return {
+        isDragging,
+        mouseX,
+        mouseY,
+        targetX,
+        targetY,
+        isAnimating,
+        handleDragOver,
+        handleDragLeave,
+        handleDrop,
+        handleMouseMove,
+    };
+}

--- a/Project/AnexosHibrido/src/editor/useParentSelection.js
+++ b/Project/AnexosHibrido/src/editor/useParentSelection.js
@@ -1,0 +1,23 @@
+import { computed, watch } from 'vue';
+
+export default function useParentSelection(props, emit) {
+    const parentSelection = computed(() => props.parentSelection);
+
+    function selectParentElement(el, ...args) {
+        wwLib.selectParentByFlag(el, ...args);
+    }
+
+    watch(
+        parentSelection,
+        parentSelection => {
+            if (parentSelection.allow && parentSelection.info) {
+                emit('update:sidepanel-content', { path: 'parentSelection', value: parentSelection.info });
+            } else {
+                emit('update:sidepanel-content', { path: 'parentSelection', value: null });
+            }
+        },
+        { immediate: true, deep: true }
+    );
+
+    return { selectParentElement };
+}

--- a/Project/AnexosHibrido/src/translation.js
+++ b/Project/AnexosHibrido/src/translation.js
@@ -1,0 +1,58 @@
+export function translatePhrase(phrase) {
+  if (phrase == null) {
+    return "";
+  }
+
+  const lang = window?.wwLib?.wwVariable?.getValue("aa44dc4c-476b-45e9-a094-16687e063342"); // idioma atual (ex: "pt-BR")
+  const jsonArr = window?.wwLib?.wwVariable?.getValue("4bb37062-2a1b-4cb6-a115-ae6df0c557d2"); // array de traduções
+  const allLangs = window?.wwLib?.wwVariable?.getValue("5abe8801-7f12-4c9c-b356-900431ab4491"); // lista de idiomas
+
+  if (!Array.isArray(jsonArr) || !Array.isArray(allLangs)) {
+    return String(phrase);
+  }
+
+  const isoLangs = allLangs.map((l) => l.Lang); // ["en-US", "pt-BR", ...]
+
+  // Helper para encontrar índice de um termo existente
+  function findIndexByTerm(term) {
+    return jsonArr.findIndex(
+      (obj) => obj.term?.trim().toLowerCase() === term.trim().toLowerCase()
+    );
+  }
+
+  const part = String(phrase).trim();
+  if (!part) {
+    return "";
+  }
+
+  const idx = findIndexByTerm(part);
+
+  if (idx === -1) {
+    // 🔹 Não existe → cria novo registro completo
+    const newEntry = { term: part, source: "FrontEnd" };
+
+    // Preenche cada idioma com o próprio texto (ou tradução automática se quiser depois)
+    isoLangs.forEach((code) => {
+      // Inicialmente copia o termo original para todos os idiomas
+      newEntry[code] = part;
+    });
+
+    // Adiciona ao array principal
+    jsonArr.push(newEntry);
+
+    // Retorna o texto no idioma atual (ou o termo se não houver tradução)
+    return newEntry[lang] ?? part;
+  } else {
+    // 🔹 Já existe → retorna a tradução existente (ou o próprio termo se estiver vazio)
+    const entry = jsonArr[idx];
+
+    const value = entry[lang];
+
+    // Se for string vazia, null ou undefined → retorna phrase
+    if (value === "" || value == null) {
+      return String(phrase);
+    }
+
+    return value;
+  }
+}

--- a/Project/AnexosHibrido/src/utils/fileProcessing.js
+++ b/Project/AnexosHibrido/src/utils/fileProcessing.js
@@ -1,0 +1,17 @@
+export function fileToBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(new Error('Failed to convert file to Base64'));
+        reader.readAsDataURL(file);
+    });
+}
+
+export function fileToBinary(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(new Error('Failed to convert file to binary'));
+        reader.readAsArrayBuffer(file);
+    });
+}

--- a/Project/AnexosHibrido/src/utils/fileValidation.js
+++ b/Project/AnexosHibrido/src/utils/fileValidation.js
@@ -1,0 +1,97 @@
+export function validateFile(file, options = {}) {
+    const { maxFileSize, minFileSize, maxTotalFileSize, currentTotalSize = 0, acceptedTypes = '' } = options;
+    const fileSizeInMB = file.size / (1024 * 1024);
+    const currentTotalSizeInMB = currentTotalSize / (1024 * 1024);
+
+    if (minFileSize && fileSizeInMB < minFileSize) {
+        return {
+            valid: false,
+            reason: `File size (${fileSizeInMB.toFixed(
+                2
+            )} MB) is less than the minimum allowed size (${minFileSize} MB)`,
+            constraint: 'MIN_SIZE',
+            details: { minSize: minFileSize, actualSize: fileSizeInMB },
+        };
+    }
+
+    if (maxFileSize && fileSizeInMB > maxFileSize) {
+        return {
+            valid: false,
+            reason: `File size (${fileSizeInMB.toFixed(2)} MB) exceeds the maximum allowed size (${maxFileSize} MB)`,
+            constraint: 'MAX_SIZE',
+            details: { maxSize: maxFileSize, actualSize: fileSizeInMB },
+        };
+    }
+
+    if (maxTotalFileSize && maxTotalFileSize > 0 && currentTotalSizeInMB + fileSizeInMB > maxTotalFileSize) {
+        return {
+            valid: false,
+            reason: `Total file size (${(currentTotalSizeInMB + fileSizeInMB).toFixed(
+                2
+            )} MB) would exceed the maximum allowed (${maxTotalFileSize} MB)`,
+            constraint: 'MAX_TOTAL_SIZE',
+            details: {
+                maxTotalSize: maxTotalFileSize,
+                currentTotalSize: currentTotalSizeInMB,
+                newFileSize: fileSizeInMB,
+                resultingTotalSize: currentTotalSizeInMB + fileSizeInMB,
+            },
+        };
+    }
+
+    if (acceptedTypes && !isFileTypeAccepted(file, acceptedTypes)) {
+        return {
+            valid: false,
+            reason: `File type "${file.type}" is not accepted. Allowed types: ${acceptedTypes}`,
+            constraint: 'INVALID_TYPE',
+            details: {
+                allowedTypes: acceptedTypes,
+                fileType: file.type,
+                fileExtension: getFileExtension(file.name, file.type),
+            },
+        };
+    }
+
+    return { valid: true };
+}
+
+function isFileTypeAccepted(file, acceptedTypes) {
+    if (!acceptedTypes || !file || !file.type) return !acceptedTypes;
+
+    const acceptedTypesArray = acceptedTypes.split(',').map(type => type.trim().toLowerCase());
+    const typeCategory = file.type.split('/')[0] + '/*';
+
+    if (acceptedTypesArray.includes(typeCategory) || acceptedTypesArray.includes(file.type.toLowerCase())) {
+        return true;
+    }
+
+    const extension = '.' + file.name.split('.').pop().toLowerCase();
+    return acceptedTypesArray.includes(extension);
+}
+
+export function getFileExtension(filename, mimeType) {
+    if (filename && filename.includes('.')) {
+        return filename.split('.').pop().toLowerCase();
+    }
+
+    if (mimeType) {
+        const mimeExtensions = {
+            'image/jpeg': 'jpg',
+            'image/png': 'png',
+            'image/gif': 'gif',
+            'image/webp': 'webp',
+            'application/pdf': 'pdf',
+            'text/csv': 'csv',
+            'application/vnd.ms-excel': 'xls',
+            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'xlsx',
+            'application/msword': 'doc',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+            'application/json': 'json',
+            'text/plain': 'txt',
+        };
+
+        return mimeExtensions[mimeType] || mimeType.split('/').pop();
+    }
+
+    return '';
+}

--- a/Project/AnexosHibrido/src/wwElement.vue
+++ b/Project/AnexosHibrido/src/wwElement.vue
@@ -1,0 +1,1142 @@
+<template>
+    <div
+        class="ww-file-upload"
+        :class="{
+            'ww-file-upload--dragging': isDragging && !isDisabled && !isReadonly,
+            'ww-file-upload--disabled': isDisabled,
+            'ww-file-upload--readonly': isReadonly,
+            'ww-file-upload--has-files': hasFiles,
+        }"
+        @dragover.prevent="handleDragOver"
+        @dragleave.prevent="handleDragLeave"
+        @drop.prevent="handleDrop"
+        role="region"
+        aria-label="File upload area"
+    >
+        <!-- Main upload area -->
+        <div
+            v-if="!isReadonly"
+            ref="dropzoneEl"
+            class="ww-file-upload__dropzone"
+            @click="openFileExplorer"
+            @mousemove="handleMouseMove"
+        >
+            <div
+                v-if="isDragging && !isDisabled && !isReadonly && enableCircleAnimation"
+                ref="circleEl"
+                class="ww-file-upload__hover-circle"
+                :style="{
+                    left: `${mouseX}px`,
+                    top: `${mouseY}px`,
+                    backgroundColor: circleColor,
+                    opacity: circleOpacity,
+                    width: circleSize,
+                    height: circleSize,
+                }"
+            ></div>
+
+            <div class="ww-file-upload__content" :class="[`ww-file-upload__content--${uploadIconPosition}`]">
+                <div v-if="showUploadIcon" class="ww-file-upload__icon" v-html="iconHTML" />
+                <div class="ww-file-upload__text">
+                    <div class="ww-file-upload__label" :style="labelMessageStyle">{{ labelMessage }}</div>
+                    <div
+                        class="ww-file-upload__info ww-file-upload__extensions-message"
+                        v-if="extensionsMessage"
+                        :style="extensionsMessageStyle"
+                    >
+                        {{ extensionsMessage }}
+                    </div>
+                    <div
+                        class="ww-file-upload__info ww-file-upload__max-file-message"
+                        v-if="maxFileMessage"
+                        :style="maxFileMessageStyle"
+                    >
+                        {{ maxFileMessage }}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- File list -->
+        <FileList
+            v-if="hasFiles"
+            :files="fileList"
+            :status="status"
+            :type="type"
+            :can-reorder="reorder"
+            :is-readonly="isReadonly"
+            :is-disabled="isDisabled"
+            :can-preview="canPreviewFile"
+            :get-preview-hint="getPreviewHint"
+            @remove="removeFile"
+            @download="downloadFileByIndex"
+            @preview="previewFileByIndex"
+            @reorder="reorderFiles"
+        />
+
+        <!-- Hidden file input -->
+        <input
+            v-if="!isReadonly"
+            ref="fileInput"
+            type="file"
+            class="ww-file-upload__input"
+            :multiple="type === 'multi'"
+            :accept="acceptedFileTypes"
+            :required="required && !hasFiles"
+            :disabled="isDisabled || isReadonly"
+            :aria-label="labelMessage"
+            @change="handleFileSelection"
+        />
+    </div>
+</template>
+
+<script>
+import { ref, computed, watch, provide, inject } from 'vue';
+import FileList from './components/FileList.vue';
+import { validateFile } from './utils/fileValidation';
+import { fileToBase64, fileToBinary } from './utils/fileProcessing';
+import { useDragAnimation } from './composables/useDragAnimation';
+import { translatePhrase } from './translation';
+
+/* wwEditor:start */
+import useParentSelection from './editor/useParentSelection';
+/* wwEditor:end */
+
+export default {
+    components: {
+        FileList,
+    },
+    props: {
+        content: { type: Object, required: true },
+        /* wwEditor:start */
+        wwFrontState: { type: Object, required: true },
+        wwEditorState: { type: Object, required: true },
+        parentSelection: { type: Object, default: () => ({ allow: false, texts: {} }) },
+        /* wwEditor:end */
+        uid: { type: String, required: true },
+        wwElementState: { type: Object, required: true },
+    },
+    emits: ['trigger-event', 'add-state', 'remove-state'],
+    setup(props, { emit }) {
+
+        const isEditing = computed(() => {
+            /* wwEditor:start */
+            return props.wwEditorState?.isEditing;
+            /* wwEditor:end */
+            // eslint-disable-next-line no-unreachable
+            return false;
+        });
+
+        /* wwEditor:start */
+        const { selectParentElement } = useParentSelection(props, emit);
+        /* wwEditor:end */
+
+        const { getIcon } = wwLib.useIcons();
+
+        const fileInput = ref(null);
+        const dropzoneEl = ref(null);
+        const circleEl = ref(null);
+        const iconText = ref(null);
+        const isProcessing = ref(false);
+
+        const extensionsMessage = computed(() => props.content?.extensionsMessage || null);
+        const maxFileMessage = computed(() => props.content?.maxFileMessage || null);
+        const labelMessage = computed(() => props.content?.labelMessage || null);
+
+        const type = computed(() => props.content?.type || 'single');
+        const reorder = computed(() => props.content?.reorder || false);
+        const drop = computed(() => props.content?.drop !== false);
+        const maxFileSize = computed(() => props.content?.maxFileSize || 10);
+        const minFileSize = computed(() => props.content?.minFileSize || 0);
+        const maxTotalFileSize = computed(() => props.content?.maxTotalFileSize || 50);
+        const maxFiles = computed(() => props.content?.maxFiles || 10);
+        const required = computed(() => props.content?.required || false);
+        const initialValue = computed(() => props.content?.initialValue || []);
+        const extensions = computed(() => props.content?.extensions || 'any');
+        const customExtensions = computed(() => props.content?.customExtensions || '');
+        const exposeBase64 = computed(() => props.content?.exposeBase64 || false);
+        const exposeBinary = computed(() => props.content?.exposeBinary || false);
+        const showUploadIcon = computed(() => props.content?.showUploadIcon !== false);
+        const uploadIcon = computed(() => props.content?.uploadIcon || 'upload');
+        const uploadIconColor = computed(() => props.content?.uploadIconColor || '#666666');
+        const uploadIconPosition = computed(() => props.content?.uploadIconPosition || 'top');
+        const uploadIconSize = computed(() => props.content?.uploadIconSize || '24px');
+        const uploadIconMargin = computed(() => props.content?.uploadIconMargin || '8px');
+        const enableCircleAnimation = computed(() => props.content?.enableCircleAnimation !== false);
+        const circleSize = computed(() => props.content?.circleSize || '80px');
+        const circleColor = computed(() => props.content?.circleColor || safeProgressBarColor.value);
+        const circleOpacity = computed(() =>
+            props.content?.circleOpacity !== undefined ? props.content.circleOpacity : 0.5
+        );
+        const animationSpeed = computed(() =>
+            props.content?.animationSpeed !== undefined ? props.content.animationSpeed : 0.5
+        );
+
+        const safeDropzoneBorderWidth = computed(() => props.content?.dropzoneBorderWidth || '2px');
+        const safeDropzoneBorderStyle = computed(() => props.content?.dropzoneBorderStyle || 'dashed');
+        const safeDropzoneBorderColor = computed(() => props.content?.dropzoneBorderColor || '#CCCCCC');
+        const safeDropzoneBorderRadius = computed(() => props.content?.dropzoneBorderRadius || '8px');
+        const safeDropzonePadding = computed(() => props.content?.dropzonePadding || '20px');
+        const safeDropzoneMinHeight = computed(() => props.content?.dropzoneMinHeight || '120px');
+        const safeDropzoneBackground = computed(() => props.content?.dropzoneBackground || 'rgba(0, 0, 0, 0)');
+        const safeDropzoneBackgroundHover = computed(
+            () => props.content?.dropzoneBackgroundHover || 'rgba(0, 0, 0, 0.01)'
+        );
+        const safeLabelFontSize = computed(() => props.content?.labelFontSize || '16px');
+        const safeLabelFontFamily = computed(() => props.content?.labelFontFamily || 'inherit');
+        const safeLabelFontWeight = computed(() => props.content?.labelFontWeight || 'normal');
+        const safeLabelColor = computed(() => props.content?.labelColor || '#333333');
+        const safeFileDetailsFontSize = computed(() => props.content?.fileDetailsFontSize || '12px');
+        const safeFileDetailsColor = computed(() => props.content?.fileDetailsColor || '#888888');
+        const safeProgressBarColor = computed(() => props.content?.progressBarColor || '#EEEEEE');
+        const safeLabelMarginBottom = computed(() => {
+            const labelMargin = props.content?.labelMargin || '0 0 4px 0';
+            return labelMargin.split(' ')[2] || '4px';
+        });
+        const safeProgressBarBackground = computed(() => {
+            const color = safeProgressBarColor.value;
+            if (!color) return 'rgba(85, 85, 85, 0.05)';
+
+            try {
+                const r = parseInt(color.slice(1, 3), 16) || 85;
+                const g = parseInt(color.slice(3, 5), 16) || 85;
+                const b = parseInt(color.slice(5, 7), 16) || 85;
+                return `rgba(${r}, ${g}, ${b}, 0.05)`;
+            } catch (e) {
+                return 'rgba(85, 85, 85, 0.05)';
+            }
+        });
+
+        const safeDropzoneBackgroundDragging = computed(
+            () => props.content?.dropzoneBackgroundDragging || 'rgba(0, 0, 0, 0.05)'
+        );
+
+        // Extensions message styling
+        const extensionsMessageStyle = computed(() => ({
+            fontFamily: props.content?.extensionsMessageFontFamily || 'inherit',
+            fontSize: props.content?.extensionsMessageFontSize || '12px',
+            fontWeight: props.content?.extensionsMessageFontWeight || 'normal',
+            color: props.content?.extensionsMessageColor || '#888888',
+            margin: props.content?.extensionsMessageMargin || '0 0 4px 0',
+        }));
+
+        // Max file message styling
+        const maxFileMessageStyle = computed(() => ({
+            fontFamily: props.content?.maxFileMessageFontFamily || 'inherit',
+            fontSize: props.content?.maxFileMessageFontSize || '12px',
+            fontWeight: props.content?.maxFileMessageFontWeight || 'normal',
+            color: props.content?.maxFileMessageColor || '#888888',
+            margin: props.content?.maxFileMessageMargin || '0 0 4px 0',
+        }));
+
+        // Label message styling
+        const labelMessageStyle = computed(() => ({
+            fontFamily: props.content?.labelFontFamily || 'inherit',
+            fontSize: props.content?.labelFontSize || '16px',
+            fontWeight: props.content?.labelFontWeight || 'normal',
+            color: props.content?.labelColor || '#333333',
+            margin: props.content?.labelMargin || '0 0 4px 0',
+        }));
+
+        const isDisabled = computed(() => props.wwElementState.props.disabled || false);
+        const isReadonly = computed(() => {
+            /* wwEditor:start */
+            if (props.wwEditorState?.isSelected) {
+                return props.wwElementState.states.includes('readonly');
+            }
+            /* wwEditor:end */
+            return props.wwElementState.props.readonly === undefined
+                ? props.content?.readonly || false
+                : props.wwElementState.props.readonly;
+        });
+
+        const { value: files, setValue: setFiles } = wwLib.wwVariable.useComponentVariable({
+            uid: props.uid,
+            name: 'value',
+            defaultValue: [],
+            type: 'file',
+            componentType: 'element',
+        });
+
+        const { value: status, setValue: setStatus } = wwLib.wwVariable.useComponentVariable({
+            uid: props.uid,
+            name: 'status',
+            defaultValue: {},
+            type: 'any',
+        });
+
+        const { value: deletedFile, setValue: setDeletedFile } = wwLib.wwVariable.useComponentVariable({
+            uid: props.uid,
+            name: 'deletedFile',
+            defaultValue: [],
+            type: 'any',
+        });
+
+        const { value: deletedFilesCount, setValue: setDeletedFilesCount } = wwLib.wwVariable.useComponentVariable({
+            uid: props.uid,
+            name: 'deletedFilesCount',
+            defaultValue: 0,
+            type: 'number',
+        });
+
+        const useForm = inject('_wwForm:useForm', () => {});
+        const fieldName = computed(() => props.content.fieldName);
+        const validation = computed(() => props.content.validation);
+        const customValidation = computed(() => props.content.customValidation);
+
+        useForm(
+            files,
+            { fieldName, validation, customValidation, required },
+            { elementState: props.wwElementState, emit, sidepanelFormPath: 'form', setValue: setFiles }
+        );
+
+        const fileList = computed(() => (Array.isArray(files.value) ? files.value : []));
+        const hasFiles = computed(() => fileList.value.length > 0);
+        const previousInitialValueHash = ref('');
+
+        const getFileKind = fileName => {
+            const ext = (fileName || '').split('.').pop()?.toLowerCase();
+            if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'].includes(ext)) return 'image';
+            if (ext === 'pdf') return 'pdf';
+            if (['txt', 'log'].includes(ext)) return 'txt';
+            return 'file';
+        };
+
+        const normalizeInitialValue = value => {
+            if (!Array.isArray(value)) return [];
+            return value
+                .map(item => {
+                    const name = item?.FileName || item?.fileName;
+                    const storageBucket = item?.StorageBucket || item?.storageBucket;
+                    const storagePath = item?.StoragePath || item?.storagePath;
+                    if (!name || !storageBucket || !storagePath) return null;
+                    const kind = getFileKind(name);
+                    return {
+                        id: item?.AttachmentID || item?.attachmentId || `init-${storagePath}`,
+                        name,
+                        size: Number(item?.SizeBytes || item?.size || 0),
+                        type: item?.ContentType || item?.contentType || 'application/octet-stream',
+                        mimeType: item?.ContentType || item?.contentType || 'application/octet-stream',
+                        attachmentId: item?.AttachmentID || item?.attachmentId || null,
+                        bucket: storageBucket,
+                        storagePath,
+                        createdDate: item?.CreatedDate || null,
+                        createdBy: item?.CreatedBy || null,
+                        isImage: kind === 'image',
+                        isPdf: kind === 'pdf',
+                        isTxt: kind === 'txt',
+                        isFromInitialValue: true,
+                    };
+                })
+                .filter(Boolean);
+        };
+
+        watch([status, fileList], ([newStatus, newFiles]) => {
+            if (newStatus && typeof newStatus === 'object') {
+                const fileNames = newFiles.map(file => file.name);
+                const updatedStatus = Object.fromEntries(
+                    Object.entries(newStatus).filter(([key]) => fileNames.includes(key))
+                );
+
+                if (Object.keys(updatedStatus).length !== Object.keys(newStatus).length) {
+                    setStatus(updatedStatus);
+                }
+            }
+        });
+
+        watch(
+            initialValue,
+            newValue => {
+                const hash = JSON.stringify(newValue || []);
+                if (hash === previousInitialValueHash.value) return;
+                previousInitialValueHash.value = hash;
+                const normalized = normalizeInitialValue(newValue);
+                setFiles(normalized);
+                emit('trigger-event', {
+                    name: 'initValueChange',
+                    event: { value: normalized },
+                });
+            },
+            { immediate: true, deep: true }
+        );
+
+        const getFileStatus = file => {
+            if (!status.value || !file.name || !status.value[file.name]) {
+                return {
+                    uploadProgress: 0,
+                    isUploading: false,
+                    isUploaded: false,
+                };
+            }
+
+            return status.value[file.name];
+        };
+
+        const acceptedFileTypes = computed(() => {
+            switch (extensions.value) {
+                case 'image':
+                    return 'image/*';
+                case 'video':
+                    return 'video/*';
+                case 'audio':
+                    return 'audio/*';
+                case 'pdf':
+                    return '.pdf';
+                case 'csv':
+                    return '.csv';
+                case 'excel':
+                    return '.xls,.xlsx,.xlsm,.xlsb';
+                case 'word':
+                    return '.doc,.docx,.docm';
+                case 'json':
+                    return '.json';
+                case 'custom':
+                    return customExtensions.value;
+                default:
+                    return '';
+            }
+        });
+
+        watch(
+            () => uploadIcon.value,
+            async icon => {
+                if (icon && showUploadIcon.value) {
+                    try {
+                        iconText.value = await getIcon(icon);
+                    } catch (error) {
+                        iconText.value = null;
+                    }
+                } else {
+                    iconText.value = null;
+                }
+            },
+            { immediate: true }
+        );
+
+        const iconHTML = computed(() => {
+            /* wwEditor:start */
+            return (
+                iconText.value ||
+                '<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-upload"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg>'
+            );
+            /* wwEditor:end */
+            return iconText.value;
+        });
+
+        const localData = ref({
+            fileUpload: {
+                value: computed(() => {
+                    return fileList.value.map(file => {
+                        const plainObject = {};
+                        for (const key in file) {
+                            if (Object.prototype.hasOwnProperty.call(file, key)) {
+                                plainObject[key] = file[key];
+                            }
+                        }
+                        plainObject.name = file.name;
+                        plainObject.size = file.size;
+                        plainObject.type = file.type;
+                        plainObject.lastModified = file.lastModified;
+                        plainObject.mimeType = file.mimeType;
+                        plainObject.id = file.id;
+
+                        if (file.base64) plainObject.base64 = file.base64;
+                        if (file.binary) plainObject.binary = file.binary;
+
+                        return plainObject;
+                    });
+                }),
+                status: status,
+                deletedFile: deletedFile,
+                deletedFilesCount: deletedFilesCount,
+            },
+        });
+
+        provide('_wwFileUpload', {
+            files: fileList,
+            status: status,
+            acceptedTypes: acceptedFileTypes,
+            isDisabled,
+            isReadonly,
+            isSingleMode: computed(() => type.value === 'single'),
+            content: computed(() => props.content || {}),
+        });
+
+        // Drag and drop animation
+        const {
+            isDragging,
+            mouseX,
+            mouseY,
+            targetX,
+            targetY,
+            isAnimating,
+            handleDragOver: animationHandleDragOver,
+            handleDragLeave: animationHandleDragLeave,
+            handleDrop: animationHandleDrop,
+            handleMouseMove: animationHandleMouseMove,
+        } = useDragAnimation({
+            dropzoneRef: dropzoneEl,
+            circleRef: circleEl,
+            isDisabled,
+            isReadonly,
+            dropEnabled: drop,
+            circleOpacity,
+            animationSpeed,
+            isEditing,
+        });
+
+        // Methods
+        const openFileExplorer = () => {
+            if (!isDisabled.value && !isReadonly.value && !isEditing.value) {
+                fileInput.value.click();
+            }
+        };
+
+        const handleDrop = async event => {
+            const animationHandled = animationHandleDrop(event);
+            if (!animationHandled || isDisabled.value || isReadonly.value || !drop.value) return;
+
+            const items = event.dataTransfer.files;
+            if (!items.length) return;
+
+            // Wait for the circle animation to complete before processing files
+            setTimeout(async () => {
+                await processFiles(items);
+            }, 1050);
+        };
+
+        const handleFileSelection = async event => {
+            const selectedFiles = event.target.files;
+            if (!selectedFiles.length) return;
+
+            await processFiles(selectedFiles);
+            event.target.value = '';
+        };
+
+        const processFiles = async fileList => {
+            isProcessing.value = true;
+            const filesToProcess = Array.from(fileList);
+
+            // Single mode handling
+            if (type.value === 'single') {
+                if (filesToProcess.length > 1) {
+                    emit('trigger-event', {
+                        name: 'error',
+                        event: {
+                            code: 'SINGLE_MODE_MULTIPLE_FILES',
+                            data: {
+                                message: 'Multiple files provided in single file mode',
+                                count: filesToProcess.length,
+                                acceptedCount: 1,
+                            },
+                        },
+                    });
+                }
+
+                filesToProcess.splice(1);
+                setFiles([]);
+            }
+
+            let availableSlots = Infinity;
+            if (type.value === 'multi' && maxFiles.value > 0) {
+                availableSlots = maxFiles.value - files.value.length;
+                if (availableSlots <= 0) {
+                    emit('trigger-event', {
+                        name: 'error',
+                        event: {
+                            code: 'MAX_FILES_REACHED',
+                            data: {
+                                message: `Maximum number of files (${maxFiles.value}) reached`,
+                                maxFiles: maxFiles.value,
+                                currentCount: files.value.length,
+                            },
+                        },
+                    });
+
+                    wwLib.wwNotification.open({
+                        text: { en: `Maximum number of files (${maxFiles.value}) reached` },
+                        color: 'warning',
+                    });
+
+                    isProcessing.value = false;
+                    return;
+                } else if (filesToProcess.length > availableSlots) {
+                    emit('trigger-event', {
+                        name: 'error',
+                        event: {
+                            code: 'TOO_MANY_FILES',
+                            data: {
+                                message: `Only ${availableSlots} more files can be added`,
+                                providedCount: filesToProcess.length,
+                                availableSlots: availableSlots,
+                                maxFiles: maxFiles.value,
+                                currentCount: files.value.length,
+                            },
+                        },
+                    });
+                }
+            }
+
+            // Process valid files
+            const limitedFiles = filesToProcess.slice(0, availableSlots);
+            const processedFiles = [];
+
+            // Only calculate currentTotalSize for multi-file mode
+            const currentTotalSize =
+                type.value === 'multi' && Array.isArray(files.value)
+                    ? files.value.reduce((sum, f) => sum + (f.size || 0), 0)
+                    : 0;
+
+            for (const file of limitedFiles) {
+                const validationResult = validateFile(file, {
+                    maxFileSize: maxFileSize.value,
+                    minFileSize: minFileSize.value,
+                    // Only apply maxTotalFileSize in multi-file mode
+                    maxTotalFileSize: type.value === 'multi' ? maxTotalFileSize.value : undefined,
+                    currentTotalSize: type.value === 'multi' ? currentTotalSize : 0,
+                    acceptedTypes: acceptedFileTypes.value,
+                });
+
+                if (validationResult.valid) {
+                    file.id = `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+                    file.mimeType = file.type;
+                    if (exposeBase64.value) file.base64 = await fileToBase64(file);
+                    if (exposeBinary.value) file.binary = await fileToBinary(file);
+                    processedFiles.push(file);
+                } else {
+                    console.warn(`File validation failed: ${validationResult.reason}`);
+                    emit('trigger-event', {
+                        name: 'error',
+                        event: {
+                            code: 'VALIDATION_ERROR',
+                            data: {
+                                message: validationResult.reason,
+                                fileName: file.name,
+                                fileSize: file.size,
+                                fileType: file.type,
+                                constraint: validationResult.constraint,
+                            },
+                        },
+                    });
+
+                    /* wwEditor:start */
+                    wwLib.wwNotification.open({
+                        text: { en: validationResult.reason },
+                        color: 'error',
+                    });
+                    /* wwEditor:end */
+                }
+            }
+
+            if (processedFiles.length > 0) {
+                if (type.value === 'single') {
+                    setFiles(processedFiles);
+                    emit('trigger-event', {
+                        name: 'change',
+                        event: { value: processedFiles },
+                    });
+                    isProcessing.value = false;
+                } else {
+                    const currentFiles = [...files.value];
+                    let newFiles = [...currentFiles];
+
+                    const addNextFile = index => {
+                        newFiles = [...newFiles, processedFiles[index]];
+                        setFiles(newFiles);
+
+                        if (index < processedFiles.length - 1) {
+                            setTimeout(() => addNextFile(index + 1), 150);
+                        } else {
+                            emit('trigger-event', {
+                                name: 'change',
+                                event: { value: newFiles },
+                            });
+                            isProcessing.value = false;
+                        }
+                    };
+
+                    // Start adding files with a small initial delay
+                    setTimeout(() => addNextFile(0), 50);
+                    return;
+                }
+            }
+
+            isProcessing.value = false;
+        };
+
+        const removeFile = index => {
+            if (isDisabled.value || isReadonly.value) return;
+
+            const removedFile = fileList.value[index] || null;
+            if (removedFile) {
+                const deletedFileEntry = {
+                    ...removedFile,
+                    id: removedFile.id || `deleted-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`,
+                    isFromInitialValue: Boolean(removedFile.isFromInitialValue),
+                };
+                setDeletedFile([...(Array.isArray(deletedFile.value) ? deletedFile.value : []), deletedFileEntry]);
+                setDeletedFilesCount((deletedFilesCount.value || 0) + 1);
+            }
+
+            const updatedFiles = [...files.value.filter((_, i) => i !== index)];
+            setFiles(updatedFiles);
+
+            emit('trigger-event', {
+                name: 'change',
+                event: { value: updatedFiles },
+            });
+        };
+
+        const getSupabase = () => wwLib?.wwPlugins?.supabase?.instance || null;
+
+        const isHttpUrl = value => typeof value === 'string' && /^https?:\/\//i.test(value);
+        const sanitizeBucket = value => (typeof value === 'string' ? value.trim().replace(/^\/+|\/+$/g, '') : '');
+        const sanitizeStoragePath = value =>
+            typeof value === 'string' ? value.trim().replace(/^\/+/, '').replace(/\?.*$/, '') : '';
+
+        const resolveStorageLocation = file => {
+            const rawBucket = sanitizeBucket(
+                file?.bucket || file?.storageBucket || file?.StorageBucket || file?.storagebucket || ''
+            );
+            let rawPath = sanitizeStoragePath(
+                file?.storagePath || file?.StoragePath || file?.storagepath || file?.path || ''
+            );
+
+            if (!rawPath && isHttpUrl(file?.url)) {
+                return { bucket: rawBucket, storagePath: '', directUrl: file.url };
+            }
+
+            if (rawPath && rawBucket && rawPath.startsWith(`${rawBucket}/`)) {
+                rawPath = rawPath.slice(rawBucket.length + 1);
+            }
+
+            if (!rawBucket && rawPath.includes('/')) {
+                const [bucketFromPath, ...rest] = rawPath.split('/');
+                return {
+                    bucket: sanitizeBucket(bucketFromPath),
+                    storagePath: sanitizeStoragePath(rest.join('/')),
+                    directUrl: isHttpUrl(file?.url) ? file.url : null,
+                };
+            }
+
+            return { bucket: rawBucket, storagePath: rawPath, directUrl: isHttpUrl(file?.url) ? file.url : null };
+        };
+
+        const resolveFileUrl = async (file, { download = false } = {}) => {
+            if (!file) return null;
+            if (!download && file.url) return file.url;
+            const localFile = file instanceof File ? file : file?.file;
+            if (localFile instanceof File) return URL.createObjectURL(localFile);
+            const supabase = getSupabase();
+            const { bucket, storagePath, directUrl } = resolveStorageLocation(file);
+            if (!supabase?.storage || !bucket || !storagePath) return directUrl || null;
+            const options = {};
+            if (download) options.download = file.name || 'download';
+            if (file?.isImage && !download) options.transform = { width: 400, resize: 'contain' };
+            const { data, error } = await supabase.storage.from(bucket).createSignedUrl(storagePath, 3600, options);
+            if (error) return null;
+            const signedUrl = data?.signedUrl || null;
+            if (!download) {
+                file.url = signedUrl;
+                file.previewUrl = signedUrl;
+            }
+            file.bucket = bucket;
+            file.storagePath = storagePath;
+            return signedUrl;
+        };
+
+        const previewUnavailableMessage = computed(() => translatePhrase('Preview not available for this file type.'));
+
+        const getFileExtension = file =>
+            (file?.name || '')
+                .split('.')
+                .pop()
+                ?.toLowerCase() || '';
+
+        const getPreviewMode = file => {
+            const ext = getFileExtension(file);
+            const type = (file?.type || file?.mimeType || file?.contentType || '').toLowerCase();
+
+            if (
+                type.startsWith('image/') ||
+                ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg', 'pdf', 'txt', 'log', 'csv', 'json'].includes(ext)
+            ) {
+                return 'direct';
+            }
+
+            if (['xls', 'xlsx', 'xlsm', 'xlsb', 'doc', 'docx', 'ppt', 'pptx'].includes(ext)) {
+                return 'office';
+            }
+
+            return 'unsupported';
+        };
+
+        const canPreviewFile = file => getPreviewMode(file) !== 'unsupported';
+
+        const getPreviewHint = file => (canPreviewFile(file) ? '' : previewUnavailableMessage.value);
+
+        const previewFileByIndex = async index => {
+            const file = fileList.value[index];
+            if (!file) return;
+            const previewMode = getPreviewMode(file);
+            if (previewMode === 'unsupported') return;
+            const url = await resolveFileUrl(file);
+            if (!url) return;
+            const previewUrl =
+                previewMode === 'office' ? `https://view.officeapps.live.com/op/view.aspx?src=${encodeURIComponent(url)}` : url;
+            window.open(previewUrl, '_blank', 'noopener,noreferrer');
+        };
+
+        const downloadFileByIndex = async index => {
+            const file = fileList.value[index];
+            if (!file) return;
+            const url = await resolveFileUrl(file, { download: true });
+            if (!url) return;
+            try {
+                const response = await fetch(url);
+                if (!response.ok) throw new Error(`HTTP ${response.status}`);
+                const blob = await response.blob();
+                const blobUrl = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = blobUrl;
+                a.download = file.name || 'download';
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+                URL.revokeObjectURL(blobUrl);
+            } catch (error) {
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = file.name || 'download';
+                document.body.appendChild(a);
+                a.click();
+                a.remove();
+            }
+        };
+
+        watch(
+            fileList,
+            async list => {
+                const items = Array.isArray(list) ? list : [];
+                await Promise.all(
+                    items.map(async file => {
+                        if (!file || !file.isImage || file.previewUrl || file.url) return;
+                        const preview = await resolveFileUrl(file);
+                        if (preview) file.previewUrl = preview;
+                    })
+                );
+            },
+            { immediate: true, deep: true }
+        );
+
+        const reorderFiles = (fromIndex, toIndex) => {
+            if (isDisabled.value || isReadonly.value || !reorder.value) return;
+
+            const newFiles = [...files.value];
+            const [movedItem] = newFiles.splice(fromIndex, 1);
+            newFiles.splice(toIndex, 0, movedItem);
+            setFiles(newFiles);
+
+            emit('trigger-event', {
+                name: 'change',
+                event: { value: newFiles },
+            });
+        };
+
+        const clearFiles = () => {
+            setFiles([]);
+        };
+
+        const getAllowedTypesLabel = () => {
+            switch (extensions.value) {
+                case 'image':
+                    return 'Images';
+                case 'video':
+                    return 'Videos';
+                case 'audio':
+                    return 'Audio files';
+                case 'pdf':
+                    return 'PDF files';
+                case 'csv':
+                    return 'CSV files';
+                case 'excel':
+                    return 'Excel files';
+                case 'word':
+                    return 'Word documents';
+                case 'json':
+                    return 'JSON files';
+                case 'custom':
+                    return customExtensions.value;
+                default:
+                    return 'All files';
+            }
+        };
+
+        wwLib.wwElement.useRegisterElementLocalContext('fileUpload', localData.value.fileUpload, {
+            clearFiles: {
+                description: 'Clear all files',
+                method: clearFiles,
+                editor: { label: 'Clear Files', group: 'File Upload', icon: 'trash' },
+            },
+        });
+
+        watch(
+            isReadonly,
+            value => {
+                if (value) {
+                    emit('add-state', 'readonly');
+                } else {
+                    emit('remove-state', 'readonly');
+                }
+            },
+            { immediate: true }
+        );
+
+        watch(
+            isDisabled,
+            value => {
+                if (value) {
+                    emit('add-state', 'disabled');
+                } else {
+                    emit('remove-state', 'disabled');
+                }
+            },
+            { immediate: true }
+        );
+
+        // Connect drag animation handlers
+        const handleDragOver = animationHandleDragOver;
+        const handleDragLeave = animationHandleDragLeave;
+        const handleMouseMove = animationHandleMouseMove;
+
+        return {
+            status,
+            fileInput,
+            isDragging,
+            fileList,
+            hasFiles,
+            isDisabled,
+            isReadonly,
+            acceptedFileTypes,
+            extensionsMessage,
+            maxFileMessage,
+            openFileExplorer,
+            handleDragOver,
+            handleDragLeave,
+            handleDrop,
+            handleFileSelection,
+            removeFile,
+            downloadFileByIndex,
+            previewFileByIndex,
+            canPreviewFile,
+            getPreviewHint,
+            reorderFiles,
+            getAllowedTypesLabel,
+            iconHTML,
+            uploadIconPosition,
+            handleMouseMove,
+            extensionsMessageStyle,
+            maxFileMessageStyle,
+            labelMessage,
+            labelMessageStyle,
+            type,
+            reorder,
+            drop,
+            maxFileSize,
+            minFileSize,
+            maxFiles,
+            required,
+            extensions,
+            customExtensions,
+            showUploadIcon,
+            uploadIcon,
+            uploadIconColor,
+            uploadIconSize,
+            uploadIconMargin,
+            enableCircleAnimation,
+            circleSize,
+            circleColor,
+            circleOpacity,
+            animationSpeed,
+
+            safeDropzoneBorderWidth,
+            safeDropzoneBorderStyle,
+            safeDropzoneBorderColor,
+            safeDropzoneBorderRadius,
+            safeDropzonePadding,
+            safeDropzoneMinHeight,
+            safeDropzoneBackground,
+            safeDropzoneBackgroundHover,
+            safeDropzoneBackgroundDragging,
+            safeLabelFontSize,
+            safeLabelFontFamily,
+            safeLabelFontWeight,
+            safeLabelColor,
+            safeFileDetailsFontSize,
+            safeFileDetailsColor,
+            safeProgressBarColor,
+            safeLabelMarginBottom,
+            safeProgressBarBackground,
+            dropzoneEl,
+            circleEl,
+            mouseX,
+            mouseY,
+            targetX,
+            targetY,
+            isAnimating,
+            isProcessing,
+            isEditing,
+
+            clearFiles,
+
+            /* wwEditor:start */
+            selectParentElement,
+            /* wwEditor:end */
+        };
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+.ww-file-upload {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    position: relative;
+
+    &__input {
+        opacity: 0;
+        background: rgba(0, 0, 0, 0);
+        border: 0;
+        bottom: -1px;
+        font-size: 0;
+        height: 1px;
+        left: 0;
+        outline: none;
+        padding: 0;
+        position: absolute;
+        right: 0;
+        width: 100%;
+    }
+
+    &__dropzone {
+        position: relative;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: v-bind('safeDropzoneBackground');
+        border: v-bind('safeDropzoneBorderWidth') v-bind('safeDropzoneBorderStyle') v-bind('safeDropzoneBorderColor');
+        border-radius: v-bind('safeDropzoneBorderRadius');
+        padding: v-bind('safeDropzonePadding');
+        min-height: v-bind('safeDropzoneMinHeight');
+        cursor: v-bind('isEditing ? "unset" : "pointer"');
+        transition: all 0.3s ease;
+        isolation: isolate;
+
+        &:hover {
+            border-color: v-bind('safeDropzoneBorderColor');
+            background-color: v-bind('safeDropzoneBackgroundHover');
+        }
+    }
+
+    &--has-files &__dropzone {
+        margin-bottom: 16px;
+    }
+
+    &__content {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        text-align: center;
+        width: 100%;
+        pointer-events: none;
+        position: relative;
+        z-index: 2;
+
+        &--top {
+            flex-direction: column;
+        }
+
+        &--right {
+            flex-direction: row-reverse;
+            justify-content: center;
+            text-align: right;
+        }
+
+        &--bottom {
+            flex-direction: column-reverse;
+        }
+
+        &--left {
+            flex-direction: row;
+            justify-content: center;
+            text-align: left;
+        }
+    }
+
+    &__text {
+        display: flex;
+        flex-direction: column;
+        pointer-events: none;
+    }
+
+    &__icon {
+        font-size: v-bind('uploadIconSize');
+        color: v-bind('uploadIconColor');
+        width: 1em;
+        height: 1em;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-shrink: 0;
+        pointer-events: none;
+        margin: v-bind('uploadIconMargin');
+
+        > :deep(svg) {
+            width: 100%;
+            height: 100%;
+        }
+    }
+
+    &__info {
+        display: block;
+    }
+
+    &--dragging {
+        .ww-file-upload__dropzone {
+            background-color: v-bind('safeDropzoneBackgroundDragging');
+        }
+    }
+
+    &--disabled {
+        opacity: 0.6;
+        pointer-events: none;
+
+        .ww-file-upload__dropzone {
+            cursor: not-allowed;
+            background-color: v-bind('safeDropzoneBackground');
+        }
+    }
+
+    &--readonly {
+        .ww-file-upload__dropzone {
+            cursor: default;
+            background-color: v-bind('safeDropzoneBackground');
+        }
+    }
+
+    &__hover-circle {
+        position: absolute;
+        border-radius: 50%;
+        pointer-events: none;
+        z-index: -1;
+        transform: translate(-50%, -50%);
+        transition: opacity 0.3s ease-out, transform 0.3s ease-out;
+        will-change: transform, opacity;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
+        backface-visibility: hidden;
+    }
+}
+</style>

--- a/Project/AnexosHibrido/ww-config.js
+++ b/Project/AnexosHibrido/ww-config.js
@@ -1,0 +1,1339 @@
+export default {
+    editor: {
+        label: 'Anexos Híbrido',
+        icon: 'upload',
+        bubble: { icon: 'upload' },
+        customSettingsPropertiesOrder: [
+            // UX properties
+            'type',
+            'reorder',
+            'drop',
+            'maxFileSize',
+            'minFileSize',
+            'maxTotalFileSize',
+            'maxFiles',
+            'required',
+            'readonly',
+            'initialValue',
+            'extensions',
+            'customExtensions',
+            'exposeBase64',
+            'exposeBinary',
+            ['formInfobox', 'fieldName', 'customValidation', 'validation'],
+        ],
+        customStylePropertiesOrder: [
+            // Dropzone properties
+            {
+                label: "Dropzone",
+                isCollapsible: true,
+                properties: [
+                    'dropzoneBorderColor',
+                    'dropzoneBorderStyle',
+                    'dropzoneBorderWidth',
+                    'dropzoneBorderRadius',
+                    'dropzoneBackground',
+                    'dropzoneBackgroundHover',
+                    'dropzoneBackgroundDragging',
+                    'dropzonePadding',
+                    'dropzoneMinHeight',
+                ],
+            },
+            // Icon properties
+            {
+                label: "Icon",
+                isCollapsible: true,
+                properties: [
+                    'showUploadIcon',
+                    'uploadIcon',
+                    'uploadIconColor',
+                    'uploadIconSize',
+                    'uploadIconMargin',
+                    'uploadIconPosition',
+                ],
+            },
+            // Label properties
+            {
+                label: "Label",
+                isCollapsible: true,
+                properties: [
+                    'labelMessage',
+                    'labelFontFamily',
+                    'labelFontSize',
+                    'labelFontWeight',
+                    'labelColor',
+                    'labelMargin',
+                ],
+            },
+            // Info messages properties
+            {
+                label: "Info messages",
+                isCollapsible: true,
+                properties: [
+                    'extensionsMessage',
+                    'extensionsMessageFontFamily',
+                    'extensionsMessageFontSize',
+                    'extensionsMessageFontWeight',
+                    'extensionsMessageColor',
+                    'extensionsMessageMargin',
+                    'maxFileMessage',
+                    'maxFileMessageFontFamily',
+                    'maxFileMessageFontSize',
+                    'maxFileMessageFontWeight',
+                    'maxFileMessageColor',
+                    'maxFileMessageMargin',
+                ],
+            },
+            // File list properties
+            {
+                label: "File list",
+                isCollapsible: true,
+                properties: [
+                    'fileListTitle',
+                    'fileItemBackground',
+                    'fileItemBorderColor',
+                    'fileItemBorderRadius',
+                    'fileItemPadding',
+                    'fileItemMargin',
+                    'fileItemShadow',
+                    'progressBarColor',
+                    'progressBarColorWarning',
+                ],
+            },
+            {
+                label: "File item hover states",
+                isCollapsible: true,
+                properties: [
+                    'fileItemHoverBorderColor',
+                    'fileItemHoverBackground',
+                    'fileItemHoverShadow',
+                ],
+            },
+            // File details properties
+            {
+                label: "File name",
+                isCollapsible: true,
+                properties: [
+                    'fileNameFontFamily',
+                    'fileNameFontSize',
+                    'fileNameFontWeight',
+                    'fileNameColor',
+                ],
+            },
+            {
+                label: "File details",
+                isCollapsible: true,
+                properties: [
+                    'showFileInfo',
+                    'fileDetailsFontFamily',
+                    'fileDetailsFontSize',
+                    'fileDetailsFontWeight',
+                    'fileDetailsColor',
+                ],
+            }, 
+            // Action buttons properties
+            {
+                label: "Remove buttons",
+                isCollapsible: true,
+                properties:  [
+                    'actionButtonSize',
+                    'actionButtonBackground',
+                    'actionButtonHoverBackground',
+                    'actionButtonColor',
+                    'actionButtonBorderColor',
+                    'actionButtonHoverBorderColor',
+                    'actionButtonBorderRadius',
+                    'actionButtonMargin',
+                ],
+            },
+            // Circle animation properties
+            {
+                label: "Drag & drop animation",
+                isCollapsible: true,
+                properties: [
+                    'enableCircleAnimation',
+                    'circleSize',
+                    'circleColor',
+                    'circleOpacity',
+                    'animationSpeed',
+                ],
+            },
+        ],
+        hint: (_, sidePanelContent) => {
+            if (!sidePanelContent.parentSelection) return null;
+            const { header, text, button, args } = sidePanelContent.parentSelection;
+            const sections = ['style', 'settings'];
+            return sections.map(section => ({
+                section,
+                header: header,
+                text: text,
+                button: {
+                    text: button,
+                    action: 'selectParent',
+                    args,
+                },
+            }));
+        },
+    },
+    options: {
+        displayAllowedValues: ['flex', 'inline-flex', 'block'],
+        icons: ['lucide/trash'],
+    },
+    triggerEvents: [
+        {
+            name: 'change',
+            label: { en: 'On change' },
+            event: { value: [] },
+            default: true,
+        },
+        {
+            name: 'initValueChange',
+            label: { en: 'On init value change' },
+            event: { value: [] },
+        },
+        {
+            name: 'error',
+            label: { en: 'On error' },
+            event: {
+                code: 'VALIDATION_ERROR',
+                data: { message: 'File validation failed' },
+            },
+        },
+    ],
+    actions: [
+        {
+            label: { en: 'Clear Files' },
+            action: 'clearFiles',
+            args: [],
+        },
+    ],
+    properties: {
+        type: {
+            label: { en: 'Upload type' },
+            type: 'TextSelect',
+            options: {
+                options: [
+                    { value: 'single', label: { en: 'Single file' } },
+                    { value: 'multi', label: { en: 'Multiple files' } },
+                ],
+            },
+            section: 'settings',
+            defaultValue: 'single',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                enum: ['single', 'multi'],
+                tooltip: 'A string that defines the upload type: `"single" | "multi"`',
+            },
+            /* wwEditor:end */
+        },
+        drop: {
+            label: { en: 'Allow drag & drop' },
+            type: 'OnOff',
+            section: 'settings',
+            defaultValue: true,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'A boolean that defines if drag and drop is enabled: `true | false`',
+            },
+            /* wwEditor:end */
+        },
+        maxFileSize: {
+            label: { en: 'Max file size (MB)' },
+            type: 'Number',
+            options: { min: 0 },
+            section: 'settings',
+            defaultValue: 10,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'number',
+                tooltip: 'A number that defines the maximum allowed file size in MB: `10`',
+            },
+            /* wwEditor:end */
+        },
+        minFileSize: {
+            label: { en: 'Min file size (MB)' },
+            type: 'Number',
+            options: { min: 0 },
+            section: 'settings',
+            defaultValue: 0,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'number',
+                tooltip: 'A number that defines the minimum allowed file size in MB: `0`',
+            },
+            /* wwEditor:end */
+        },
+        maxTotalFileSize: {
+            label: { en: 'Max total size (MB)' },
+            type: 'Number',
+            options: { min: 0 },
+            section: 'settings',
+            defaultValue: 50,
+            hidden: content => content.type !== 'multi',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'number',
+                tooltip: 'A number that defines the maximum total file size in MB: `50`',
+            },
+            /* wwEditor:end */
+        },
+        maxFiles: {
+            label: { en: 'Max number of files' },
+            type: 'Number',
+            options: { min: 1 },
+            section: 'settings',
+            defaultValue: 10,
+            hidden: content => content.type !== 'multi',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'number',
+                tooltip: 'A number that defines the maximum number of files allowed: `10`',
+            },
+            /* wwEditor:end */
+        },
+        showFileInfo: {
+            label: { en: 'Show file details' },
+            type: 'OnOff',
+            defaultValue: true,
+            bindable: true,
+        },
+        required: {
+            label: { en: 'Required' },
+            type: 'OnOff',
+            section: 'settings',
+            defaultValue: false,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'A boolean that defines if the upload is required: `true | false`',
+            },
+            /* wwEditor:end */
+        },
+        readonly: {
+            label: { en: 'Read only' },
+            type: 'OnOff',
+            section: 'settings',
+            defaultValue: false,
+            bindable: true,
+            hidden: (content, sidePanelContent, boundProps, wwProps) => !!(wwProps && wwProps.readonly !== undefined),
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'A boolean that defines if the upload is in readonly mode: `true | false`',
+            },
+            /* wwEditor:end */
+        },
+        initialValue: {
+            label: { en: 'Initial value (attachments JSON)' },
+            type: 'Array',
+            section: 'settings',
+            bindable: true,
+            defaultValue: [],
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'array',
+                tooltip:
+                    'Array in the same structure returned by getKnowledgeAttachmentsByVersion: AttachmentID, StorageBucket, StoragePath, FileName, ContentType, SizeBytes, CreatedDate, CreatedBy.',
+            },
+            /* wwEditor:end */
+        },
+        extensions: {
+            label: { en: 'Allowed file types' },
+            type: 'TextSelect',
+            options: {
+                options: [
+                    { value: 'any', label: { en: 'Any' } },
+                    { value: 'image', label: { en: 'Image' } },
+                    { value: 'video', label: { en: 'Video' } },
+                    { value: 'audio', label: { en: 'Audio' } },
+                    { value: 'pdf', label: { en: 'PDF' } },
+                    { value: 'csv', label: { en: 'CSV' } },
+                    { value: 'excel', label: { en: 'Excel' } },
+                    { value: 'word', label: { en: 'Word' } },
+                    { value: 'json', label: { en: 'JSON' } },
+                    { value: 'custom', label: { en: 'Custom' } },
+                ],
+            },
+            section: 'settings',
+            defaultValue: 'any',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'A string that defines the allowed file types: `"any" | "image" | "video" | "custom"`',
+            },
+            /* wwEditor:end */
+        },
+        customExtensions: {
+            type: 'Text',
+            options: { placeholder: '.html, .xml, .pt' },
+            section: 'settings',
+            hidden: content => content.extensions !== 'custom',
+            defaultValue: '',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'A comma-separated list of allowed file extensions: `".html, .xml, .pt"`',
+            },
+            /* wwEditor:end */
+        },
+        exposeBase64: {
+            label: { en: 'Expose as Base64' },
+            type: 'OnOff',
+            section: 'settings',
+            defaultValue: false,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'A boolean that defines if files should be exposed as Base64: `true | false`',
+            },
+            propertyHelp: {
+                tooltip:
+                    "Base64 strings can be very large, so we crop them when displayed in the editor interface. Don't worry, the variable contains the full value when it is used.",
+            },
+            /* wwEditor:end */
+        },
+        exposeBinary: {
+            label: { en: 'Expose as Binary' },
+            type: 'OnOff',
+            section: 'settings',
+            defaultValue: false,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'A boolean that defines if files should be exposed as Binary: `true | false`',
+            },
+            propertyHelp: {
+                tooltip:
+                    'Binary data is a special object that can be very large in size. It will appear as an empty object in the editor interface. To inspect it, you can log it to the console.',
+            },
+            /* wwEditor:end */
+        },
+
+        // ======== DROPZONE PROPERTIES ========
+        dropzoneBorderColor: {
+            label: { en: 'Border color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#CCCCCC',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzoneBorderStyle: {
+            label: { en: 'Border style' },
+            type: 'TextSelect',
+            section: 'style',
+            options: {
+                options: [
+                    { value: 'solid', label: 'Solid' },
+                    { value: 'dashed', label: 'Dashed' },
+                    { value: 'dotted', label: 'Dotted' },
+                    { value: 'none', label: 'None' },
+                ],
+            },
+            defaultValue: 'dashed',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzoneBorderWidth: {
+            label: { en: 'Border width' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [{ value: 'px', label: 'px', min: 0, max: 10 }],
+            },
+            defaultValue: '2px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzoneBorderRadius: {
+            label: { en: 'Border radius' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 0, max: 100 },
+                    { value: '%', label: '%', min: 0, max: 50 },
+                ],
+            },
+            defaultValue: '8px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzoneBackground: {
+            label: { en: 'Background color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: 'rgba(0, 0, 0, 0.01)',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzoneBackgroundHover: {
+            label: { en: 'Background color hover' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: 'rgba(0, 0, 0, 0.01)',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzoneBackgroundDragging: {
+            label: { en: 'Background color dragging' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: 'rgba(0, 0, 0, 0.05)',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzonePadding: {
+            label: { en: 'Padding' },
+            type: 'Spacing',
+            section: 'style',
+            defaultValue: '20px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        dropzoneMinHeight: {
+            label: { en: 'Min height' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 0, max: 500 },
+                    { value: 'vh', label: 'vh', min: 0, max: 100 },
+                ],
+            },
+            defaultValue: '120px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+
+        // ======== ICON PROPERTIES ========
+        showUploadIcon: {
+            label: { en: 'Show upload icon' },
+            type: 'OnOff',
+            section: 'icon',
+            defaultValue: true,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'A boolean that defines if the upload icon should be displayed: `true | false`',
+            },
+            /* wwEditor:end */
+        },
+        uploadIcon: {
+            label: { en: 'Upload icon' },
+            type: 'SystemIcon',
+            section: 'icon',
+            defaultValue: 'upload',
+            bindable: true,
+            hidden: content => !content.showUploadIcon,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'A string that defines the upload icon code',
+            },
+            /* wwEditor:end */
+        },
+        uploadIconPosition: {
+            label: { en: 'Icon position' },
+            type: 'TextSelect',
+            options: {
+                options: [
+                    { value: 'top', label: { en: 'Top' } },
+                    { value: 'right', label: { en: 'Right' } },
+                    { value: 'bottom', label: { en: 'Bottom' } },
+                    { value: 'left', label: { en: 'Left' } },
+                ],
+            },
+            section: 'icon',
+            defaultValue: 'top',
+            hidden: content => !content.showUploadIcon,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                enum: ['top', 'right', 'bottom', 'left'],
+                tooltip:
+                    'A string that defines the position of the icon relative to the text: `"top" | "right" | "bottom" | "left"`',
+            },
+            /* wwEditor:end */
+        },
+        uploadIconColor: {
+            label: { en: 'Icon color' },
+            type: 'Color',
+            section: 'icon',
+            defaultValue: '#666666',
+            bindable: true,
+            hidden: content => !content.showUploadIcon,
+            options: {
+                nullable: true,
+            },
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'The color of the icon',
+            },
+            /* wwEditor:end */
+        },
+        uploadIconSize: {
+            label: { en: 'Size' },
+            type: 'Length',
+            section: 'icon',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 12, max: 100 },
+                    { value: 'em', label: 'em', min: 0.5, max: 6 },
+                    { value: 'rem', label: 'rem', min: 0.5, max: 6 },
+                ],
+            },
+            defaultValue: '24px',
+            classes: true,
+            states: true,
+            responsive: true,
+            hidden: content => !content.showUploadIcon,
+            bindable: true,
+        },
+        uploadIconMargin: {
+            label: { en: 'Margin' },
+            type: 'Spacing',
+            section: 'icon',
+            defaultValue: '8px',
+            classes: true,
+            states: true,
+            responsive: true,
+            hidden: content => !content.showUploadIcon,
+            bindable: true,
+        },
+
+        // ======== LABEL PROPERTIES ========
+        labelMessage: {
+            label: { en: 'Label' },
+            type: 'Text',
+            defaultValue: 'Drop files here or click to upload',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'A string that defines the label message: `"Drop files here or click to upload"`',
+            },
+            /* wwEditor:end */
+        },
+        labelFontFamily: {
+            label: { en: 'Font family' },
+            type: 'FontFamily',
+            section: 'style',
+            defaultValue: null,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        labelFontSize: {
+            label: { en: 'Font size' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 8, max: 64 },
+                    { value: 'em', label: 'em', min: 0.5, max: 4 },
+                    { value: 'rem', label: 'rem', min: 0.5, max: 4 },
+                ],
+            },
+            defaultValue: '16px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        labelFontWeight: {
+            label: { en: 'Font weight' },
+            type: 'TextSelect',
+            section: 'style',
+            options: {
+                options: [
+                    { value: null, label: { en: 'Default' } },
+                    { value: 300, label: { en: '300 - Light' } },
+                    { value: 400, label: { en: '400 - Regular' } },
+                    { value: 500, label: { en: '500 - Medium' } },
+                    { value: 600, label: { en: '600 - Semi Bold' } },
+                    { value: 700, label: { en: '700 - Bold' } },
+                ],
+            },
+            defaultValue: null,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        labelColor: {
+            label: { en: 'Color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#333333',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        labelMargin: {
+            label: { en: 'Margin' },
+            type: 'Spacing',
+            section: 'style',
+            defaultValue: '0 0 4px 0',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+
+        // ======== INFO MESSAGES PROPERTIES ========
+        extensionsMessage: {
+            label: { en: 'Extensions message' },
+            type: 'Text',
+            defaultValue: 'Allowed file types: {extensions}',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip:
+                    'A string that defines the message to display when an invalid file type is uploaded: `"Allowed file types: {extensions}"`',
+            },
+            /* wwEditor:end */
+        },
+        extensionsMessageFontFamily: {
+            label: { en: 'Extensions message font family' },
+            type: 'FontFamily',
+            section: 'style',
+            defaultValue: null,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        extensionsMessageFontSize: {
+            label: { en: 'Extensions message font size' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 8, max: 64 },
+                    { value: 'em', label: 'em', min: 0.5, max: 4 },
+                    { value: 'rem', label: 'rem', min: 0.5, max: 4 },
+                ],
+            },
+            defaultValue: '12px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        extensionsMessageFontWeight: {
+            label: { en: 'Extensions message font weight' },
+            type: 'TextSelect',
+            section: 'style',
+            options: {
+                options: [
+                    { value: null, label: { en: 'Default' } },
+                    { value: 300, label: { en: '300 - Light' } },
+                    { value: 400, label: { en: '400 - Regular' } },
+                    { value: 500, label: { en: '500 - Medium' } },
+                    { value: 600, label: { en: '600 - Semi Bold' } },
+                    { value: 700, label: { en: '700 - Bold' } },
+                ],
+            },
+            defaultValue: 400,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        extensionsMessageColor: {
+            label: { en: 'Extensions message color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#888888',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        extensionsMessageMargin: {
+            label: { en: 'Extensions message margin' },
+            type: 'Spacing',
+            section: 'style',
+            defaultValue: '0 0 4px 0',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        maxFileMessage: {
+            label: { en: 'Max file message' },
+            type: 'Text',
+            defaultValue: 'Max file size: {maxFileSize} MB',
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'A string that defines the max file message: `"Max file size: {maxFileSize} MB"`',
+            },
+            /* wwEditor:end */
+        },
+        maxFileMessageFontFamily: {
+            label: { en: 'Max file message font family' },
+            type: 'FontFamily',
+            section: 'style',
+            defaultValue: null,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        maxFileMessageFontSize: {
+            label: { en: 'Max file message font size' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 8, max: 64 },
+                    { value: 'em', label: 'em', min: 0.5, max: 4 },
+                    { value: 'rem', label: 'rem', min: 0.5, max: 4 },
+                ],
+            },
+            defaultValue: '12px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        maxFileMessageFontWeight: {
+            label: { en: 'Max file message font weight' },
+            type: 'TextSelect',
+            section: 'style',
+            options: {
+                options: [
+                    { value: null, label: { en: 'Default' } },
+                    { value: 300, label: { en: '300 - Light' } },
+                    { value: 400, label: { en: '400 - Regular' } },
+                    { value: 500, label: { en: '500 - Medium' } },
+                    { value: 600, label: { en: '600 - Semi Bold' } },
+                    { value: 700, label: { en: '700 - Bold' } },
+                ],
+            },
+            defaultValue: 400,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        maxFileMessageColor: {
+            label: { en: 'Max file message color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#888888',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        maxFileMessageMargin: {
+            label: { en: 'Max file message margin' },
+            type: 'Spacing',
+            section: 'style',
+            defaultValue: '0 0 4px 0',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+
+        // ======== FILE LIST PROPERTIES ========
+        fileItemBackground: {
+            label: { en: 'Background color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#FFFFFF',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileItemBorderColor: {
+            label: { en: 'Border color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#EEEEEE',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileItemBorderRadius: {
+            label: { en: 'Border radius' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 0, max: 100 },
+                    { value: '%', label: '%', min: 0, max: 50 },
+                ],
+            },
+            defaultValue: '6px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileItemPadding: {
+            label: { en: 'Padding' },
+            type: 'Spacing',
+            section: 'style',
+            defaultValue: '12px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileItemMargin: {
+            label: { en: 'Margin' },
+            type: 'Spacing',
+            section: 'style',
+            defaultValue: '0 0 8px 0',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileItemShadow: {
+            label: { en: 'Shadow' },
+            type: 'Shadows',
+            section: 'style',
+            defaultValue: '0 2px 4px rgba(0, 0, 0, 0.05)',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        progressBarColor: {
+            label: { en: 'Progress bar color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#4CAF50',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        progressBarColorWarning: {
+            type: 'InfoBox',
+            options: {
+                variant: 'warning',
+                content: "The progress bar is only compatible with the WeWeb's upload file action.",
+            },
+            editorOnly: true,
+        },
+        fileItemHoverBorderColor: {
+            label: { en: 'Hover border color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#DDDDDD',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileItemHoverBackground: {
+            label: { en: 'Hover background color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#FFFFFF',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileItemHoverShadow: {
+            label: { en: 'Hover shadow' },
+            type: 'Shadows',
+            section: 'style',
+            defaultValue: '0 2px 4px rgba(0, 0, 0, 0.05)',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+
+        // ======== FILE DETAILS PROPERTIES ========
+        fileNameFontFamily: {
+            label: { en: 'Font family' },
+            type: 'FontFamily',
+            section: 'style',
+            defaultValue: null,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileNameFontSize: {
+            label: { en: 'Font size' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 8, max: 64 },
+                    { value: 'em', label: 'em', min: 0.5, max: 4 },
+                    { value: 'rem', label: 'rem', min: 0.5, max: 4 },
+                ],
+            },
+            defaultValue: '14px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileNameFontWeight: {
+            label: { en: 'Font weight' },
+            type: 'TextSelect',
+            section: 'style',
+            options: {
+                options: [
+                    { value: null, label: { en: 'Default' } },
+                    { value: 300, label: { en: '300 - Light' } },
+                    { value: 400, label: { en: '400 - Regular' } },
+                    { value: 500, label: { en: '500 - Medium' } },
+                    { value: 600, label: { en: '600 - Semi Bold' } },
+                    { value: 700, label: { en: '700 - Bold' } },
+                ],
+            },
+            defaultValue: 500,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileNameColor: {
+            label: { en: 'Color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#333333',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileDetailsFontFamily: {
+            label: { en: 'Font family' },
+            type: 'FontFamily',
+            section: 'style',
+            defaultValue: null,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileDetailsFontSize: {
+            label: { en: 'Font size' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 8, max: 64 },
+                    { value: 'em', label: 'em', min: 0.5, max: 4 },
+                    { value: 'rem', label: 'rem', min: 0.5, max: 4 },
+                ],
+            },
+            defaultValue: '12px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileDetailsFontWeight: {
+            label: { en: 'Font weight' },
+            type: 'TextSelect',
+            section: 'style',
+            options: {
+                options: [
+                    { value: null, label: { en: 'Default' } },
+                    { value: 300, label: { en: '300 - Light' } },
+                    { value: 400, label: { en: '400 - Regular' } },
+                    { value: 500, label: { en: '500 - Medium' } },
+                    { value: 600, label: { en: '600 - Semi Bold' } },
+                    { value: 700, label: { en: '700 - Bold' } },
+                ],
+            },
+            defaultValue: 400,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileDetailsColor: {
+            label: { en: 'Color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#888888',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+
+        // ======== ACTION BUTTON PROPERTIES ========
+        actionButtonSize: {
+            label: { en: 'Size' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 16, max: 64 },
+                    { value: 'em', label: 'em', min: 1, max: 4 },
+                    { value: 'rem', label: 'rem', min: 1, max: 4 },
+                ],
+            },
+            defaultValue: '28px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        actionButtonBackground: {
+            label: { en: 'Background color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#FFFFFF',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        actionButtonHoverBackground: {
+            label: { en: 'Hover background color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#F8F8F8',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        actionButtonColor: {
+            label: { en: 'Icon color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#666666',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        actionButtonBorderColor: {
+            label: { en: 'Border color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#EEEEEE',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        actionButtonHoverBorderColor: {
+            label: { en: 'Hover border color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#DDDDDD',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        actionButtonBorderRadius: {
+            label: { en: 'Border radius' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 0, max: 100 },
+                    { value: '%', label: '%', min: 0, max: 50 },
+                ],
+            },
+            defaultValue: '4px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        actionButtonMargin: {
+            label: { en: 'Margin' },
+            type: 'Spacing',
+            section: 'style',
+            defaultValue: '0 0 0 4px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+
+        // ======== CIRCLE ANIMATION PROPERTIES ========
+        enableCircleAnimation: {
+            label: { en: 'Enable circle animation' },
+            type: 'OnOff',
+            section: 'style',
+            defaultValue: true,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip:
+                    'A boolean that defines if the circle animation during drag and drop is enabled: `true | false`',
+            },
+            /* wwEditor:end */
+        },
+        circleSize: {
+            label: { en: 'Circle size' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [{ value: 'px', label: 'px', min: 20, max: 500 }],
+            },
+            defaultValue: '180px',
+            hidden: content => !content.enableCircleAnimation,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        circleColor: {
+            label: { en: 'Circle color' },
+            type: 'Color',
+            section: 'style',
+            defaultValue: '#EEEEEE',
+            hidden: content => !content.enableCircleAnimation,
+            classes: true,
+            states: true,
+            responsive: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'string',
+                tooltip: 'The color of the drag and drop circle. If not set, uses the progress bar color.',
+            },
+            /* wwEditor:end */
+        },
+        circleOpacity: {
+            label: { en: 'Circle opacity' },
+            type: 'Number',
+            options: { min: 0, max: 1, step: 0.1 },
+            section: 'style',
+            defaultValue: 0.5,
+            hidden: content => !content.enableCircleAnimation,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        animationSpeed: {
+            label: { en: 'Animation speed' },
+            type: 'Number',
+            options: { min: 0.1, max: 2, step: 0.1 },
+            section: 'style',
+            defaultValue: 0.5, // Half speed by default
+            hidden: content => !content.enableCircleAnimation,
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'number',
+                tooltip:
+                    'Controls the speed of the drag and drop animation (0.5 = half speed, 1 = normal, 2 = double speed)',
+            },
+            /* wwEditor:end */
+        },
+        // FORM PROPERTIES: Mainly used in the sidepanel for UX purposes
+        /* wwEditor:start */
+        parentSelection: {
+            editorOnly: true,
+            defaultValue: false,
+        },
+        /* wwEditor:end */
+        /* wwEditor:start */
+        form: {
+            editorOnly: true,
+            hidden: true,
+            defaultValue: false,
+        },
+        formInfobox: {
+            type: 'InfoBox',
+            section: 'settings',
+            options: (_, sidePanelContent) => ({
+                variant: sidePanelContent.form?.name ? 'success' : 'warning',
+                icon: 'pencil',
+                title: sidePanelContent.form?.name || 'Unnamed form',
+                content: !sidePanelContent.form?.name && 'Give your form a meaningful name.',
+            }),
+            hidden: (_, sidePanelContent) => !sidePanelContent.form?.uid,
+        },
+        /* wwEditor:end */
+        fieldName: {
+            label: 'Field name',
+            section: 'settings',
+            type: 'Text',
+            defaultValue: '',
+            bindable: true,
+            hidden: (_, sidePanelContent) => {
+                return !sidePanelContent.form?.uid;
+            },
+        },
+        customValidation: {
+            label: 'Custom validation',
+            section: 'settings',
+            type: 'OnOff',
+            defaultValue: false,
+            bindable: true,
+            hidden: (_, sidePanelContent) => {
+                return !sidePanelContent.form?.uid;
+            },
+        },
+        validation: {
+            label: 'Validation',
+            section: 'settings',
+            type: 'Formula',
+            defaultValue: '',
+            bindable: false,
+            hidden: (content, sidePanelContent) => {
+                return !sidePanelContent.form?.uid || !content.customValidation;
+            },
+        },
+    },
+};


### PR DESCRIPTION
### Motivation
- Criar um novo componente de anexos que una a apresentação visual do `Project/Anexos` com o fluxo local de arquivos do `Project/AnexosGenerico` sem dependência obrigatória de persistência externa.
- Manter compatibilidade com automações e ações existentes provendo os mesmos eventos, component actions e variáveis do componente genérico.
- Exibir miniaturas como no `AnexosGenerico` e ícones de arquivo no estilo do `Anexos` para manter a mesma experiência visual.

### Description
- Adicionado novo componente em `Project/AnexosHibrido` contendo `ww-config.js`, `src/wwElement.vue`, `src/components/FileList.vue`, `src/components/FileItem.vue`, `src/composables/useDragAnimation.js`, `src/editor/useParentSelection.js`, `src/utils/fileProcessing.js`, `src/utils/fileValidation.js` e `src/translation.js` com a lógica de upload/preview/remoção tratada localmente no componente.
- Preservadas as variáveis de componente usadas pelo formulário via `wwLib.wwVariable.useComponentVariable` (`value`, `status`, `deletedFile`, `deletedFilesCount`) e registrado contexto local com `wwLib.wwElement.useRegisterElementLocalContext`, incluindo a action `clearFiles` disponível no editor.
- Implementada validação de arquivos com `validateFile`, conversões `fileToBase64`/`fileToBinary`, animação de drag (`useDragAnimation`) e fluxo de processamento que emite os eventos `change`, `initValueChange` e `error` conforme o comportamento esperado.
- Ajustado `FileItem` para manter miniatura de imagens (como no genérico) e usar classes de ícones por extensão (`fa-solid fa-file-*`) para igualar a aparência do `Project/Anexos`, além de incluir estilos de apoio e tradução via `translatePhrase`.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f9230d3483308a6b09f884cf6998)