### PR TITLE
AnexosHibrido: trocar dropzone por tile '+' e layout de miniaturas com wrap

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -239,7 +239,7 @@ export default {
     padding: v-bind('content?.fileItemPadding || "12px"');
     border: 1px solid v-bind('content?.fileItemBorderColor || "#eee"');
     border-radius: v-bind('content?.fileItemBorderRadius || "6px"');
-    margin-bottom: v-bind('(content?.fileItemMargin || "0 0 8px 0").split(" ")[2] || "8px"');
+    margin-bottom: 0;
     background-color: v-bind('content?.fileItemBackground || "#fff"');
     transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
     transform-origin: center;

--- a/Project/AnexosHibrido/src/components/FileList.vue
+++ b/Project/AnexosHibrido/src/components/FileList.vue
@@ -75,12 +75,13 @@ export default {
 <style lang="scss" scoped>
 .ww-file-list {
     display: flex;
-    flex-direction: column;
-    width: 100%;
+    flex: 1;
+    min-width: 0;
 
     &__inner {
-        position: relative;
-        min-height: 0;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
         will-change: transform;
     }
 }

--- a/Project/AnexosHibrido/src/wwElement.vue
+++ b/Project/AnexosHibrido/src/wwElement.vue
@@ -13,66 +13,37 @@
         role="region"
         aria-label="File upload area"
     >
-        <!-- Main upload area -->
-        <div
-            v-if="!isReadonly"
-            ref="dropzoneEl"
-            class="ww-file-upload__dropzone"
-            @click="openFileExplorer"
-            @mousemove="handleMouseMove"
-        >
-            <div
-                v-if="isDragging && !isDisabled && !isReadonly && enableCircleAnimation"
-                ref="circleEl"
-                class="ww-file-upload__hover-circle"
-                :style="{
-                    left: `${mouseX}px`,
-                    top: `${mouseY}px`,
-                    backgroundColor: circleColor,
-                    opacity: circleOpacity,
-                    width: circleSize,
-                    height: circleSize,
-                }"
-            ></div>
+        <div class="ww-file-upload__grid">
+            <button
+                v-if="!isReadonly"
+                type="button"
+                ref="dropzoneEl"
+                class="ww-file-upload__add-tile"
+                :disabled="isDisabled"
+                :aria-label="labelMessage || 'Adicionar anexo'"
+                @click="openFileExplorer"
+                @mousemove="handleMouseMove"
+            >
+                <span class="ww-file-upload__add-icon">+</span>
+            </button>
 
-            <div class="ww-file-upload__content" :class="[`ww-file-upload__content--${uploadIconPosition}`]">
-                <div v-if="showUploadIcon" class="ww-file-upload__icon" v-html="iconHTML" />
-                <div class="ww-file-upload__text">
-                    <div class="ww-file-upload__label" :style="labelMessageStyle">{{ labelMessage }}</div>
-                    <div
-                        class="ww-file-upload__info ww-file-upload__extensions-message"
-                        v-if="extensionsMessage"
-                        :style="extensionsMessageStyle"
-                    >
-                        {{ extensionsMessage }}
-                    </div>
-                    <div
-                        class="ww-file-upload__info ww-file-upload__max-file-message"
-                        v-if="maxFileMessage"
-                        :style="maxFileMessageStyle"
-                    >
-                        {{ maxFileMessage }}
-                    </div>
-                </div>
-            </div>
+            <!-- File list -->
+            <FileList
+                v-if="hasFiles"
+                :files="fileList"
+                :status="status"
+                :type="type"
+                :can-reorder="reorder"
+                :is-readonly="isReadonly"
+                :is-disabled="isDisabled"
+                :can-preview="canPreviewFile"
+                :get-preview-hint="getPreviewHint"
+                @remove="removeFile"
+                @download="downloadFileByIndex"
+                @preview="previewFileByIndex"
+                @reorder="reorderFiles"
+            />
         </div>
-
-        <!-- File list -->
-        <FileList
-            v-if="hasFiles"
-            :files="fileList"
-            :status="status"
-            :type="type"
-            :can-reorder="reorder"
-            :is-readonly="isReadonly"
-            :is-disabled="isDisabled"
-            :can-preview="canPreviewFile"
-            :get-preview-hint="getPreviewHint"
-            @remove="removeFile"
-            @download="downloadFileByIndex"
-            @preview="previewFileByIndex"
-            @reorder="reorderFiles"
-        />
 
         <!-- Hidden file input -->
         <input
@@ -1019,30 +990,40 @@ export default {
         width: 100%;
     }
 
-    &__dropzone {
-        position: relative;
-        overflow: hidden;
+    &__grid {
         display: flex;
-        flex-direction: column;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        gap: 8px;
+    }
+
+    &__add-tile {
+        width: 48px;
+        height: 48px;
+        border: 1px dashed v-bind('safeDropzoneBorderColor');
+        border-radius: 6px;
+        background-color: v-bind('safeDropzoneBackground');
+        display: flex;
         align-items: center;
         justify-content: center;
-        background-color: v-bind('safeDropzoneBackground');
-        border: v-bind('safeDropzoneBorderWidth') v-bind('safeDropzoneBorderStyle') v-bind('safeDropzoneBorderColor');
-        border-radius: v-bind('safeDropzoneBorderRadius');
-        padding: v-bind('safeDropzonePadding');
-        min-height: v-bind('safeDropzoneMinHeight');
-        cursor: v-bind('isEditing ? "unset" : "pointer"');
-        transition: all 0.3s ease;
-        isolation: isolate;
+        cursor: pointer;
+        flex-shrink: 0;
+        transition: all 0.2s ease;
 
         &:hover {
-            border-color: v-bind('safeDropzoneBorderColor');
             background-color: v-bind('safeDropzoneBackgroundHover');
+        }
+
+        &:disabled {
+            cursor: not-allowed;
+            opacity: 0.6;
         }
     }
 
-    &--has-files &__dropzone {
-        margin-bottom: 16px;
+    &__add-icon {
+        font-size: 34px;
+        line-height: 1;
+        color: v-bind('safeDropzoneBorderColor');
     }
 
     &__content {
@@ -1105,7 +1086,7 @@ export default {
     }
 
     &--dragging {
-        .ww-file-upload__dropzone {
+        .ww-file-upload__add-tile {
             background-color: v-bind('safeDropzoneBackgroundDragging');
         }
     }
@@ -1114,17 +1095,11 @@ export default {
         opacity: 0.6;
         pointer-events: none;
 
-        .ww-file-upload__dropzone {
-            cursor: not-allowed;
-            background-color: v-bind('safeDropzoneBackground');
-        }
+        .ww-file-upload__add-tile { cursor: not-allowed; }
     }
 
     &--readonly {
-        .ww-file-upload__dropzone {
-            cursor: default;
-            background-color: v-bind('safeDropzoneBackground');
-        }
+        .ww-file-upload__add-tile { cursor: default; }
     }
 
     &__hover-circle {


### PR DESCRIPTION
### Motivation
- Substituir a dropzone tradicional por um container de adição no tamanho das miniaturas com um ícone grande "+" para simplificar a ação de adicionar anexos.
- Exibir as miniaturas ao lado do container de adição e permitir quebra automática de linha (wrap) quando não couberem na linha.
- Ajustar o espaçamento dos itens para ser controlado pelo container com wrap em vez de margens fixas nos itens.

### Description
- Substituído o markup da dropzone em `AnexosHibrido/src/wwElement.vue` por um botão tile `ww-file-upload__add-tile` que abre o seletor de arquivos ao ser clicado.
- Adicionado o container `ww-file-upload__grid` e estilos associados para dispor o tile de adição e as miniaturas em uma linha com `flex-wrap` e `gap`, incluindo estados de hover/disabled/dragging.
- Modificado `AnexosHibrido/src/components/FileList.vue` para renderizar a lista como um flex container com `flex-wrap` e `gap`.
- Removida a margem inferior fixa em `AnexosHibrido/src/components/FileItem.vue` para que o espaçamento passe a ser controlado pelo `gap` do container.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f239bb9910833095ab2743b41952f2)