### PR TITLE
feat(anexos-hibrido): permitir tamanho configurável dos tiles e elipse no nome

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -273,17 +273,19 @@ export default {
     }
 
     &__info {
-        flex: 1;
-        min-width: 0;
+        width: v-bind('content?.fileTileWidth || "120px"');
+        height: v-bind('content?.fileTileHeight || "120px"');
         position: relative;
         z-index: 1;
         display: flex;
+        flex-direction: column;
         align-items: center;
+        justify-content: center;
         gap: 10px;
     }
     &__preview {
-        width: 48px;
-        height: 48px;
+        width: 100%;
+        height: calc(100% - 30px);
         border: 1px solid #e5e7eb;
         border-radius: 6px;
         background: #f8fafc;
@@ -303,9 +305,11 @@ export default {
         cursor: not-allowed;
     }
     &__meta {
+        width: 100%;
         min-width: 0;
         display: flex;
         flex-direction: column;
+        align-items: center;
     }
     &__thumb {
         width: 100%;
@@ -323,6 +327,8 @@ export default {
         font-size: v-bind('content?.fileNameFontSize || "14px"');
         font-weight: v-bind('content?.fileNameFontWeight || 500');
         margin-bottom: 4px;
+        width: 100%;
+        text-align: center;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/Project/AnexosHibrido/src/wwElement.vue
+++ b/Project/AnexosHibrido/src/wwElement.vue
@@ -998,8 +998,8 @@ export default {
     }
 
     &__add-tile {
-        width: 48px;
-        height: 48px;
+        width: v-bind('content?.fileTileWidth || "120px"');
+        height: v-bind('content?.fileTileHeight || "120px"');
         border: 1px dashed v-bind('safeDropzoneBorderColor');
         border-radius: 6px;
         background-color: v-bind('safeDropzoneBackground');

--- a/Project/AnexosHibrido/ww-config.js
+++ b/Project/AnexosHibrido/ww-config.js
@@ -89,6 +89,8 @@ export default {
                 isCollapsible: true,
                 properties: [
                     'fileListTitle',
+                    'fileTileWidth',
+                    'fileTileHeight',
                     'fileItemBackground',
                     'fileItemBorderColor',
                     'fileItemBorderRadius',
@@ -878,6 +880,38 @@ export default {
         },
 
         // ======== FILE LIST PROPERTIES ========
+        fileTileWidth: {
+            label: { en: 'Tile width' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 40, max: 500 },
+                    { value: '%', label: '%', min: 10, max: 100 },
+                ],
+            },
+            defaultValue: '120px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
+        fileTileHeight: {
+            label: { en: 'Tile height' },
+            type: 'Length',
+            section: 'style',
+            options: {
+                unitChoices: [
+                    { value: 'px', label: 'px', min: 40, max: 500 },
+                    { value: 'vh', label: 'vh', min: 5, max: 80 },
+                ],
+            },
+            defaultValue: '120px',
+            classes: true,
+            states: true,
+            responsive: true,
+            bindable: true,
+        },
         fileItemBackground: {
             label: { en: 'Background color' },
             type: 'Color',


### PR DESCRIPTION
### Motivation
- Permitir que o componente `AnexosHibrido` tenha tiles (miniaturas e botão de adicionar) com largura e altura configuráveis via propriedades de estilo para melhor controle visual.
- Garantir que nomes de arquivo longos não quebrem o layout, ficando truncados com elipse abaixo da miniatura.

### Description
- Adicionadas as propriedades de estilo `fileTileWidth` e `fileTileHeight` em `Project/AnexosHibrido/ww-config.js` para expor largura/altura dos tiles no editor.
- Aplicado `content?.fileTileWidth` e `content?.fileTileHeight` ao botão de adicionar (`.ww-file-upload__add-tile`) em `Project/AnexosHibrido/src/wwElement.vue` para que use o mesmo tamanho configurável.
- Ajustado `Project/AnexosHibrido/src/components/FileItem.vue` para que o container que engloba miniatura e metadados (`&__info`) use as dimensões configuráveis e organize a miniatura acima do nome, centralizando o nome e mantendo `text-overflow: ellipsis`.
- Arquivos alterados: `Project/AnexosHibrido/ww-config.js`, `Project/AnexosHibrido/src/wwElement.vue`, `Project/AnexosHibrido/src/components/FileItem.vue`.

### Testing
- Inspeção de código com `rg` e `sed` foi executada para localizar pontos de aplicação e confirmar alterações, e estes comandos concluíram com sucesso.
- As alterações foram aplicadas via patch and staged, e `git status --short` foi verificado successfully.
- Arquivos foram adicionados e o commit foi criado com `git commit -m "feat(anexos-hibrido): permitir tamanho dos tiles e elipse no nome"`, e o commit foi bem-sucedido.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f23df3bf288330904acebad4fbb3f3)