### PR TITLE
Fix missing thumbnails/icons for existing files in AnexosHibrido

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -4,7 +4,7 @@
         :class="{ 'ww-file-item--disabled': isDisabled }"
         :style="fileItemStyles"
         role="listitem"
-        :aria-label="`File: ${file.name}, Size: ${formattedSize}`"
+        :aria-label="`File: ${resolvedName || 'Attachment'}, Size: ${formattedSize}`"
     >
         <div
             v-if="status && status.uploadProgress !== undefined"
@@ -21,7 +21,7 @@
                 class="ww-file-item__preview"
                 :disabled="isDisabled"
                 @click="$emit('preview')"
-                :aria-label="`Preview ${file.name}`"
+                :aria-label="`Preview ${resolvedName || 'attachment'}`"
                 :title="previewHint || null"
                 :class="{ 'ww-file-item__preview--not-allowed': !canPreview }"
             >
@@ -54,7 +54,7 @@
             </button>
 
             <div class="ww-file-item__meta">
-                <div class="ww-file-item__name" :style="fileNameStyles">{{ file.name }}</div>
+                <div class="ww-file-item__name" :style="fileNameStyles">{{ resolvedName }}</div>
                 <div class="ww-file-item__details" :style="fileDetailsStyles" v-if="showFileInfo">
                     <span>{{ formattedSize }}</span>
                     <span v-if="status && status.uploadProgress !== undefined">• {{ `${Math.round(status.uploadProgress)}%` }}</span>
@@ -94,6 +94,11 @@ export default {
             height: content.value?.actionButtonSize || '28px',
         }));
 
+        
+
+        const resolvedName = computed(() => props.file?.name || props.file?.fileName || props.file?.FileName || props.file?.originalName || '');
+        const resolvedType = computed(() => (props.file?.type || props.file?.mimeType || props.file?.contentType || props.file?.ContentType || '').toLowerCase());
+
         const formattedSize = computed(() => {
             const n = props.file.size || 0;
             if (!n) return '0 B';
@@ -103,9 +108,9 @@ export default {
         });
 
         const isImage = computed(() => {
-            const type = (props.file?.type || props.file?.mimeType || '').toLowerCase();
+            const type = resolvedType.value;
             if (type.startsWith('image/')) return true;
-            const ext = (props.file?.name || '').split('.').pop()?.toLowerCase();
+            const ext = (resolvedName.value || '').split('.').pop()?.toLowerCase();
             return ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'].includes(ext);
         });
 
@@ -119,7 +124,7 @@ export default {
         };
 
         const fileIcon = computed(() => {
-            const ext = (props.file?.name || '').split('.').pop()?.toLowerCase();
+            const ext = (resolvedName.value || '').split('.').pop()?.toLowerCase();
             if (ext === 'pdf') return 'fa fa-file-pdf-o';
             if (['doc', 'docx'].includes(ext)) return 'fa fa-file-word-o';
             if (['xls', 'xlsx', 'csv'].includes(ext)) return 'fa fa-file-excel-o';
@@ -129,12 +134,12 @@ export default {
         });
 
         onMounted(updatePreviewUrl);
-        watch(() => [props.file?.previewUrl, props.file?.url, props.file?.name, props.file?.type], updatePreviewUrl, { immediate: true });
+        watch(() => [props.file?.previewUrl, props.file?.url, resolvedName.value, resolvedType.value], updatePreviewUrl, { immediate: true });
         onBeforeUnmount(() => {
             if (previewUrl.value && previewUrl.value.startsWith('blob:')) URL.revokeObjectURL(previewUrl.value);
         });
 
-        return { content, showFileInfo, formattedSize, fileNameStyles, fileDetailsStyles, actionButtonStyles, isImage, previewUrl, fileIcon, fileItemStyles };
+        return { content, showFileInfo, formattedSize, fileNameStyles, fileDetailsStyles, actionButtonStyles, isImage, previewUrl, fileIcon, fileItemStyles, resolvedName };
     },
 };
 </script>

--- a/Project/AnexosHibrido/src/wwElement.vue
+++ b/Project/AnexosHibrido/src/wwElement.vue
@@ -277,20 +277,23 @@ export default {
             if (!Array.isArray(value)) return [];
             return value
                 .map(item => {
-                    const name = item?.FileName || item?.fileName;
-                    const storageBucket = item?.StorageBucket || item?.storageBucket;
-                    const storagePath = item?.StoragePath || item?.storagePath;
-                    if (!name || !storageBucket || !storagePath) return null;
+                    const name = item?.FileName || item?.fileName || item?.name || item?.originalName;
+                    const storageBucket = item?.StorageBucket || item?.storageBucket || item?.bucket;
+                    const storagePath = item?.StoragePath || item?.storagePath || item?.path;
+                    const directUrl = item?.Url || item?.url || item?.signedUrl || null;
+                    if (!name || (!storageBucket && !storagePath && !directUrl)) return null;
                     const kind = getFileKind(name);
                     return {
-                        id: item?.AttachmentID || item?.attachmentId || `init-${storagePath}`,
+                        id: item?.AttachmentID || item?.attachmentId || item?.id || `init-${storagePath || name}`,
                         name,
                         size: Number(item?.SizeBytes || item?.size || 0),
                         type: item?.ContentType || item?.contentType || 'application/octet-stream',
                         mimeType: item?.ContentType || item?.contentType || 'application/octet-stream',
-                        attachmentId: item?.AttachmentID || item?.attachmentId || null,
-                        bucket: storageBucket,
-                        storagePath,
+                        attachmentId: item?.AttachmentID || item?.attachmentId || item?.id || null,
+                        bucket: storageBucket || null,
+                        storagePath: storagePath || '',
+                        url: directUrl,
+                        previewUrl: directUrl,
                         createdDate: item?.CreatedDate || null,
                         createdBy: item?.CreatedBy || null,
                         isImage: kind === 'image',


### PR DESCRIPTION
### Motivation
- Persisted attachments were rendered as empty tiles because the hybrid attachments component expected strict property names (`name`, `type`, `storagePath`), causing missing thumbnails/icons and non-functional actions for existing files.

### Description
- Updated `Project/AnexosHibrido/src/components/FileItem.vue` to resolve display name and MIME/type from multiple keys by adding `resolvedName` and `resolvedType` computed values and using them for aria labels, icon selection, image detection, and reactive preview updates.
- Switched `FileItem` to use `resolvedName` in the UI and `resolvedType` in image/type checks, and updated the `watch` that drives preview URL generation to observe these resolved values.
- Updated `Project/AnexosHibrido/src/wwElement.vue` `normalizeInitialValue` to accept more payload variants (`name`, `originalName`, `bucket`, `path`, `url`, `signedUrl`, `id`) and to preserve `url`/`previewUrl` when a direct link exists so initial attachments render and can be previewed/downloaded.
- Added fallbacks for `id`, `attachmentId`, `bucket`, and `storagePath` to avoid rejecting valid initial entries that used different field names.

### Testing
- Ran `git status --short` to verify modified files and it completed successfully.
- Committed the changes with `git commit -m "Fix hybrid attachments preview metadata resolution"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3302a19108330a5287d7d4d1dbb5d)