### PR TITLE
Corrige miniaturas de imagens em AnexosHibrido

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -98,8 +98,19 @@ export default {
 
         
 
-        const resolvedName = computed(() => props.file?.name || props.file?.fileName || props.file?.FileName || props.file?.originalName || '');
-        const resolvedType = computed(() => (props.file?.type || props.file?.mimeType || props.file?.contentType || props.file?.ContentType || '').toLowerCase());
+        const resolvedName = computed(
+            () => props.file?.name || props.file?.fileName || props.file?.FileName || props.file?.originalName || ''
+        );
+        const resolvedType = computed(() =>
+            (
+                props.file?.type ||
+                props.file?.mimeType ||
+                props.file?.contentType ||
+                props.file?.ContentType ||
+                props.file?.mime_type ||
+                ''
+            ).toLowerCase()
+        );
 
         const formattedSize = computed(() => {
             const n = props.file.size || 0;
@@ -118,7 +129,16 @@ export default {
 
         const previewUrl = ref(null);
         const updatePreviewUrl = () => {
-            previewUrl.value = props.file?.previewUrl || props.file?.url || null;
+            previewUrl.value =
+                props.file?.previewUrl ||
+                props.file?.url ||
+                props.file?.downloadUrl ||
+                props.file?.downloadURL ||
+                props.file?.thumbnailUrl ||
+                props.file?.base64 ||
+                props.file?.base64Data ||
+                props.file?.Base64Data ||
+                null;
             const localFile = props.file instanceof File ? props.file : props.file?.file;
             if (!previewUrl.value && localFile instanceof File && isImage.value) {
                 previewUrl.value = URL.createObjectURL(localFile);
@@ -145,7 +165,22 @@ export default {
         });
 
         onMounted(updatePreviewUrl);
-        watch(() => [props.file?.previewUrl, props.file?.url, resolvedName.value, resolvedType.value], updatePreviewUrl, { immediate: true });
+        watch(
+            () => [
+                props.file?.previewUrl,
+                props.file?.url,
+                props.file?.downloadUrl,
+                props.file?.downloadURL,
+                props.file?.thumbnailUrl,
+                props.file?.base64,
+                props.file?.base64Data,
+                props.file?.Base64Data,
+                resolvedName.value,
+                resolvedType.value,
+            ],
+            updatePreviewUrl,
+            { immediate: true }
+        );
         onBeforeUnmount(() => {
             if (previewUrl.value && previewUrl.value.startsWith('blob:')) URL.revokeObjectURL(previewUrl.value);
         });


### PR DESCRIPTION
### Motivation
- The file tile UI rendered a generic file icon instead of an image thumbnail when backend payloads used alternative fields or nonstandard MIME keys. 
- Thumbnails must be resolved from multiple common preview sources so image attachments display correctly.

### Description
- Updated `Project/AnexosHibrido/src/components/FileItem.vue` to consider `mime_type` in addition to existing MIME fields when resolving `resolvedType`. 
- Expanded `updatePreviewUrl` to accept additional preview keys: `downloadUrl`, `downloadURL`, `thumbnailUrl`, `base64`, `base64Data`, and `Base64Data`. 
- Extended the reactive `watch` to include the new preview fields so thumbnails refresh when any supported source changes.

### Testing
- No automated tests were executed for this change. 
- Changes are limited to `FileItem.vue` and were reviewed for syntactic correctness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3339aa8f0833093e460f732cc513e)