### PR TITLE
Support base64 previews and additional file fields in FileItem.vue

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -98,8 +98,19 @@ export default {
 
         
 
-        const resolvedName = computed(() => props.file?.name || props.file?.fileName || props.file?.FileName || props.file?.originalName || '');
-        const resolvedType = computed(() => (props.file?.type || props.file?.mimeType || props.file?.contentType || props.file?.ContentType || '').toLowerCase());
+        const resolvedName = computed(
+            () => props.file?.name || props.file?.fileName || props.file?.FileName || props.file?.originalName || ''
+        );
+        const resolvedType = computed(() =>
+            (
+                props.file?.type ||
+                props.file?.mimeType ||
+                props.file?.contentType ||
+                props.file?.ContentType ||
+                props.file?.mime_type ||
+                ''
+            ).toLowerCase()
+        );
 
         const formattedSize = computed(() => {
             const n = props.file.size || 0;
@@ -117,8 +128,28 @@ export default {
         });
 
         const previewUrl = ref(null);
+        const getDataUrlFromBase64 = value => {
+            if (!value || typeof value !== 'string') return null;
+            if (value.startsWith('data:')) return value;
+            const sanitized = value.replace(/\s/g, '');
+            if (!sanitized) return null;
+            const mime = resolvedType.value || 'image/png';
+            return `data:${mime};base64,${sanitized}`;
+        };
+
         const updatePreviewUrl = () => {
-            previewUrl.value = props.file?.previewUrl || props.file?.url || null;
+            const base64Preview =
+                getDataUrlFromBase64(props.file?.base64) ||
+                getDataUrlFromBase64(props.file?.base64Data) ||
+                getDataUrlFromBase64(props.file?.Base64Data);
+            previewUrl.value =
+                props.file?.previewUrl ||
+                props.file?.url ||
+                props.file?.downloadUrl ||
+                props.file?.downloadURL ||
+                props.file?.thumbnailUrl ||
+                base64Preview ||
+                null;
             const localFile = props.file instanceof File ? props.file : props.file?.file;
             if (!previewUrl.value && localFile instanceof File && isImage.value) {
                 previewUrl.value = URL.createObjectURL(localFile);
@@ -145,7 +176,22 @@ export default {
         });
 
         onMounted(updatePreviewUrl);
-        watch(() => [props.file?.previewUrl, props.file?.url, resolvedName.value, resolvedType.value], updatePreviewUrl, { immediate: true });
+        watch(
+            () => [
+                props.file?.previewUrl,
+                props.file?.url,
+                props.file?.downloadUrl,
+                props.file?.downloadURL,
+                props.file?.thumbnailUrl,
+                props.file?.base64,
+                props.file?.base64Data,
+                props.file?.Base64Data,
+                resolvedName.value,
+                resolvedType.value,
+            ],
+            updatePreviewUrl,
+            { immediate: true }
+        );
         onBeforeUnmount(() => {
             if (previewUrl.value && previewUrl.value.startsWith('blob:')) URL.revokeObjectURL(previewUrl.value);
         });


### PR DESCRIPTION
### Motivation
- Accept more variations of file metadata coming from different backends so previews resolve reliably across integrations.
- Allow base64-encoded image data to be used as preview sources in addition to URL and `File` objects.
- Add fallbacks for alternate field names like `mime_type`, `downloadUrl`, and `thumbnailUrl` to improve robustness.

### Description
- Added a helper `getDataUrlFromBase64` to sanitize and convert base64 strings into data URLs for previews.
- Extended `resolvedType` to check for `mime_type` and normalize mime types to lowercase.
- Expanded `updatePreviewUrl` to prefer `previewUrl`, `url`, `downloadUrl`, `downloadURL`, `thumbnailUrl`, or a base64-derived data URL before falling back to `null`, and retain creating an object URL for local `File` instances.
- Updated the `watch` dependencies to include the new preview-related fields (`downloadUrl`, `downloadURL`, `thumbnailUrl`, `base64`, `base64Data`, `Base64Data`) so the preview updates when any of them change.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3339aa8f0833093e460f732cc513e)