### PR TITLE
feat(AnexosHibrido): exibir miniaturas para qualquer tipo de imagem

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -120,11 +120,36 @@ export default {
             return `${(n / Math.pow(1024, i)).toFixed(2)} ${sizes[i]}`;
         });
 
+        const IMAGE_EXTENSIONS = new Set([
+            'apng', 'avif', 'bmp', 'cur', 'gif', 'heic', 'heif', 'ico', 'jfif', 'jpeg', 'jpg', 'pjpeg', 'pjp',
+            'png', 'svg', 'tif', 'tiff', 'webp',
+        ]);
+
+        const getExtension = value => {
+            if (!value || typeof value !== 'string') return '';
+            const sanitized = value.split('?')[0].split('#')[0];
+            const extension = sanitized.split('.').pop()?.toLowerCase();
+            return extension && extension !== sanitized.toLowerCase() ? extension : '';
+        };
+
         const isImage = computed(() => {
             const type = resolvedType.value;
             if (type.startsWith('image/')) return true;
-            const ext = (resolvedName.value || '').split('.').pop()?.toLowerCase();
-            return ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp', 'svg'].includes(ext);
+            const dataUrl = props.file?.base64 || props.file?.base64Data || props.file?.Base64Data || '';
+            if (typeof dataUrl === 'string' && dataUrl.startsWith('data:image/')) return true;
+
+            const extensionCandidates = [
+                resolvedName.value,
+                props.file?.url,
+                props.file?.downloadUrl,
+                props.file?.downloadURL,
+                props.file?.previewUrl,
+                props.file?.thumbnailUrl,
+            ]
+                .map(getExtension)
+                .filter(Boolean);
+
+            return extensionCandidates.some(ext => IMAGE_EXTENSIONS.has(ext));
         });
 
         const previewUrl = ref(null);


### PR DESCRIPTION
### Motivation
- Garantir que anexos do tipo imagem sejam exibidos como miniaturas no componente AnexosHibrido mesmo quando o MIME estiver ausente ou inconsistente.

### Description
- Atualiza a lógica em `Project/AnexosHibrido/src/components/FileItem.vue` para detectar imagens além do `image/*` via MIME. 
- Adiciona um conjunto ampliado de extensões de imagem suportadas (`avif`, `heic`, `heif`, `tiff`, `ico`, etc.).
- Introduz o helper `getExtension` que extrai a extensão de nomes/URLs removendo querystring e hash antes da verificação. 
- Passa a considerar também `data:` URLs e as extensões encontradas em `name`, `url`, `downloadUrl`, `previewUrl` e `thumbnailUrl` para decidir renderizar a miniatura.

### Testing
- Não houve testes automatizados específicos adicionados a este PR; uma verificação básica de integridade do repositório foi realizada com sucesso.
- Alteração limitada a um arquivo e validação local da build/linters deve ser feita no pipeline usual (nenhum erro introduzido pelo patch localmente).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3492482388330b0476094304611bc)