### PR TITLE
Ajusta altura do modal e cursor dos anexos no AnexosHibrido

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -230,6 +230,7 @@ export default {
 .ww-file-item { position: relative;
 &__info { width: v-bind('content?.fileTileWidth || "120px"'); }
 &__preview { width: 100%; height: v-bind('content?.fileTileHeight || "120px"'); display: flex; align-items: center; justify-content: center; position: relative; border: 1px solid #e5e7eb; border-radius: 6px; background: #fff; overflow: hidden; }
+&__preview:hover { cursor: pointer; }
 &__thumb { width: 100%; height: 100%; object-fit: cover; border-radius: 6px; }
 &__file-icon { font-size: 42px; color: #64748b; line-height: 1; }
 &__actions { position: absolute; top: 6px; right: 6px; display: flex; gap: 4px; opacity: 0; pointer-events: none; transition: opacity .2s; }

--- a/Project/AnexosHibrido/src/wwElement.vue
+++ b/Project/AnexosHibrido/src/wwElement.vue
@@ -1191,7 +1191,7 @@ export default {
     &__content {
         position: relative;
         width: min(1000px, 95vw);
-        max-height: 92vh;
+        max-height: 90vh;
         background: #fff;
         border-radius: 12px;
         padding: 16px;
@@ -1220,7 +1220,7 @@ export default {
 
     &__body {
         min-height: 240px;
-        max-height: calc(92vh - 120px);
+        max-height: calc(90vh - 120px);
         display: flex;
         align-items: center;
         justify-content: center;


### PR DESCRIPTION
### Motivation
- Melhorar a experiência de pré-visualização no componente AnexosHibrido fazendo o modal ocupar 90% da altura da viewport e indicando que os anexos são interativos ao exibir o cursor `pointer` ao passar o mouse.

### Description
- Alteradas regras SCSS em `Project/AnexosHibrido/src/wwElement.vue` para reduzir o `max-height` do modal de `92vh` para `90vh` e ajustar o `max-height` do corpo para `calc(90vh - 120px)`.
- Adicionada regra CSS em `Project/AnexosHibrido/src/components/FileItem.vue` para definir `cursor: pointer` em `.ww-file-item__preview:hover`.

### Testing
- Aplicado o patch e verificado os trechos alterados com `nl -ba /workspace/NewCode/Project/AnexosHibrido/src/wwElement.vue | sed -n '1188,1235p'` e `nl -ba /workspace/NewCode/Project/AnexosHibrido/src/components/FileItem.vue | sed -n '228,248p'`, e inspecionado o status do repositório com `git status --short`; todas as verificações automáticas concluíram sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f34e79a53483309e1d0f0bc70128a8)