### PR TITLE
Remove list marker next to attachments in AnexosHibrido

### DIFF
--- a/Project/AnexosHibrido/src/components/FileItem.vue
+++ b/Project/AnexosHibrido/src/components/FileItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <li
+    <div
         class="ww-file-item"
         :class="{ 'ww-file-item--disabled': isDisabled }"
         :style="fileItemStyles"
@@ -63,7 +63,7 @@
                 </div>
             </div>
         </div>
-    </li>
+    </div>
 </template>
 
 <script>


### PR DESCRIPTION
### Motivation
- Prevent the default list-item marker (black dot) appearing next to attachment tiles in the `AnexosHibrido` component by avoiding an actual `<li>` root element while preserving accessibility semantics.

### Description
- Replaced the root element in `Project/AnexosHibrido/src/components/FileItem.vue` from `<li>` to `<div>` and retained `role="listitem"` and the existing `aria-label` so the visual marker is removed without losing semantics.

### Testing
- No automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f362b68e0483309f88590bbdafbcee)