### PR TITLE
Switch tree grid icons from Material Symbols to Font Awesome

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -10,10 +10,10 @@
                 :aria-label="translatedTexts.add"
                 :title="translatedTexts.add"
             >
-                <span class="material-symbols-outlined">add</span>
+                <i class="fa-solid fa-plus" aria-hidden="true"></i>
             </button>
             <div class="search-box">
-                <span class="material-symbols-outlined search-icon">search</span>
+                <i class="fa-solid fa-magnifying-glass search-icon" aria-hidden="true"></i>
                 <input
                     v-model="searchText"
                     class="search-input"
@@ -52,13 +52,15 @@
                     :aria-label="isExpanded(row.id) ? translatedTexts.collapse : translatedTexts.expand"
                     :title="isExpanded(row.id) ? translatedTexts.collapse : translatedTexts.expand"
                 >
-                    <span class="material-symbols-outlined">
-                        {{ row.hasChildren && isExpanded(row.id) ? 'folder_open' : 'folder' }}
-                    </span>
+                    <i
+                        class="fa-solid"
+                        :class="row.hasChildren && isExpanded(row.id) ? 'fa-angle-up' : 'fa-angle-down'"
+                        aria-hidden="true"
+                    ></i>
                 </button>
                 <span v-else class="toggle-placeholder"></span>
 
-                <span v-if="row.icon" class="material-symbols-outlined node-icon">{{ row.icon }}</span>
+                <i v-if="row.icon" class="fa-solid node-icon" :class="normalizeNodeIconClass(row.icon)" aria-hidden="true"></i>
                 <span v-else-if="showIconColumn" class="node-icon node-icon--placeholder"></span>
                 <template v-if="isRowBeingEdited(row)">
                     <div class="node-label-edit" @click.stop>
@@ -78,7 +80,7 @@
                             :aria-label="translatedTexts.cancel"
                             @click.stop="cancelRenameEdit"
                         >
-                            <span class="material-symbols-outlined node-icon">close</span>
+                            <i class="fa-solid fa-xmark node-icon" aria-hidden="true"></i>
                         </button>
                         <button
                             class="icon-button row-action-button row-action-button--confirm"
@@ -88,7 +90,7 @@
                             :aria-label="translatedTexts.confirm"
                             @click.stop="confirmRenameEdit(row)"
                         >
-                            <span class="material-symbols-outlined node-icon">check</span>
+                            <i class="fa-solid fa-check node-icon" aria-hidden="true"></i>
                         </button>
                     </div>
                 </template>
@@ -115,7 +117,7 @@
                         :aria-label="translatedTexts.addChild"
                         @click.stop="onAddChild(row.raw)"
                     >
-                        <span class="material-symbols-outlined node-icon">add</span>
+                        <i class="fa-solid fa-plus node-icon" aria-hidden="true"></i>
                     </button>
                     <button
                         v-if="row.canRename"
@@ -126,7 +128,7 @@
                         :aria-label="translatedTexts.rename"
                         @click.stop="startRenameEdit(row)"
                     >
-                        <span class="material-symbols-outlined node-icon">edit</span>
+                        <i class="fa-solid fa-pen node-icon" aria-hidden="true"></i>
                     </button>
                     <button
                         v-if="row.canDelete && !isRowBeingEdited(row)"
@@ -137,7 +139,7 @@
                         :aria-label="translatedTexts.delete"
                         @click.stop="onDelete(row.raw)"
                     >
-                        <span class="material-symbols-outlined node-icon">delete</span>
+                        <i class="fa-solid fa-trash node-icon" aria-hidden="true"></i>
                     </button>
                 </div>
             </div>
@@ -543,6 +545,12 @@ import { translatePhrase } from './translation';
         hideContextActions() {
             this.contextNodeId = null;
         },
+        normalizeNodeIconClass(icon) {
+            const value = `${icon || ''}`.trim();
+            if (!value) return '';
+            if (value.includes('fa-')) return value;
+            return `fa-${value}`;
+        },
         escapeRegex(value) {
             return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
         },
@@ -937,7 +945,7 @@ import { translatePhrase } from './translation';
         opacity: 0.5;
     }
 
-    .material-symbols-outlined {
+    .fa-solid {
         font-size: 18px;
         line-height: 1;
     }


### PR DESCRIPTION
### Motivation
- Replace the Material Symbols usage with Font Awesome to standardize iconography and allow configurable node icon names to map to FA classes.

### Description
- Replaced `span.material-symbols-outlined` usages with `i.fa-solid` elements and appropriate Font Awesome classes for toolbar, search, toggles, and row actions in `wwElement.vue`.
- Added `normalizeNodeIconClass(icon)` to convert node `icon` values into `fa-` class names and used it when rendering node icons.
- Changed toggle indicators from folder icons to angle-up/angle-down variants and added `aria-hidden="true"` to decorative icons.
- Renamed the CSS selector `.material-symbols-outlined` to `.fa-solid` and kept existing sizing styles.

### Testing
- Ran the project's unit tests with `npm test`, which succeeded.
- Ran linting with `npm run lint`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37536c72c8330b358c5d6d15ca9ee)