### PR TITLE
Ajusta espessura e tamanho dos ícones no treeGrid

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -942,8 +942,11 @@ import { translatePhrase } from './translation';
     }
 
     .fa {
-        font-size: 18px;
+        font-size: 16px;
         line-height: 1;
+        font-weight: 400;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
     }
 
     .search-box {


### PR DESCRIPTION
### Motivation
- Melhorar a legibilidade visual dos ícones no componente `treeGrid` reduzindo a aparência de traços grossos dos ícones Font Awesome.

### Description
- Ajusta o estilo CSS em `Project/treeGrid/src/wwElement.vue`: altera `.fa { font-size: 18px; }` para `font-size: 16px`, adiciona `font-weight: 400` e aplica `-webkit-font-smoothing: antialiased` e `-moz-osx-font-smoothing: grayscale` para suavizar os traços.

### Testing
- Nenhum teste automatizado foi executado; a mudança é estritamente visual e foi verificada pela revisão do diff no arquivo `Project/treeGrid/src/wwElement.vue`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ae4d5f083308957fca7685414af)