### PR TITLE
Adjust icon font styling in wwElement component

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -942,8 +942,11 @@ import { translatePhrase } from './translation';
     }
 
     .fa {
-        font-size: 18px;
+        font-size: 16px;
         line-height: 1;
+        font-weight: 900;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
     }
 
     .search-box {


### PR DESCRIPTION
### Motivation
- Improve icon clarity and visual weight so icons render crisper and align with the component design at a slightly smaller size.

### Description
- Reduce the `.fa` icon `font-size` from `18px` to `16px` in `wwElement.vue`.
- Increase icon contrast by setting `font-weight: 900` for `.fa` elements.
- Add font smoothing rules `-webkit-font-smoothing: antialiased` and `-moz-osx-font-smoothing: grayscale` for sharper rendering on different platforms.

### Testing
- Ran the repository's automated tests and linter with `npm test` and `npm run lint`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f39ae4d5f083308957fca7685414af)