### PR TITLE
feat(treeGrid): add action to perform search via text input

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -166,6 +166,9 @@ import { translatePhrase } from './translation';
             clearSelectedNode() {
                 this.clearSelectedNode();
             },
+            searchNodes(text) {
+                this.searchNodes(text);
+            },
         },
     },
     data() {
@@ -686,6 +689,9 @@ import { translatePhrase } from './translation';
             this.contextNodeId = null;
             this.selectedNodeId = null;
             this.setSelectedItemId?.(null);
+        },
+        searchNodes(text) {
+            this.searchText = `${text ?? ''}`;
         },
         onNodeClick(row) {
         if (this.isEditingAnyNode && this.editingNodeId !== row?.id) {

--- a/Project/treeGrid/ww-config.js
+++ b/Project/treeGrid/ww-config.js
@@ -30,6 +30,17 @@ export default {
             action: 'clearSelectedNode',
             args: [],
         },
+        {
+            label: { en: 'Search nodes', pt: 'Buscar nós' },
+            action: 'searchNodes',
+            args: [
+                {
+                    name: 'text',
+                    type: 'text',
+                    label: { en: 'Search text', pt: 'Texto de busca' },
+                },
+            ],
+        },
     ],
     properties: {
         data: {


### PR DESCRIPTION
### Motivation
- Expose a programmatic way to trigger the component search so external editor actions can perform the same filtering/highlighting as the search input.

### Description
- Added a `searchNodes` editor action in `Project/treeGrid/ww-config.js` (argument `text`) and wired it into `wwEditor.actions`, and implemented `searchNodes(text)` in `Project/treeGrid/src/wwElement.vue` which sets `searchText` to reuse the existing search/filter behavior.

### Testing
- Verified the code changes with `git diff` and committed the changes as commit `e92beb7`, and PR metadata was generated; the `git` operations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a12a2b808330ba79b830d186a524)