### PR TITLE
feat(treeGrid): adicionar propriedade para exibir/ocultar toolbar de busca/adicionar

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="tree-manager" :style="containerStyle" @click="hideContextActions">
-        <div class="tree-manager__toolbar">
+        <div v-if="showToolbar" class="tree-manager__toolbar">
             <button
                 v-if="!isReadOnly"
                 class="icon-button"
@@ -211,6 +211,10 @@ import { translatePhrase } from './translation';
         },
         isReadOnly() {
             return this.content.readOnly === true;
+        },
+
+        showToolbar() {
+            return this.content.showToolbar !== false;
         },
         isEditingAnyNode() {
             return !!this.editingNodeId;

--- a/Project/treeGrid/ww-config.js
+++ b/Project/treeGrid/ww-config.js
@@ -213,6 +213,15 @@ export default {
             bindable: true,
             defaultValue: '#e7f1ff',
         },
+        showToolbar: {
+            label: {
+                en: 'Show search/add toolbar',
+                pt: 'Exibir barra de busca/adicionar',
+            },
+            type: 'boolean',
+            bindable: true,
+            defaultValue: true,
+        },
         readOnly: {
             label: {
                 en: 'Read only',


### PR DESCRIPTION
### Motivation
- Permitir que a barra superior do componente (campo de busca + botão de adicionar) seja opcional para cenários onde não se deseja expor essas ações.
- Preservar o comportamento atual por padrão enquanto adiciona controle via configuração do componente.

### Description
- Adiciona a propriedade `showToolbar` em `Project/treeGrid/ww-config.js` como `boolean`, `bindable` e com `defaultValue: true` para controlar a visibilidade da toolbar. 
- Atualiza `Project/treeGrid/src/wwElement.vue` para envolver a barra em `v-if="showToolbar"` no template. 
- Introduz a computed `showToolbar()` em `wwElement.vue` com fallback que trata qualquer valor diferente de `false` como habilitado, mantendo compatibilidade.

### Testing
- Validado por inspeção do diff entre os arquivos modificados e verificação do conteúdo atualizado dos arquivos, sem mudanças em outros comportamentos.
- Verificações de conteúdo dos arquivos (`nl`/`sed`) confirmaram que a propriedade e a condição foram inseridas nas posições esperadas, e essas checagens foram bem-sucedidas.
- Não foram adicionados testes automatizados unitários para este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a37788808330ad4d5e3e718f64ef)