### PR TITLE
Fix treeGrid sibling ordering to preserve JSON input order by level

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -315,7 +315,7 @@ import { translatePhrase } from './translation';
             const map = new Map();
             const roots = [];
 
-            this.normalizedData.forEach(item => {
+            this.normalizedData.forEach((item, index) => {
                 const id = item?.[this.fieldMap.id];
                 if (id === undefined || id === null || id === '') return;
                 
@@ -334,6 +334,7 @@ import { translatePhrase } from './translation';
                 type: `${item?.[this.fieldMap.type] ?? ''}`.trim(),
                 order: this.getNodeOrder(item, normalizedId),
                 raw: item,
+                sourceIndex: index,
                 children: [],
                 });
             });
@@ -593,7 +594,13 @@ import { translatePhrase } from './translation';
         },
         sortNodesByOrder(nodes) {
             nodes.sort((a, b) => {
-                if (a.order !== b.order) return a.order - b.order;
+                const hasOrderA = Number.isFinite(a.order) && a.order !== Number.MAX_SAFE_INTEGER;
+                const hasOrderB = Number.isFinite(b.order) && b.order !== Number.MAX_SAFE_INTEGER;
+
+                if (hasOrderA && hasOrderB && a.order !== b.order) return a.order - b.order;
+                if (hasOrderA !== hasOrderB) return hasOrderA ? -1 : 1;
+
+                if (a.sourceIndex !== b.sourceIndex) return a.sourceIndex - b.sourceIndex;
                 return `${a.id}`.localeCompare(`${b.id}`);
             });
         },


### PR DESCRIPTION
### Motivation
- Sibling nodes were being reordered deterministically by `id` when no explicit `order` field was present, which broke the intended sequence coming from the backend JSON.
- The tree should preserve the input array order for siblings at each level unless an explicit `order` value is provided.

### Description
- Capture each item’s original array index as `sourceIndex` during tree construction by changing the loop to `this.normalizedData.forEach((item, index) => { ... })` and adding `sourceIndex: index` to each node object in `Project/treeGrid/src/wwElement.vue`.
- Update `sortNodesByOrder(nodes)` to prefer explicit numeric `order` values when present, place nodes with an explicit `order` before those without, then preserve original JSON order by comparing `sourceIndex`, and finally fall back to `id` comparison for deterministic ties.
- These changes keep siblings in the same sequence as the input JSON per level while still honoring any provided `order` field.

### Testing
- No automated unit or integration tests were added or executed as part of this change.
- Basic repository validations were executed: `git -C /workspace/NewCode status --short`, `git -C /workspace/NewCode diff -- Project/treeGrid/src/wwElement.vue`, and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8d575313c8330a0493367c652bc96)