### PR TITLE
feat(treeGrid): add DivColor column type with Color/BgColor support

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -124,6 +124,11 @@
                                     <span class="tree-cell-progress__label">{{ getProgressPercent(row, column.field) }}%</span>
                                 </div>
                             </template>
+                            <template v-else-if="column.type === 'divcolor'">
+                                <div class="tree-cell-div-color" :style="getDivColorStyle(column)">
+                                    <span v-html="highlightCell(row, column)"></span>
+                                </div>
+                            </template>
                             <template v-else>
                                 <span v-html="highlightCell(row, column)"></span>
                             </template>
@@ -271,11 +276,15 @@ import { translatePhrase } from './translation';
                     const flex = Number(column.flex);
                     const type = `${column.type ?? 'text'}`.trim().toLowerCase();
                     const userNameField = `${column.UserName ?? column.userName ?? ''}`.trim();
+                    const color = `${column.Color ?? column.color ?? ''}`.trim();
+                    const bgColor = `${column.BgColor ?? column.bgColor ?? ''}`.trim();
                     return {
                         field,
                         title,
                         type,
                         userNameField,
+                        color,
+                        bgColor,
                         position: Number.isFinite(position) ? position : Number.MAX_SAFE_INTEGER,
                         width,
                         flex: Number.isFinite(flex) ? flex : null,
@@ -553,6 +562,18 @@ import { translatePhrase } from './translation';
             }
 
             return `${value}`;
+        },
+
+        getDivColorStyle(column) {
+            const style = {
+                padding: '2px 6px',
+                borderRadius: '4px',
+            };
+
+            if (column.color) style.color = column.color;
+            if (column.bgColor) style.backgroundColor = column.bgColor;
+
+            return style;
         },
         getAvatarUserName(row, column) {
             const field = column.userNameField;
@@ -1251,6 +1272,11 @@ import { translatePhrase } from './translation';
         color: #495057;
         font-size: 12px;
         font-weight: 600;
+    }
+
+
+    .tree-cell-div-color {
+        display: inline-block;
     }
 
     .tree-cell-progress {


### PR DESCRIPTION
### Motivation
- Add a new column type that allows cells to render their value inside a colored `div` so authors can control text and background colors per column from the JSON.
- Support `Color` and `BgColor` properties on column definitions so the UI can be themed per-column without extra templates.

### Description
- Extended `normalizedColumns` to parse `Color`/`color` and `BgColor`/`bgColor` into the normalized column object as `color` and `bgColor`.
- Added a template branch for the normalized `divcolor` column type that renders the cell value inside a wrapper `div` using `getDivColorStyle(column)`.
- Implemented `getDivColorStyle(column)` which applies `padding: '2px 6px'`, `border-radius: '4px'`, and sets `color` and `backgroundColor` when `column.color` / `column.bgColor` are present.
- Added CSS `.tree-cell-div-color { display: inline-block; }` to ensure the wrapper behaves correctly in the cell.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e57646f883309062cc5c3236cea4)