### PR TITLE
RichText: add SVG fallback for toolbar icons in published WeWeb builds

### DIFF
--- a/Project/RichText/src/wwElement.vue
+++ b/Project/RichText/src/wwElement.vue
@@ -1197,38 +1197,45 @@ export default {
                     'lucide/undo',
                     'lucide/redo',
                 ];
+                const fallbackIconByName = {
+                    'lucide/bold': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 12a4 4 0 0 0 0-8H6v8Z"/><path d="M15 20a4 4 0 0 0 0-8H6v8Z"/></svg>',
+                    'lucide/italic': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="19" x2="10" y1="4" y2="4"/><line x1="14" x2="5" y1="20" y2="20"/><line x1="15" x2="9" y1="4" y2="20"/></svg>',
+                    'lucide/underline': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 4v6a6 6 0 0 0 12 0V4"/><line x1="4" x2="20" y1="20" y2="20"/></svg>',
+                    'lucide/strikethrough': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4H9a3 3 0 0 0-2.83 4"/><path d="M14 12a4 4 0 0 1 0 8H6"/><line x1="4" x2="20" y1="12" y2="12"/></svg>',
+                    'lucide/align-left': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="21" x2="3" y1="6" y2="6"/><line x1="15" x2="3" y1="12" y2="12"/><line x1="17" x2="3" y1="18" y2="18"/></svg>',
+                    'lucide/align-center': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="21" x2="3" y1="6" y2="6"/><line x1="17" x2="7" y1="12" y2="12"/><line x1="19" x2="5" y1="18" y2="18"/></svg>',
+                    'lucide/align-right': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="21" x2="3" y1="6" y2="6"/><line x1="21" x2="9" y1="12" y2="12"/><line x1="21" x2="7" y1="18" y2="18"/></svg>',
+                    'lucide/align-justify': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" x2="21" y1="6" y2="6"/><line x1="3" x2="21" y1="12" y2="12"/><line x1="3" x2="21" y1="18" y2="18"/></svg>',
+                    'lucide/palette': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="13.5" cy="6.5" r=".5" fill="currentColor"/><circle cx="17.5" cy="10.5" r=".5" fill="currentColor"/><circle cx="8.5" cy="7.5" r=".5" fill="currentColor"/><circle cx="6.5" cy="12.5" r=".5" fill="currentColor"/><path d="M12 22a1 1 0 0 1-1-1v-1a2 2 0 0 0-2-2H5a2 2 0 0 1-2-2 9 9 0 0 1 9-9 9 9 0 1 1 0 18Z"/></svg>',
+                    'lucide/list': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" x2="21" y1="6" y2="6"/><line x1="8" x2="21" y1="12" y2="12"/><line x1="8" x2="21" y1="18" y2="18"/><line x1="3" x2="3.01" y1="6" y2="6"/><line x1="3" x2="3.01" y1="12" y2="12"/><line x1="3" x2="3.01" y1="18" y2="18"/></svg>',
+                    'lucide/list-ordered': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="10" x2="21" y1="6" y2="6"/><line x1="10" x2="21" y1="12" y2="12"/><line x1="10" x2="21" y1="18" y2="18"/><path d="M4 6h1v4"/><path d="M4 10h2"/><path d="M6 18H4c0-1 2-2 2-3a1 1 0 0 0-2 0"/></svg>',
+                    'lucide/list-checks': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m3 17 2 2 4-4"/><path d="m3 7 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg>',
+                    'lucide/link': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>',
+                    'lucide/image': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2" ry="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-3.1-3.1a2 2 0 0 0-2.8 0L6 21"/></svg>',
+                    'lucide/file-code': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="m10 13-2 2 2 2"/><path d="m14 17 2-2-2-2"/></svg>',
+                    'lucide/code': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>',
+                    'lucide/quote': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21c3 0 7-1 7-8V5H3v8h4"/><path d="M14 21c3 0 7-1 7-8V5h-7v8h4"/></svg>',
+                    'lucide/square-function': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="M9 17c2 0 2-3 4-3s2 3 4 3"/><path d="M9 7h6"/></svg>',
+                    'lucide/sigma': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 7H6l6 5-6 5h12"/></svg>',
+                    'lucide/undo': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7v6h6"/><path d="M21 17a9 9 0 0 0-9-9 9 9 0 0 0-6 2.3L3 13"/></svg>',
+                    'lucide/redo': '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 7v6h-6"/><path d="M3 17a9 9 0 0 1 9-9 9 9 0 0 1 6 2.3L21 13"/></svg>',
+                };
                 const results = await Promise.all(
                     names.map(async n => {
                         try {
                             const html = await getIcon(n);
-                            return html || null;
+                            return html || fallbackIconByName[n] || null;
                         } catch (e) {
-                            return null;
+                            return fallbackIconByName[n] || null;
                         }
                     })
                 );
                 this.iconHTMLs = {
-                    bold: results[0],
-                    italic: results[1],
-                    underline: results[2],
-                    strikethrough: results[3],
-                    'align-left': results[4],
-                    'align-center': results[5],
-                    'align-right': results[6],
-                    'align-justify': results[7],
-                    palette: results[8],
-                    list: results[9],
-                    'list-ordered': results[10],
-                    'check-square': results[11],
-                    link: results[12],
-                    image: results[13],
-                    htmlEditor: results[14],
-                    code: results[15],
-                    quote: results[16],
-                    'square-function': results[17],
-                    sigma: results[18],
-                    undo: results[19],
-                    redo: results[20],
+                    bold: results[0], italic: results[1], underline: results[2], strikethrough: results[3],
+                    'align-left': results[4], 'align-center': results[5], 'align-right': results[6], 'align-justify': results[7],
+                    palette: results[8], list: results[9], 'list-ordered': results[10], 'check-square': results[11],
+                    link: results[12], image: results[13], htmlEditor: results[14], code: results[15], quote: results[16],
+                    'square-function': results[17], sigma: results[18], undo: results[19], redo: results[20],
                 };
             } catch (e) {
                 this.iconHTMLs = {};


### PR DESCRIPTION
### Motivation

- Published WeWeb builds sometimes fail to resolve icons from the icon service, causing many RichText toolbar buttons to render without icons.  
- The RichText component previously relied solely on `wwLib.useIcons().getIcon(...)` which can return empty or throw in production.  
- Provide a deterministic, local fallback so the toolbar remains usable and visually consistent after publish. 

### Description

- Added a `fallbackIconByName` map in `Project/RichText/src/wwElement.vue` containing inline SVG markup for every toolbar icon key used by the component.  
- Updated `loadIcons()` to prefer the dynamic `getIcon` result and fall back to `fallbackIconByName[name]` whenever `getIcon` returns empty or throws, preserving existing behavior when the icon service works.  
- Kept the original `names` list and the final `this.iconHTMLs` mapping so toolbar keys (`bold`, `italic`, alignments, lists, `link`, `image`, `code`, math, `undo`/`redo`, etc.) remain unchanged.  

### Testing

- Ran repository searches to locate and inspect the component with `rg` and verified the change locations, all commands completed successfully.  
- Applied the patch via a scripted edit and verified the modified lines with `nl`, `sed` and `git diff`, and those checks succeeded.  
- Committed the change with `git commit` which returned a successful commit summary.  
- No unit or integration tests were present/executed for this change; manual/static verification of the resulting file and mappings was performed and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c0396b2c8330b517ef280daede88)