### PR TITLE
Render DEADLINE as normal DateTime and add explicit Select in datepicker

### DIFF
--- a/Project/FormBuilder/Component/components/CustomDatePicker.vue
+++ b/Project/FormBuilder/Component/components/CustomDatePicker.vue
@@ -51,6 +51,7 @@
       <div class="dp-actions">
         <button type="button" class="dp-action" @click="pickToday">{{ labelToday }}</button>
         <button type="button" class="dp-action" @click="clearDate">{{ labelClear }}</button>
+        <button type="button" class="dp-action dp-action-primary" @click="applySelection">{{ labelSelect }}</button>
       </div>
     </div>
   </div>
@@ -84,6 +85,7 @@ export default {
     ];
     const labelToday = computed(() => (isPt.value ? 'Hoje' : translateText('Today')));
     const labelClear = computed(() => (isPt.value ? 'Limpar' : translateText('Clear')));
+    const labelSelect = computed(() => (isPt.value ? 'Selecionar' : translateText('Select')));
 
     function toYMD(date) {
       const y = date.getFullYear();
@@ -284,8 +286,6 @@ export default {
     function selectDay(d){
       if(!d.inMonth) return;
       selectedDate.value = d.dateStr;
-      emitValue();
-      if(!props.showTime) closeDp();
     }
     function pickToday(){
       const now = new Date();
@@ -306,7 +306,11 @@ export default {
 
     function onTimeInput(e){
       timePart.value = e.target.value;
+    }
+
+    function applySelection(){
       emitValue();
+      closeDp();
     }
 
     function onDocClick(e){
@@ -345,8 +349,10 @@ export default {
       displayDate,
       labelToday,
       labelClear,
+      labelSelect,
       timePart,
       onTimeInput,
+      applySelection,
       showTime: props.showTime,
       disabled: props.disabled,
       error: props.error

--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -23,43 +23,16 @@
       </template>
 
       <template v-else-if="field.fieldType === 'DEADLINE'">
-        <div style="position: relative;">
-          <div
-            class="deadline-visual"
-            :class="[
-              deadlineColorClass,
-              { 'readonly-field': isReadOnly, 'deadline-empty': !deadlineHasValue }
-            ]"
-            :title="deadlineOriginalFormatted"
-            role="button"
-            :tabindex="isDeadlineDisplayOnly || isReadOnly ? -1 : 0"
-            @mousedown.stop
-            @touchstart.stop
-            @click="!isDeadlineDisplayOnly && openDeadlinePicker()"
-            @keydown.enter.prevent="!isDeadlineDisplayOnly && openDeadlinePicker()"
-            @keydown.space.prevent="!isDeadlineDisplayOnly && openDeadlinePicker()"
-          >
-            <template v-if="deadlineHasValue">
-              <span class="deadline-diff-display">{{ deadlineDiff }}</span>
-            </template>
-            <template v-else>
-              <span class="material-symbols-outlined deadline-empty-icon">calendar_month</span>
-              <span class="deadline-empty-text">{{ translateText('Select') }}</span>
-            </template>
-          </div>
-          <CustomDatePicker
-            ref="deadlineDatePicker"
-            v-model="deadlineValue"
-            :disabled="isReadOnly"
-            :show-time="true"
-            :open-up-offset="60"
-            @mousedown.stop
-            @touchstart.stop
-            @update:modelValue="onDeadlineChange"
-            :class="['field-input', 'date-input', { error: !!error && isMandatory }, { 'readonly-field': isReadOnly }]"
-            style="position: absolute; top: 0; left: 0; width: 100%; height: 0; overflow: hidden;"
-          />
-        </div>
+        <CustomDatePicker
+          v-model="localValue"
+          :disabled="isReadOnly"
+          :show-time="true"
+          :error="!!error && isMandatory"
+          @mousedown.stop
+          @touchstart.stop
+          @update:modelValue="onDateChange"
+          :class="['field-input', 'date-input', { error: !!error && isMandatory }, { 'readonly-field': isReadOnly }]"
+        />
       </template>
 
       <template v-else-if="field.fieldType === 'DECIMAL'">


### PR DESCRIPTION
### Motivation
- DEADLINE fields should behave like regular Date Time inputs without special countdown/visual formatting and allow the user to explicitly confirm the chosen date/time from the popup.

### Description
- Replaced the custom deadline visual/countdown rendering in `Project/FormBuilder/Component/components/FieldComponent.vue` so `DEADLINE` now renders a `CustomDatePicker` bound to `localValue` with `:show-time="true"` and `:error` handling like other date fields.
- Removed the hidden/absolute `CustomDatePicker` + visual display path so the field shows the picker value directly instead of a countdown UI.
- Added an explicit `Select` action to `Project/FormBuilder/Component/components/CustomDatePicker.vue` by introducing `labelSelect`, a new `applySelection()` function, and a `dp-action-primary` button in the popup.
- Changed selection behavior in `CustomDatePicker.vue` so clicking a day or changing time only updates the pending selection, and the new `Select` button confirms (emits) the value and closes the popup.

### Testing
- Ran `git diff --check` with no whitespace errors and no issues reported.
- Changes were committed (`Adjust deadline field display and datepicker selection flow`) and a PR was created using the repository tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c794984c833099b9b048db7d8ffd)