### PR TITLE
Renderizar DEADLINE como DateTime e adicionar botão Select no datepicker

### DIFF
--- a/Project/FormRender/Component/components/CustomDatePicker.vue
+++ b/Project/FormRender/Component/components/CustomDatePicker.vue
@@ -49,6 +49,7 @@
         <input type="time" v-model="timePart" @input="onTimeInput" />
       </div>
       <div class="dp-actions">
+        <button type="button" class="dp-action dp-action-primary" @click="confirmSelection">{{ labelSelect }}</button>
         <button type="button" class="dp-action" @click="pickToday">{{ labelToday }}</button>
         <button type="button" class="dp-action" @click="clearDate">{{ labelClear }}</button>
       </div>
@@ -79,6 +80,7 @@ export default {
 
     const labelToday = computed(() => t('Today'));
     const labelClear = computed(() => t('Clear'));
+    const labelSelect = computed(() => t('Select'));
 
     function toYMD(date) {
       const y = date.getFullYear();
@@ -293,6 +295,10 @@ export default {
       emit('update:modelValue', '');
       closeDp();
     }
+    function confirmSelection() {
+      emitValue();
+      closeDp();
+    }
 
     function onTimeInput(e){
       timePart.value = e.target.value;
@@ -335,8 +341,10 @@ export default {
       displayDate,
       labelToday,
       labelClear,
+      labelSelect,
       timePart,
       onTimeInput,
+      confirmSelection,
       showTime: props.showTime,
       disabled: props.disabled,
       error: props.error

--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -17,27 +17,9 @@
           :class="['field-input', 'date-input', { error: error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]" />
       </template>
       <template v-else-if="field.fieldType === 'DEADLINE'">
-        <div style="position:relative;">
-          <div class="deadline-visual" :class="[
-              deadlineColorClass,
-              { 'readonly-field': field.is_readonly, 'deadline-empty': !deadlineHasValue }
-            ]" :title="deadlineOriginalFormatted" role="button" :tabindex="field.is_readonly ? -1 : 0"
-            @click="openDeadlinePicker" @keydown.enter.prevent="openDeadlinePicker"
-            @keydown.space.prevent="openDeadlinePicker">
-            <template v-if="deadlineHasValue">
-              <span class="deadline-diff-display">{{ deadlineDisplay }}</span>
-            </template>
-            <template v-else>
-              <span class="material-symbols-outlined deadline-empty-icon">calendar_month</span>
-              <span class="deadline-empty-text">{{ t('Select') }}</span>
-            </template>
-          </div>
-          <CustomDatePicker ref="deadlineDatePicker" v-model="deadlineValue" :disabled="field.is_readonly"
-            :show-time="true" :open-up-offset="60" @update:modelValue="onDeadlineChange"
-            :class="['field-input', 'date-input', { error: error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
-            style="position:absolute;top:0;left:0;width:100%;height:0;overflow:hidden;" />
-
-        </div>
+        <CustomDatePicker v-model="deadlineValue" :disabled="field.is_readonly" :show-time="true"
+          @update:modelValue="onDeadlineChange"
+          :class="['field-input', 'date-input', { error: error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]" />
       </template>
       <template v-else-if="field.fieldType === 'DECIMAL'">
         <input


### PR DESCRIPTION
### Motivation
- Ajustar a apresentação do campo `DEADLINE` para se comportar como um campo Date Time normal, sem contagem regressiva nem formatação especial.
- Garantir que em todos os campos de data o popup permita confirmar a escolha e fechar o popup com um botão de seleção explícito.

### Description
- Substituído o markup customizado de visualização/contagem regressiva do `DEADLINE` por um `CustomDatePicker` com `:show-time="true"` em `Project/FormRender/Component/components/FieldComponent.vue`.
- Adicionado um botão `Select` na área de ações do popup em `Project/FormRender/Component/components/CustomDatePicker.vue` e o rótulo traduzível `labelSelect` (`t('Select')`).
- Implementada a função `confirmSelection` que chama `emitValue()` e fecha o popup, e exposta no `return` do `setup` para uso pelo template.
- Arquivos modificados: `Project/FormRender/Component/components/FieldComponent.vue` e `Project/FormRender/Component/components/CustomDatePicker.vue`.

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c9632690833096130aa6be99bdcb)