### PR TITLE
Add 'Select' action to CustomDatePicker and simplify DEADLINE field rendering

### DIFF
--- a/Project/FormRender/Component/components/CustomDatePicker.vue
+++ b/Project/FormRender/Component/components/CustomDatePicker.vue
@@ -49,6 +49,7 @@
         <input type="time" v-model="timePart" @input="onTimeInput" />
       </div>
       <div class="dp-actions">
+        <button type="button" class="dp-action dp-action-primary" @click="confirmSelection">{{ labelSelect }}</button>
         <button type="button" class="dp-action" @click="pickToday">{{ labelToday }}</button>
         <button type="button" class="dp-action" @click="clearDate">{{ labelClear }}</button>
       </div>
@@ -79,6 +80,7 @@ export default {
 
     const labelToday = computed(() => t('Today'));
     const labelClear = computed(() => t('Clear'));
+    const labelSelect = computed(() => t('Select'));
 
     function toYMD(date) {
       const y = date.getFullYear();
@@ -293,6 +295,10 @@ export default {
       emit('update:modelValue', '');
       closeDp();
     }
+    function confirmSelection() {
+      emitValue();
+      closeDp();
+    }
 
     function onTimeInput(e){
       timePart.value = e.target.value;
@@ -335,8 +341,10 @@ export default {
       displayDate,
       labelToday,
       labelClear,
+      labelSelect,
       timePart,
       onTimeInput,
+      confirmSelection,
       showTime: props.showTime,
       disabled: props.disabled,
       error: props.error

--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -17,27 +17,9 @@
           :class="['field-input', 'date-input', { error: error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]" />
       </template>
       <template v-else-if="field.fieldType === 'DEADLINE'">
-        <div style="position:relative;">
-          <div class="deadline-visual" :class="[
-              deadlineColorClass,
-              { 'readonly-field': field.is_readonly, 'deadline-empty': !deadlineHasValue }
-            ]" :title="deadlineOriginalFormatted" role="button" :tabindex="field.is_readonly ? -1 : 0"
-            @click="openDeadlinePicker" @keydown.enter.prevent="openDeadlinePicker"
-            @keydown.space.prevent="openDeadlinePicker">
-            <template v-if="deadlineHasValue">
-              <span class="deadline-diff-display">{{ deadlineDisplay }}</span>
-            </template>
-            <template v-else>
-              <span class="material-symbols-outlined deadline-empty-icon">calendar_month</span>
-              <span class="deadline-empty-text">{{ t('Select') }}</span>
-            </template>
-          </div>
-          <CustomDatePicker ref="deadlineDatePicker" v-model="deadlineValue" :disabled="field.is_readonly"
-            :show-time="true" :open-up-offset="60" @update:modelValue="onDeadlineChange"
-            :class="['field-input', 'date-input', { error: error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]"
-            style="position:absolute;top:0;left:0;width:100%;height:0;overflow:hidden;" />
-
-        </div>
+        <CustomDatePicker v-model="deadlineValue" :disabled="field.is_readonly" :show-time="true"
+          @update:modelValue="onDeadlineChange"
+          :class="['field-input', 'date-input', { error: error && field.is_mandatory }, { 'readonly-field': field.is_readonly }]" />
       </template>
       <template v-else-if="field.fieldType === 'DECIMAL'">
         <input
@@ -249,10 +231,6 @@ export default {
       return {};
     },
     componentStyleVars() {
-      if (this.field && this.field.fieldType === 'DEADLINE') {
-        return {};
-      }
-
       const tokens = this.themeTokens || {};
       return {
         '--text-input-bg': tokens.inputBG || '#FFFFFF',


### PR DESCRIPTION
### Motivation
- Provide an explicit confirmation action for the date picker when `showTime` is enabled so users can select a date+time and confirm it explicitly. 
- Surface a translated `Select` label for that action. 
- Simplify the `DEADLINE` field rendering by using the inline `CustomDatePicker` instead of a custom visual wrapper and absolute-positioned picker, and remove the special-case style override for deadlines.

### Description
- Added a computed `labelSelect` that uses `translatePhrase('Select')` and exposed it to the template. 
- Added a `confirmSelection` method that calls `emitValue()` and `closeDp()` and wired it to a new `Select` button in the date picker actions. 
- Updated the `return` object in `setup` to expose `labelSelect` and `confirmSelection`. 
- Replaced the custom wrapper/visual for `field.fieldType === 'DEADLINE'` with a direct inline `CustomDatePicker` configured with `:show-time="true"` and `@update:modelValue="onDeadlineChange"`. 
- Removed the `DEADLINE` special-case in `componentStyleVars` so theme tokens apply consistently to deadline fields.

### Testing
- Ran the frontend unit/component test suite with `npm test` and component-level smoke checks locally, and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9c9632690833096130aa6be99bdcb)