### PR TITLE
Fix duplicate field entries when dragging between FormBuilder sections

### DIFF
--- a/Project/FormBuilder/Component/components/FormSection.vue
+++ b/Project/FormBuilder/Component/components/FormSection.vue
@@ -661,12 +661,30 @@ function normalizeOptions(raw) {
             }
           },
           onEnd: (evt) => {
-            if (evt && evt.to && evt.oldIndex !== undefined && evt.newIndex !== undefined && evt.oldIndex !== evt.newIndex) {
+            if (!evt || evt.from !== evt.to) {
+              return;
+            }
+
+            if (evt.oldIndex !== undefined && evt.newIndex !== undefined && evt.oldIndex !== evt.newIndex) {
               // Reordene o array fields conforme a nova ordem
               const movedField = props.section.fields.splice(evt.oldIndex, 1)[0];
               props.section.fields.splice(evt.newIndex, 0, movedField);
 
               // Atualize as posições dos campos conforme a nova ordem
+              props.section.fields.forEach((field, idx) => {
+                field.position = idx + 1;
+              });
+
+              emit('update-section');
+            }
+          },
+          onRemove: (evt) => {
+            if (!evt || evt.from === evt.to || evt.oldIndex === undefined) {
+              return;
+            }
+
+            const removedField = props.section.fields.splice(evt.oldIndex, 1)[0];
+            if (removedField) {
               props.section.fields.forEach((field, idx) => {
                 field.position = idx + 1;
               });


### PR DESCRIPTION
### Motivation
- Prevent a field from appearing in both the source and destination sections in `formData.sections` after a drag-and-drop move between sections.

### Description
- Constrained the `onEnd` handler in `Project/FormBuilder/Component/components/FormSection.vue` to only run reorder logic for intra-section moves (`evt.from === evt.to`).
- Added an `onRemove` handler to the Sortable options that removes the field from the source section array during cross-section moves, recalculates `position`, and emits `update-section`.
- Left `onAdd` as the insertion point for the destination section while ensuring source/target arrays are kept in sync after moves.

### Testing
- No automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9dbfe41688330a90d3f6296d55bea)