### PR TITLE
feat: add TicketGrid component as a functional copy of GridViewDinamica

### DIFF
--- a/Project/TicketGrid/src/components/ActionCellRenderer.vue
+++ b/Project/TicketGrid/src/components/ActionCellRenderer.vue
@@ -1,0 +1,68 @@
+<template>
+<div class="btn-container">
+<button
+@click.stop="onButtonClicked"
+class="datagrid-btn"
+:class="params.withFont ? 'with-font' : 'without-font'"
+>
+{{ params.label }}
+</button>
+</div>
+</template>
+
+<script>
+export default {
+name: "ImageCellRenderer",
+props: {
+params: {
+type: Object,
+required: true,
+},
+},
+methods: {
+onButtonClicked() {
+this.params.trigger({
+actionName: this.params.name,
+id: this.params.node?.id,
+index: this.params.node?.sourceRowIndex,
+displayIndex: this.params.node?.rowIndex != null ? this.params.node.rowIndex : null,
+row: this.params.data,
+});
+},
+},
+};
+</script>
+
+<style scoped lang="scss">
+.btn-container {
+display: flex;
+justify-content: center;
+align-items: center;
+height: 100%;
+}
+.datagrid-btn {
+  background-color: var(--ww-data-grid_action-backgroundColor, unset);
+  color: var(--ww-data-grid_action-color, unset);
+  padding: var(--ww-data-grid_action-padding, unset);
+  border: var(--ww-data-grid_action-border, unset);
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  font-size: var(--grid-view-dinamica-font-size, 12px);
+  font-weight: var(--ww-data-grid_action-fontWeight);
+  font-style: var(--ww-data-grid_action-fontStyle);
+  line-height: var(--ww-data-grid_action-lineHeight, normal);
+  &.with-font {
+    font: var(--ww-data-grid_action-font);
+    font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif) !important;
+    font-size: var(--grid-view-dinamica-font-size, 12px) !important;
+  }
+  &.without-font {
+    font-size: var(--grid-view-dinamica-font-size, 12px);
+    font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+    font-weight: var(--ww-data-grid_action-fontWeight);
+    font-style: var(--ww-data-grid_action-fontStyle);
+    line-height: var(--ww-data-grid_action-lineHeight, normal);
+  }
+  border-radius: var(--ww-data-grid_action-borderRadius);
+  cursor: pointer;
+}
+</style>

--- a/Project/TicketGrid/src/components/CustomDatePicker.vue
+++ b/Project/TicketGrid/src/components/CustomDatePicker.vue
@@ -1,0 +1,346 @@
+<template>
+  <div class="dp-wrapper" ref="dpWrapper">
+    <input
+      ref="dpInput"
+      class="dp-input"
+      type="text"
+      :value="displayDate"
+      readonly
+      :disabled="disabled"
+      @pointerdown.stop.prevent="!disabled && openDp($event)"
+      @mousedown.stop.prevent="!disabled && openDp($event)"
+      @click.stop.prevent="!disabled && openDp($event)"
+      @focus="!disabled && autoOpen && openDp($event)"
+      aria-haspopup="dialog"
+      :aria-expanded="dpOpen ? 'true' : 'false'"
+    />
+    <button
+      v-if="!disabled"
+      type="button"
+      class="dp-icon"
+      @pointerdown.stop.prevent="openDp($event)"
+      @mousedown.stop.prevent="openDp($event)"
+      @click.stop.prevent="openDp($event)"
+    >
+      <span class="material-symbols-outlined">calendar_month</span>
+    </button>
+
+    <div
+      v-if="dpOpen"
+      class="datepicker-pop"
+      :style="dpPopStyle"
+      ref="dpPopRef"
+      role="dialog"
+      aria-modal="true"
+      data-grid-popup="datepicker"
+
+    >
+      <div class="dp-header">
+        <button type="button" class="dp-nav" @click="prevMonth">&lt;</button>
+        <div class="dp-title">{{ monthLabel }}</div>
+        <button type="button" class="dp-nav" @click="nextMonth">&gt;</button>
+      </div>
+
+      <div class="dp-weekdays">
+        <div class="dp-weekday" v-for="d in weekdayAbbrs" :key="d">{{ d }}</div>
+      </div>
+
+      <div class="dp-grid">
+        <button
+          v-for="d in gridDays"
+          :key="d.dateStr"
+          type="button"
+          class="dp-cell"
+          :class="{ 'is-muted': !d.inMonth, 'is-selected': d.isSelected, 'is-today': d.isToday }"
+          @click="selectDay(d)"
+        >
+          {{ d.label }}
+        </button>
+      </div>
+
+      <div v-if="showTime" class="dp-time">
+        <input type="time" v-model="timePart" @input="onTimeInput" />
+      </div>
+
+      <div class="dp-actions">
+        <button type="button" class="dp-action" @click="pickToday">{{ labelToday }}</button>
+        <button type="button" class="dp-action" @click="clearDate">{{ labelClear }}</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import { translatePhrase } from '../translation';
+
+export default {
+  name: 'CustomDatePicker',
+  props: {
+    modelValue: { type: String, default: '' },
+    disabled: { type: Boolean, default: false },
+    showTime: { type: Boolean, default: false },
+    autoOpen: { type: Boolean, default: false }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit, expose }) {
+    
+    const ww = window.wwLib?.wwVariable;
+    const lang = ww?.getValue('aa44dc4c-476b-45e9-a094-16687e063342') || navigator.language;
+    const formatStyleRaw = ww?.getValue('21a41590-e7d8-46a5-af76-bb3542da1df3') || 'european';
+    const formatStyle = String(formatStyleRaw).toLowerCase() === 'american' ? 'american' : 'european';
+
+    const isPt = computed(() => String(lang || '').toLowerCase().startsWith('pt'));
+        const labelToday = computed(() => translatePhrase('Today'));
+    const labelClear = computed(() => translatePhrase('Clear'));
+
+    const dpWrapper = ref(null);
+    const dpInput   = ref(null);
+    const dpPopRef  = ref(null);
+
+    const dpOpen = ref(false);
+    const dpPopStyle = ref({});
+    const selectedDate = ref('');
+    const timePart = ref('00:00');
+
+    // Guarda a posição exata do clique (clientX/Y)
+    const anchorPoint = ref(null); // { x, y } quando abrir por clique
+
+    function toYMD(date) {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, '0');
+      const d = String(date.getDate()).padStart(2, '0');
+      return `${y}-${m}-${d}`;
+    }
+    function parseYMD(ymd) {
+      if (!ymd) return null;
+      const [y,m,d] = ymd.split('-').map(Number);
+      if (!y || !m || !d) return null;
+      return new Date(y, m - 1, d);
+    }
+    function formatDateByStyle(yyyyMmDd, style = formatStyle) {
+      if (!yyyyMmDd) return '';
+      const [y,m,d] = yyyyMmDd.split('-').map(Number);
+      const DD = String(d).padStart(2,'0');
+      const MM = String(m).padStart(2,'0');
+      const YYYY = String(y);
+      return style === 'american' ? `${MM}/${DD}/${YYYY}` : `${DD}/${MM}/${YYYY}`;
+    }
+    function sameYMD(a,b){ return a && b && toYMD(a) === toYMD(b); }
+
+    watch(() => props.modelValue, v => {
+      if (props.showTime) {
+        const [d, t] = (v || '').split('T');
+        selectedDate.value = d || '';
+        timePart.value = t ? t.slice(0,5) : '00:00';
+      } else {
+        selectedDate.value = v || '';
+      }
+    }, { immediate: true });
+
+    const dpMonth = ref(0);
+    const dpYear  = ref(0);
+    const weekStart = computed(() => (formatStyle === 'american' ? 0 : 1));
+
+    const weekdayAbbrs = computed(() => {
+      if (isPt.value) {
+        const base = ['dom','seg','ter','qua','qui','sex','sáb'];
+        return weekStart.value === 1 ? base.slice(1).concat(base.slice(0,1)) : base;
+      }
+      try {
+        const base = Array.from({ length: 7 }, (_, i) =>
+          new Intl.DateTimeFormat(lang, { weekday: 'short' }).format(new Date(Date.UTC(2021,7,1+i)))
+        );
+        return weekStart.value === 1 ? base.slice(1).concat(base.slice(0,1)) : base;
+      } catch {
+        const en = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+        return weekStart.value === 1 ? en.slice(1).concat(en.slice(0,1)) : en;
+      }
+    });
+
+    const monthLabel = computed(() => {
+      try {
+        return new Intl.DateTimeFormat(lang, { month: 'long', year: 'numeric' }).format(new Date(dpYear.value, dpMonth.value, 1));
+      } catch {
+        const EN_MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+        return `${EN_MONTHS[dpMonth.value]} ${dpYear.value}`;
+      }
+    });
+
+    function makeCell(date, inMonth){
+      const label = date.getDate();
+      const today = new Date();
+      const selected = parseYMD(selectedDate.value);
+      return { label, dateStr: toYMD(date), inMonth, isToday: sameYMD(date,today), isSelected: selected && sameYMD(date, selected) };
+    }
+
+    const gridDays = computed(() => {
+      const first = new Date(dpYear.value, dpMonth.value, 1);
+      const startWeekday = first.getDay();
+      const lead = (startWeekday - weekStart.value + 7) % 7;
+      const daysInCur = new Date(dpYear.value, dpMonth.value + 1, 0).getDate();
+      const prevYear = dpMonth.value === 0 ? dpYear.value - 1 : dpYear.value;
+      const prevMonth = dpMonth.value === 0 ? 11 : dpMonth.value - 1;
+      const daysInPrev = new Date(prevYear, prevMonth + 1, 0).getDate();
+      const cells = [];
+      for (let i = daysInPrev - lead + 1; i <= daysInPrev; i++) cells.push(makeCell(new Date(prevYear, prevMonth, i), false));
+      for (let i = 1; i <= daysInCur; i++) cells.push(makeCell(new Date(dpYear.value, dpMonth.value, i), true));
+      const tail = 42 - cells.length;
+      const nextYear = dpMonth.value === 11 ? dpYear.value + 1 : dpYear.value;
+      const nextMonth = dpMonth.value === 11 ? 0 : dpMonth.value + 1;
+      for (let i = 1; i <= tail; i++) cells.push(makeCell(new Date(nextYear, nextMonth, i), false));
+      return cells;
+    });
+
+    function emitValue(){
+      if(!selectedDate.value){ emit('update:modelValue', ''); return; }
+      const val = props.showTime ? `${selectedDate.value}T${timePart.value}` : selectedDate.value;
+      emit('update:modelValue', val);
+    }
+
+    function updatePopoverPosition() {
+      const wrap = dpWrapper.value;
+      if (!wrap) return;
+      const rect = wrap.getBoundingClientRect();
+      const left = Math.round(rect.left - 300);
+      const bottom = Math.round(window.innerHeight - rect.top - 185);
+      dpPopStyle.value = {
+        position: 'fixed',
+        left: `${left}px`,
+        bottom: `${bottom}px`,
+        minWidth: `${Math.max(rect.width, 230)}px`,
+        zIndex: 2147483647
+      };
+    }
+
+    function onDocClick(e){
+      if(!dpOpen.value) return;
+      const insideWrapper = dpWrapper.value && dpWrapper.value.contains(e.target);
+      const insidePop = dpPopRef.value && dpPopRef.value.contains(e.target);
+      if(!insideWrapper && !insidePop) closeDp();
+    }
+
+    function openDp(e){
+      // captura coords do clique (pointer/mouse). Se veio de focus, anchorPoint será null.
+      anchorPoint.value = (e && typeof e.clientX === 'number') ? { x: e.clientX, y: e.clientY } : null;
+
+      const base = parseYMD(selectedDate.value) || new Date();
+      dpMonth.value = base.getMonth();
+      dpYear.value  = base.getFullYear();
+      if(props.showTime && !selectedDate.value){
+        const pad2 = n => String(n).padStart(2,'0');
+        timePart.value = `${pad2(base.getHours())}:${pad2(base.getMinutes())}`;
+      }
+      dpOpen.value = true;
+
+      nextTick(() => {
+        updatePopoverPosition();
+        try { dpInput.value && dpInput.value.focus(); } catch {}
+        document.addEventListener('click', onDocClick, false);
+        window.addEventListener('scroll', updatePopoverPosition, true);
+        window.addEventListener('resize', updatePopoverPosition, true);
+      });
+    }
+
+    function closeDp(){
+      dpOpen.value = false;
+      anchorPoint.value = null;
+      document.removeEventListener('click', onDocClick, false);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      window.removeEventListener('resize', updatePopoverPosition, true);
+    }
+
+    function prevMonth(){ dpMonth.value = dpMonth.value === 0 ? 11 : dpMonth.value - 1; if (dpMonth.value === 11) dpYear.value--; nextTick(updatePopoverPosition); }
+    function nextMonth(){ dpMonth.value = dpMonth.value === 11 ? 0 : dpMonth.value + 1; if (dpMonth.value === 0) dpYear.value++; nextTick(updatePopoverPosition); }
+    function selectDay(d){ if(!d.inMonth) return; selectedDate.value = d.dateStr; emitValue(); if(!props.showTime) closeDp(); }
+    function pickToday(){ const now = new Date(); selectedDate.value = toYMD(now); if(props.showTime){ const p = n=>String(n).padStart(2,'0'); timePart.value = `${p(now.getHours())}:${p(now.getMinutes())}`; } emitValue(); closeDp(); }
+    function clearDate(){ selectedDate.value = ''; if(props.showTime) timePart.value = '00:00'; emit('update:modelValue',''); closeDp(); }
+    function onTimeInput(e){ timePart.value = e.target.value; emitValue(); }
+
+    onMounted(() => { if (props.autoOpen) nextTick(() => openDp()); });
+    onBeforeUnmount(() => {
+      document.removeEventListener('click', onDocClick, false);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      window.removeEventListener('resize', updatePopoverPosition, true);
+    });
+
+    expose({ openDp });
+
+    const displayDate = computed(() => {
+      if (!selectedDate.value) return '';
+      const base = formatDateByStyle(selectedDate.value, formatStyle);
+      return props.showTime ? `${base} ${timePart.value}` : base;
+    });
+
+    return {
+      dpWrapper, dpInput, dpPopRef,
+      dpOpen, dpPopStyle,
+      openDp, prevMonth, nextMonth,
+      selectDay, pickToday, clearDate,
+      weekdayAbbrs, monthLabel, gridDays,
+      displayDate, labelToday, labelClear,
+      timePart, onTimeInput,
+      showTime: props.showTime, disabled: props.disabled
+    };
+  }
+};
+</script>
+
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400&display=swap');
+
+.dp-wrapper {
+  position: relative;
+  width: 100%;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, sans-serif);
+  font-size: 14px;
+  z-index: 99999;
+}
+
+.dp-input {
+  display: block;
+  width: 100%;
+  padding-left: 5px;
+  padding-right: 30px;
+  height: 35px;
+  cursor: pointer;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, sans-serif);
+  font-size: 13px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.dp-icon {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  color: #ddd;
+}
+.dp-icon:hover { color: #ccc; }
+
+.datepicker-pop {
+  position: fixed;
+  background: #fff;
+  border: 1px solid #acacad;
+  border-radius: 8px;
+  box-shadow: 0 8px 20px rgba(0,0,0,0.15);
+  padding: 8px;
+  z-index: 2147483647 !important;
+}
+
+.dp-header { display: flex; align-items: center; justify-content: space-between; gap: 6px; margin-bottom: 6px; }
+.dp-title  { font-weight: 500; text-transform: capitalize; }
+.dp-nav    { border: 1px solid #ccc; background: #f7f7f7; border-radius: 6px; padding: 2px 8px; cursor: pointer; }
+.dp-weekdays, .dp-grid { display: grid; grid-template-columns: repeat(7,1fr); gap: 2px; }
+.dp-weekday { text-align: center; font-size: 12px; color: #666; padding: 4px 0; }
+.dp-cell { border: 0; background: transparent; border-radius: 6px; padding: 6px 0; cursor: pointer; align-items:center; text-align: center; justify-content: center;}

--- a/Project/TicketGrid/src/components/DateTimeCellEditor.vue
+++ b/Project/TicketGrid/src/components/DateTimeCellEditor.vue
@@ -1,0 +1,572 @@
+<template>
+  <div class="dp-wrapper" ref="dpWrapper">
+    <input
+      ref="dpInput"
+      :class="['dp-input', { 'dp-input--hidden': hideInlineInput }]"
+      type="text"
+      :value="displayDate"
+      readonly
+      :disabled="disabled"
+      @pointerdown.stop.prevent="!disabled && openDp($event)"
+      @mousedown.stop.prevent="!disabled && openDp($event)"
+      @click.stop.prevent="!disabled && openDp($event)"
+      aria-haspopup="dialog"
+      :aria-expanded="dpOpen ? 'true' : 'false'"
+    />
+    <button
+      v-if="!disabled"
+      type="button"
+      :class="['dp-icon', { 'dp-icon--hidden': hideInlineInput }]"
+      @pointerdown.stop.prevent="openDp($event)"
+      @mousedown.stop.prevent="openDp($event)"
+      @click.stop.prevent="openDp($event)"
+      :aria-label="labelOpenCalendar"
+    >
+      <span class="material-symbols-outlined">calendar_month</span>
+    </button>
+
+    <!-- Teleport to body -->
+    <teleport to="body">
+      <div v-if="dpOpen" ref="dpPopRef" role="dialog" aria-modal="true" :style="popRootStyle">
+        <div :style="rowBetweenStyle">
+          <button type="button" :style="navBtnStyle" @click="prevMonth" :aria-label="labelPreviousMonth">&lt;</button>
+          <div :style="titleStyle">{{ monthLabel }}</div>
+          <button type="button" :style="navBtnStyle" @click="nextMonth" :aria-label="labelNextMonth">&gt;</button>
+        </div>
+
+        <div :style="gridHeaderStyle">
+          <div v-for="d in weekdayAbbrs" :key="d" :style="weekdayStyle">{{ d }}</div>
+        </div>
+
+        <div :style="gridDaysStyle">
+          <button
+            v-for="d in gridDays"
+            :key="d.dateStr"
+            type="button"
+            :style="[dayBtnStyle, d.isSelected ? daySelectedStyle : null, d.isToday ? dayTodayStyle : null, !d.inMonth ? dayMutedStyle : null]"
+            @click="selectDay(d)"
+          >
+            {{ d.label }}
+          </button>
+        </div>
+
+        <div v-if="showTime" :style="timeWrapStyle">
+          <input type="time" v-model="timePart" @input="onTimeInput" :style="timeInputStyle" />
+        </div>
+
+        <div :style="actionsRowStyle">
+          <button type="button" :style="actionBtnStyle" @click="onPickToday">{{ labelToday }}</button>
+          <button type="button" :style="actionBtnStyle" @click="onApply">{{ labelSelect }}</button>
+          <button type="button" :style="actionBtnStyle" @click="onClear">{{ labelClear }}</button>
+        </div>
+      </div>
+    </teleport>
+  </div>
+</template>
+
+<script>
+import { ref, computed, watch, onBeforeUnmount, nextTick } from 'vue';
+import { translatePhrase } from '../translation';
+
+export default {
+  name: 'DateTimeCellEditor',
+  props: {
+    params: { type: Object, default: null },
+    modelValue: { type: String, default: '' },
+    disabled: { type: Boolean, default: false },
+    showTime: { type: Boolean, default: false },
+    autoOpen: { type: Boolean, default: true }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit, expose }) {
+    const colDef = (props.params && props.params.colDef) ? props.params.colDef : {};
+    const tag = String(colDef.TagControl || colDef.tagControl || (colDef.context && colDef.context.TagControl) || '').toUpperCase();
+    const fieldName = String(colDef.field || '').toLowerCase();
+    const cellType = String(colDef.cellDataType || colDef.cellType || '').toLowerCase();
+    const isShowTime = ref(tag === 'DEADLINE' || fieldName === 'deadline' || cellType === 'datetime' || props.showTime === true);
+    const hideInlineInput = computed(() => tag === 'DEADLINE' || fieldName === 'deadline' || cellType === 'datetime' || cellType === 'date');
+
+    const ww = window.wwLib?.wwVariable;
+    const lang = ww?.getValue('aa44dc4c-476b-45e9-a094-16687e063342') || navigator.language;
+    const formatStyleRaw = ww?.getValue('21a41590-e7d8-46a5-af76-bb3542da1df3') || 'european';
+    const formatStyle = String(formatStyleRaw).toLowerCase() === 'american' ? 'american' : 'european';
+    const isPt = computed(() => String(lang || '').toLowerCase().startsWith('pt'));
+        const labelToday = computed(() => translatePhrase('Today'));
+    const labelSelect = computed(() => translatePhrase('Select'));
+    const labelClear = computed(() => translatePhrase('Clear'));
+    const labelOpenCalendar = computed(() => translatePhrase('Open calendar'));
+    const labelPreviousMonth = computed(() => translatePhrase('Previous month'));
+    const labelNextMonth = computed(() => translatePhrase('Next month'));
+
+    const dpWrapper = ref(null);
+    const dpInput   = ref(null);
+    const dpPopRef  = ref(null);
+
+    const dpOpen = ref(false);
+    const dpPopStyle = ref({});
+    const selectedDate = ref('');
+    const timePart = ref('00:00');
+
+    // Valor original (o que estava na célula ao abrir)
+    const originalValue = ref('');
+    // Flag de alteração efetiva
+    const changed = ref(false);
+    // Ponto de ancoragem do popup (coordenadas do clique)
+    const anchorPoint = ref(null);
+    // Evita emitir antes de qualquer interação
+    const readyToEmit = ref(false);
+
+    function toYMD(date) {
+      const y = date.getFullYear();
+      const m = String(date.getMonth() + 1).padStart(2, '0');
+      const d = String(date.getDate()).padStart(2, '0');
+      return `${y}-${m}-${d}`;
+    }
+    function parseYMD(ymd) {
+      if (!ymd) return null;
+      const [y,m,d] = ymd.split('-').map(Number);
+      if (!y || !m || !d) return null;
+      return new Date(y, m - 1, d);
+    }
+    function sameYMD(a,b){ return a && b && toYMD(a) === toYMD(b); }
+
+    function applyValue(val){
+      const v = val || '';
+      originalValue.value = String(v); // define apenas na carga inicial/reload
+      changed.value = false;           // reset do estado de alteração
+
+      if (!v) {
+        selectedDate.value = '';
+        timePart.value = '00:00';
+        return;
+      }
+      if (isShowTime.value) {
+        if (typeof v === 'string' && v.includes('T')) {
+          const [d, t] = v.split('T');
+          selectedDate.value = d || '';
+          timePart.value = t ? t.slice(0,5) : '00:00';
+          return;
+        }
+        const d = new Date(v);
+        if (!isNaN(d.getTime())) {
+          selectedDate.value = toYMD(d);
+          const hh = String(d.getHours()).padStart(2,'0');
+          const mm = String(d.getMinutes()).padStart(2,'0');
+          timePart.value = `${hh}:${mm}`;
+          return;
+        }
+      }
+      selectedDate.value = String(v);
+    }
+
+    // Valor inicial: modelValue > params.value > params.data[field]
+    const initVal =
+      props.modelValue !== undefined &&
+      props.modelValue !== null &&
+      props.modelValue !== ''
+        ? props.modelValue
+        : (
+            props.params &&
+            (props.params.value !== undefined && props.params.value !== null
+              ? props.params.value
+              : props.params.colDef && props.params.data
+                ? props.params.data[props.params.colDef.field]
+                : undefined)
+          );
+    applyValue(initVal);
+
+    watch(
+      () => {
+        const mv = props.modelValue;
+        const p = props.params || {};
+        const pv =
+          p.value !== undefined && p.value !== null
+            ? p.value
+            : p.colDef && p.data
+              ? p.data[p.colDef.field]
+              : undefined;
+        return mv !== undefined && mv !== null && mv !== '' ? mv : pv;
+      },
+      v => {
+        applyValue(v);
+      }
+    );
+
+    const dpMonth = ref(0);
+    const dpYear  = ref(0);
+    const weekStart = computed(() => (formatStyle === 'american' ? 0 : 1));
+
+    const weekdayAbbrs = computed(() => {
+      if (isPt.value) {
+        const base = ['dom','seg','ter','qua','qui','sex','sáb'];
+        return weekStart.value === 1 ? base.slice(1).concat(base.slice(0,1)) : base;
+      }
+      try {
+        const base = Array.from({ length: 7 }, (_, i) =>
+          new Intl.DateTimeFormat(lang, { weekday: 'short' }).format(new Date(Date.UTC(2021,7,1+i)))
+        );
+        return weekStart.value === 1 ? base.slice(1).concat(base.slice(0,1)) : base;
+      } catch {
+        const en = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+        return weekStart.value === 1 ? en.slice(1).concat(en.slice(0,1)) : en;
+      }
+    });
+
+    const monthLabel = computed(() => {
+      try {
+        return new Intl.DateTimeFormat(lang, { month: 'long', year: 'numeric' }).format(new Date(dpYear.value, dpMonth.value, 1));
+      } catch {
+        const EN_MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December'];
+        return `${EN_MONTHS[dpMonth.value]} ${dpYear.value}`;
+      }
+    });
+
+    function makeCell(date, inMonth){
+      const label = date.getDate();
+      const today = new Date();
+      const selected = parseYMD(selectedDate.value);
+      return { label, dateStr: toYMD(date), inMonth, isToday: sameYMD(date,today), isSelected: selected && sameYMD(date, selected) };
+    }
+
+    const gridDays = computed(() => {
+      const first = new Date(dpYear.value, dpMonth.value, 1);
+      const startWeekday = first.getDay();
+      const lead = (startWeekday - weekStart.value + 7) % 7;
+      const daysInCur = new Date(dpYear.value, dpMonth.value + 1, 0).getDate();
+      const prevYear = dpMonth.value === 0 ? dpYear.value - 1 : dpYear.value;
+      const prevMonth = dpMonth.value === 0 ? 11 : dpMonth.value - 1;
+      const daysInPrev = new Date(prevYear, prevMonth + 1, 0).getDate();
+      const cells = [];
+      for (let i = daysInPrev - lead + 1; i <= daysInPrev; i++) cells.push(makeCell(new Date(prevYear, prevMonth, i), false));
+      for (let i = 1; i <= daysInCur; i++) cells.push(makeCell(new Date(dpYear.value, dpMonth.value, i), true));
+      const tail = 42 - cells.length;
+      const nextYear = dpMonth.value === 11 ? dpYear.value + 1 : dpYear.value;
+      const nextMonth = dpMonth.value === 11 ? 0 : dpMonth.value + 1;
+      for (let i = 1; i <= tail; i++) cells.push(makeCell(new Date(nextYear, nextMonth, i), false));
+      return cells;
+    });
+
+    // ---------- construir “valor atual” sem efeitos colaterais ----------
+    function buildCurrentValue() {
+      if (!selectedDate.value) return '';
+      if (!isShowTime.value) return selectedDate.value;
+
+      const orig = originalValue.value || '';
+      if (/t/i.test(orig)) {
+        return `${selectedDate.value}T${timePart.value}`;
+      } else {
+        const baseDate = new Date(`${selectedDate.value}T${timePart.value}`);
+        const mm = String(baseDate.getMonth() + 1).padStart(2,'0');
+        const dd = String(baseDate.getDate()).padStart(2,'0');
+        const yyyy = baseDate.getFullYear();
+        const min = String(baseDate.getMinutes()).padStart(2,'0');
+        if (/am|pm/i.test(orig)) {
+          let hh = baseDate.getHours();
+          const ampm = hh >= 12 ? 'PM' : 'AM';
+          hh = hh % 12; if (hh === 0) hh = 12;
+          const hh12 = String(hh).padStart(2,'0');
+          return `${mm}/${dd}/${yyyy} ${hh12}:${min} ${ampm}`;
+        } else if (orig.includes('/')) {
+          const hh = String(baseDate.getHours()).padStart(2,'0');
+          return `${mm}/${dd}/${yyyy} ${hh}:${min}`;
+        } else {
+          return `${selectedDate.value} ${timePart.value}`;
+        }
+      }
+    }
+
+    function emitValue(){
+      if (!readyToEmit.value) return;
+      const newVal = buildCurrentValue();
+      emit('update:modelValue', newVal);
+    }
+
+    function finalizeEditing(){
+      const p = props.params || {};
+      try {
+        if (p.api && typeof p.api.stopEditing === 'function') p.api.stopEditing();
+        else if (typeof p.stopEditing === 'function') p.stopEditing();
+      } catch (e) {}
+    }
+
+    function clampToViewport(x, y, w, h, margin = 8) {
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      let nx = Math.min(Math.max(margin, x), Math.max(margin, vw - w - margin));
+      let ny = Math.min(Math.max(margin, y), Math.max(margin, vh - h - margin));
+      return { x: nx, y: ny };
+    }
+
+    const POPUP_VERTICAL_OFFSET = 30;
+
+    function updatePopoverPosition() {
+      const pop = dpPopRef.value;
+      if (!pop) return;
+      let baseLeft = 0;
+      let baseTop = 0;
+
+      if (anchorPoint.value) {
+        baseLeft = anchorPoint.value.x - 130;
+        baseTop = anchorPoint.value.y - 100;
+      } else if (dpWrapper.value) {
+        const rect = dpWrapper.value.getBoundingClientRect();
+        baseLeft = rect.left;
+        baseTop = rect.bottom;
+      }
+
+      baseTop -= POPUP_VERTICAL_OFFSET;
+
+      const prevVis = pop.style.visibility;
+      const prevDisp = pop.style.display;
+      pop.style.visibility = 'hidden';
+      pop.style.display = 'block';
+      const w = pop.offsetWidth || 200;
+      const h = pop.offsetHeight || 200;
+      pop.style.visibility = prevVis || '';
+      pop.style.display = prevDisp || '';
+
+      const { x, y } = clampToViewport(baseLeft, baseTop, w, h, 8);
+
+      dpPopStyle.value = {
+        left: `${Math.round(x)}px`,
+        top: `${Math.round(y)}px`
+      };
+    }
+
+    function onDocClick(e){
+      if(!dpOpen.value) return;
+      const insideWrapper = dpWrapper.value && dpWrapper.value.contains(e.target);
+      const insidePop = dpPopRef.value && dpPopRef.value.contains(e.target);
+      if(!insideWrapper && !insidePop) {
+        closeDp();
+        finalizeEditing(); // fechar fora = finalizar edição
+      }
+    }
+
+    function openDp(e){
+      anchorPoint.value = (e && typeof e.clientX === 'number') ? { x: e.clientX, y: e.clientY } : null;
+      const base = parseYMD(selectedDate.value) || new Date();
+      dpMonth.value = base.getMonth();
+      dpYear.value  = base.getFullYear();
+      if(isShowTime.value && !selectedDate.value){
+        const pad2 = n => String(n).padStart(2,'0');
+        timePart.value = `${pad2(base.getHours())}:${pad2(base.getMinutes())}`;
+      }
+      dpOpen.value = true;
+
+      nextTick(() => {
+        updatePopoverPosition();
+        try { dpInput.value && dpInput.value.focus(); } catch {}
+        document.addEventListener('click', onDocClick, false);
+        window.addEventListener('scroll', updatePopoverPosition, true);
+        window.addEventListener('resize', updatePopoverPosition, true);
+      });
+    }
+
+    function closeDp(){
+      dpOpen.value = false;
+      anchorPoint.value = null;
+      document.removeEventListener('click', onDocClick, false);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      window.removeEventListener('resize', updatePopoverPosition, true);
+    }
+
+    function prevMonth(){
+      dpMonth.value = dpMonth.value === 0 ? 11 : dpMonth.value - 1;
+      if (dpMonth.value === 11) dpYear.value--;
+      nextTick(updatePopoverPosition);
+    }
+    function nextMonth(){
+      dpMonth.value = dpMonth.value === 11 ? 0 : dpMonth.value + 1;
+      if (dpMonth.value === 0) dpYear.value++;
+      nextTick(updatePopoverPosition);
+    }
+    function selectDay(d){
+      if(!d.inMonth) return;
+      selectedDate.value = d.dateStr;
+      readyToEmit.value = true;
+      changed.value = true;
+      emitValue();
+    }
+    function onPickToday(){
+      const now = new Date();
+      selectedDate.value = toYMD(now);
+      if(isShowTime.value){
+        const p = n=>String(n).padStart(2,'0');
+        timePart.value = `${p(now.getHours())}:${p(now.getMinutes())}`;
+      }
+      readyToEmit.value = true;
+      changed.value = true;
+      emitValue();
+      closeDp();
+      finalizeEditing();
+    }
+    function onClear(){
+      selectedDate.value = '';
+      if(isShowTime.value) timePart.value = '00:00';
+      readyToEmit.value = true;
+      changed.value = true;
+      emitValue();
+      closeDp();
+      finalizeEditing();
+    }
+    function onApply(){
+      readyToEmit.value = true;
+      changed.value = true;
+      emitValue();
+      closeDp();
+      finalizeEditing();
+    }
+    function onTimeInput(e){
+      timePart.value = e.target.value;
+      readyToEmit.value = true;
+      changed.value = true;
+      emitValue();
+    }
+
+    onBeforeUnmount(() => {
+      document.removeEventListener('click', onDocClick, false);
+      window.removeEventListener('scroll', updatePopoverPosition, true);
+      window.removeEventListener('resize', updatePopoverPosition, true);
+    });
+
+    // === AG Grid cell editor API ===
+    expose({
+      openDp,
+      afterGuiAttached(params){
+        try {
+          const initVal = params?.value ?? (params?.colDef?.field ? params?.data?.[params.colDef.field] : undefined);
+          applyValue(initVal);
+          const ev = params && params.event;
+          if (props.autoOpen) openDp(ev);
+        } catch (e) {}
+      },
+      // Se não houve alteração, devolve original; se houve, devolve o valor construído
+      getValue(){
+        return changed.value ? (buildCurrentValue() || '') : (originalValue.value || '');
+      },
+      isPopup(){ return true; },
+      isCancelBeforeStart(){ return false; },
+      // Cancela apenas se não houve mudança alguma
+      isCancelAfterEnd(){ return !changed.value; }
+    });
+
+    const displayDate = computed(() => {
+      if (!selectedDate.value) return '';
+      return isShowTime.value
+        ? `${selectedDate.value} ${timePart.value}`
+       : selectedDate.value;
+    });
+
+    // === Inline CSS objects (para evitar overrides externos) ===
+    const popRootStyle = computed(() => ({
+      position: 'fixed',
+      left: dpPopStyle.value.left || '0px',
+      top: dpPopStyle.value.top || '0px',
+      zIndex: 2147483647,
+      background: '#fff',
+      border: '1px solid #acacad',
+      borderRadius: '8px',
+      boxShadow: '0 8px 20px rgba(0,0,0,0.15)',
+      padding: '8px',
+      minWidth: '260px',
+      maxWidth: '320px',
+      fontFamily: 'var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif)',
+      fontSize: 'var(--grid-view-dinamica-font-size, 12px)',
+      userSelect: 'none'
+    }));
+    const rowBetweenStyle = { display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '6px', marginBottom: '6px' };
+    const titleStyle = { fontWeight: 500, textTransform: 'capitalize', whiteSpace: 'nowrap' };
+    const navBtnStyle = { border: '1px solid #ccc', background: '#f7f7f7', borderRadius: '6px', padding: '2px 8px', minWidth: '28px', minHeight: '28px', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', cursor: 'pointer', lineHeight: '1' };
+    const gridHeaderStyle = { display: 'grid', gridTemplateColumns: 'repeat(7,1fr)', gap: '2px' };
+    const weekdayStyle = { textAlign: 'center', fontSize: '12px', color: '#666', padding: '4px 0' };
+    const gridDaysStyle = { display: 'grid', gridTemplateColumns: 'repeat(7,1fr)', gap: '2px' };
+    const dayBtnStyle = { border: '1px solid transparent', background: 'transparent', borderRadius: '6px', padding: '6px 0', minHeight: '30px', textAlign: 'center', lineHeight: '1', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', width: '100%', cursor: 'pointer' };
+    const daySelectedStyle = { background: '#e7f0ff', borderColor: '#84a9ff' };
+    const dayTodayStyle = { outline: '1px dashed #aaa' };
+    const dayMutedStyle = { color: '#bbb' };
+    const timeWrapStyle = { marginTop: '6px' };
+    const timeInputStyle = { width: '100%', padding: '6px', border: '1px solid #ccc', borderRadius: '6px' };
+    const actionsRowStyle = { marginTop: '8px', display: 'flex', gap: '6px', justifyContent: 'flex-end', flexWrap: 'wrap' };
+    const actionBtnStyle = { border: '1px solid #ccc', background: '#f7f7f7', borderRadius: '6px', padding: '4px 8px', minHeight: '28px', cursor: 'pointer' };
+
+    return {
+      dpWrapper, dpInput, dpPopRef,
+      dpOpen, dpPopStyle,
+      openDp, prevMonth, nextMonth,
+      selectDay, onPickToday, onClear, onApply,
+      weekdayAbbrs, monthLabel, gridDays,
+      displayDate, labelToday, labelSelect, labelClear, labelOpenCalendar, labelPreviousMonth, labelNextMonth,
+      timePart, onTimeInput,
+      showTime: isShowTime.value, disabled: props.disabled,
+      hideInlineInput,
+
+      popRootStyle, rowBetweenStyle, titleStyle, navBtnStyle,
+      gridHeaderStyle, weekdayStyle, gridDaysStyle,
+      dayBtnStyle, daySelectedStyle, dayTodayStyle, dayMutedStyle,
+      timeWrapStyle, timeInputStyle, actionsRowStyle, actionBtnStyle
+    };
+  }
+};
+</script>
+
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght@400&display=swap');
+
+  .dp-wrapper {
+    position: relative;
+    width: 100%;
+    font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+    font-size: var(--grid-view-dinamica-font-size, 12px);
+    z-index: 1;
+  }
+
+  .dp-input {
+    display: block;
+    width: 100%;
+    padding-left: 5px;
+    padding-right: 30px;
+    height: 35px;
+    cursor: pointer;
+    font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+    font-size: var(--grid-view-dinamica-font-size, 12px);
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #fff;
+    outline: transparent;
+  }
+
+  .dp-input--hidden {
+    opacity: 0;
+    background: transparent;
+    border-color: transparent;
+    color: transparent;
+    caret-color: transparent;
+  }
+
+  .dp-icon {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    cursor: pointer;
+    color: #888;
+  }
+
+  .dp-icon:hover {
+    color: #555;
+  }
+
+  .dp-icon--hidden {
+    display: none;
+  }
+</style>

--- a/Project/TicketGrid/src/components/DeadlineFilterRenderer.js
+++ b/Project/TicketGrid/src/components/DeadlineFilterRenderer.js
@@ -1,0 +1,1226 @@
+import * as VueRuntimeModule from "vue";
+import { readTypographyVariable, DEFAULT_FONT_FAMILY } from "../utils/fontFamily.js";
+import { translatePhrase } from "../translation";
+
+/* CustomDatePicker + DeadlineFilterRenderer
+   - Popup via Teleport para <body>
+   - Anti-loop (syncLock)
+   - Datas custom em UTC (Apply idempotente)
+   - POSICIONAMENTO ROBUSTO (clamp + flip)
+   - ESTILO INLINE (imune a resets / CSS faltando)
+*/
+
+const getResolvedFontFamily = () => readTypographyVariable() || DEFAULT_FONT_FAMILY;
+
+//import "./list-filter.css"; // opcional para o resto do filtro, o calendário não depende disso
+
+let cachedVueRuntime = null;
+function getVueRuntime() {
+  if (cachedVueRuntime) {
+    return cachedVueRuntime;
+  }
+
+  const candidates = [];
+
+  if (typeof window !== "undefined") {
+    const winVue = window?.Vue;
+    if (winVue) candidates.push(winVue);
+
+    try {
+      const parentWin = window.parent;
+      if (parentWin && parentWin !== window && parentWin.Vue) {
+        candidates.push(parentWin.Vue);
+      }
+    } catch (err) {
+      /* ignore cross-origin access */
+    }
+
+    try {
+      const frontWindow = window.wwLib?.getFrontWindow?.();
+      if (frontWindow?.Vue) {
+        candidates.push(frontWindow.Vue);
+      }
+    } catch (err) {
+      /* ignore wwLib access issues */
+    }
+  }
+
+  if (
+    VueRuntimeModule &&
+    typeof VueRuntimeModule.createApp === "function"
+  ) {
+    candidates.push(VueRuntimeModule);
+  }
+
+  const moduleDefault = VueRuntimeModule?.default;
+  if (moduleDefault && typeof moduleDefault.createApp === "function") {
+    candidates.push(moduleDefault);
+  }
+
+  cachedVueRuntime =
+    candidates.find(
+      (candidate) => candidate && typeof candidate.createApp === "function"
+    ) || null;
+
+  return cachedVueRuntime;
+}
+
+const CustomDatePicker = (() => {
+  const VueGlobal = getVueRuntime();
+
+  if (!VueGlobal) {
+    
+    return null;
+  }
+
+  const {
+    ref,
+    computed,
+    watch,
+    nextTick,
+    h,
+    Teleport,
+    onBeforeUnmount,
+  } = VueGlobal;
+
+  return {
+    props: {
+      modelValue: { type: String, default: "" },
+      disabled: { type: Boolean, default: false },
+      showTime: { type: Boolean, default: false },
+    },
+    emits: ["update:modelValue"],
+    setup(props, { emit }) {
+      // ===== helpers de data/locale =====
+      const translateText = (t) => translatePhrase(t);
+      const ww = window.wwLib?.wwVariable;
+      const lang =
+        ww?.getValue("aa44dc4c-476b-45e9-a094-16687e063342") ||
+        navigator.language;
+      const formatStyleRaw =
+        ww?.getValue("21a41590-e7d8-46a5-af76-bb3542da1df3") || "european";
+      const formatStyle =
+        String(formatStyleRaw).toLowerCase() === "american"
+          ? "american"
+          : "european";
+
+      const isPt = computed(() =>
+        String(lang || "").toLowerCase().startsWith("pt")
+      );
+      const PT_MONTHS = [
+        "janeiro",
+        "fevereiro",
+        "março",
+        "abril",
+        "maio",
+        "junho",
+        "julho",
+        "agosto",
+        "setembro",
+        "outubro",
+        "novembro",
+        "dezembro",
+      ];
+      const labelToday = computed(() =>
+        isPt.value ? "Hoje" : translateText("Today")
+      );
+      const labelClear = computed(() =>
+        isPt.value ? "Limpar" : translateText("Clear")
+      );
+
+      const toYMD = (date) => {
+        const y = date.getFullYear();
+        const m = String(date.getMonth() + 1).padStart(2, "0");
+        const d = String(date.getDate()).padStart(2, "0");
+        return `${y}-${m}-${d}`;
+      };
+      const parseYMD = (ymd) => {
+        if (!ymd) return null;
+        const [y, m, d] = ymd.split("-").map(Number);
+        if (!y || !m || !d) return null;
+        return new Date(y, m - 1, d);
+      };
+      const formatDateByStyle = (yyyyMmDd, style = formatStyle) => {
+        if (!yyyyMmDd) return "";
+        const [y, m, d] = yyyyMmDd.split("-").map(Number);
+        const DD = String(d).padStart(2, "0");
+        const MM = String(m).padStart(2, "0");
+        const YYYY = String(y);
+        return style === "american"
+          ? `${MM}/${DD}/${YYYY}`
+          : `${DD}/${MM}/${YYYY}`;
+      };
+      const sameYMD = (a, b) => a && b && toYMD(a) === toYMD(b);
+
+      // ===== refs =====
+      const dpWrapper = ref(null);
+      const dpOpen = ref(false);
+      const dpPopRef = ref(null);
+      const dpPopPos = ref({ left: 0, top: 0 });
+      const selectedDate = ref("");
+      const timePart = ref("00:00");
+
+      // ===== anti-loop =====
+      let syncLock = false;
+
+      watch(
+        () => props.modelValue,
+        (v) => {
+          if (syncLock) return;
+          const prevDate = selectedDate.value || "";
+          let nextDate = "";
+          let nextTime = timePart.value;
+          if (props.showTime) {
+            const [d, t] = (v || "").split("T");
+            nextDate = d || "";
+            nextTime = t ? t.slice(0, 5) : "00:00";
+          } else {
+            nextDate = (v || "").split("T")[0] || "";
+          }
+          if (nextDate !== prevDate || nextTime !== timePart.value) {
+            selectedDate.value = nextDate;
+            timePart.value = nextTime;
+          }
+        },
+        { immediate: true }
+      );
+
+      const dpMonth = ref(0);
+      const dpYear = ref(0);
+      const weekStart = computed(() =>
+        formatStyle === "american" ? 0 : 1
+      );
+
+      const weekdayAbbrs = computed(() => {
+        if (isPt.value) {
+          const base = ["dom", "seg", "ter", "qua", "qui", "sex", "sáb"];
+          return weekStart.value === 1
+            ? base.slice(1).concat(base.slice(0, 1))
+            : base;
+        }
+        try {
+          const base = Array.from({ length: 7 }, (_, i) =>
+            new Intl.DateTimeFormat(lang, { weekday: "short" }).format(
+              new Date(Date.UTC(2021, 7, 1 + i))
+            )
+          );
+          return weekStart.value === 1
+            ? base.slice(1).concat(base.slice(0, 1))
+            : base;
+        } catch {
+          const en = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+          return weekStart.value === 1
+            ? en.slice(1).concat(en.slice(0, 1))
+            : en;
+        }
+      });
+
+      const monthLabel = computed(() => {
+        if (isPt.value) return `${PT_MONTHS[dpMonth.value]} ${dpYear.value}`;
+        try {
+          return new Intl.DateTimeFormat(lang, {
+            month: "long",
+            year: "numeric",
+          }).format(new Date(dpYear.value, dpMonth.value, 1));
+        } catch {
+          const EN = [
+            "January",
+            "February",
+            "March",
+            "April",
+            "May",
+            "June",
+            "July",
+            "August",
+            "September",
+            "October",
+            "November",
+            "December",
+          ];
+          return `${EN[dpMonth.value]} ${dpYear.value}`;
+        }
+      });
+
+      function makeCell(date, inMonth) {
+        const label = date.getDate();
+        const today = new Date();
+        const sel = parseYMD(selectedDate.value);
+        return {
+          label,
+          dateStr: toYMD(date),
+          inMonth,
+          isToday: sameYMD(date, today),
+          isSelected: sel && sameYMD(date, sel),
+        };
+      }
+
+      const gridDays = computed(() => {
+        const first = new Date(dpYear.value, dpMonth.value, 1);
+        const startWeekday = first.getDay();
+        const lead = (startWeekday - weekStart.value + 7) % 7;
+        const daysInCur = new Date(
+          dpYear.value,
+          dpMonth.value + 1,
+          0
+        ).getDate();
+        const prevYear = dpMonth.value === 0 ? dpYear.value - 1 : dpYear.value;
+        const prevMonth = dpMonth.value === 0 ? 11 : dpMonth.value - 1;
+        const daysInPrev = new Date(
+          prevYear,
+          prevMonth + 1,
+          0
+        ).getDate();
+        const cells = [];
+        for (let i = daysInPrev - lead + 1; i <= daysInPrev; i++)
+          cells.push(makeCell(new Date(prevYear, prevMonth, i), false));
+        for (let i = 1; i <= daysInCur; i++)
+          cells.push(makeCell(new Date(dpYear.value, dpMonth.value, i), true));
+        const tail = 42 - cells.length;
+        const nextYear = dpMonth.value === 11 ? dpYear.value + 1 : dpYear.value;
+        const nextMonth = dpMonth.value === 11 ? 0 : dpMonth.value + 1;
+        for (let i = 1; i <= tail; i++)
+          cells.push(makeCell(new Date(nextYear, nextMonth, i), false));
+        return cells;
+      });
+
+      const fontFamily = getResolvedFontFamily();
+
+      // ===== estilos inline (críticos) =====
+      const stylePopupBase = {
+        position: "fixed",
+        zIndex: 2147483647,
+        background: "#fff",
+        border: "1px solid #e5e7eb",
+        borderRadius: "12px",
+        boxShadow: "0 10px 30px rgba(0,0,0,.08)",
+        width: "280px",
+        padding: "8px",
+        userSelect: "none",
+        boxSizing: "border-box",
+        fontFamily: fontFamily,
+        fontSize: "13px",
+      };
+      const styleBackdrop = {
+        position: "fixed",
+        inset: "0",
+        zIndex: 2147483646,
+        background: "transparent",
+      };
+      const sHeader = {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        padding: "4px 4px 8px",
+      };
+      const sTitle = { font: `600 13px/1.2 ${fontFamily}` };
+      const sNav = {
+        minWidth: "28px",
+        minHeight: "28px",
+        border: "1px solid #ccc",
+        background: "#f7f7f7",
+        borderRadius: "6px",
+        padding: "2px 8px",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        lineHeight: "1",
+        color: "#424242",
+        font: `600 13px/1 ${fontFamily}`,
+      };
+      const sWeek = {
+        display: "grid",
+        gridTemplateColumns: "repeat(7,1fr)",
+        gap: "2px",
+        padding: "4px 2px",
+        color: "#6b7280",
+        font: `600 13px/1 ${fontFamily}`,
+        textTransform: "uppercase",
+        letterSpacing: ".02em",
+      };
+      const sWeekday = { textAlign: "center" };
+      const sGrid = {
+        display: "grid",
+        gridTemplateColumns: "repeat(7,1fr)",
+        gap: "2px",
+        padding: "6px 2px 4px",
+      };
+      const sCell = {
+        border: "1px solid transparent",
+        background: "transparent",
+        borderRadius: "6px",
+        padding: "6px 0",
+        minHeight: "30px",
+        width: "100%",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        font: `500 13px/1 ${fontFamily}`,
+        lineHeight: "1",
+      };
+      const sCellMuted = { color: "#9ca3af" };
+      const sCellSel = { background: "#e7f0ff", borderColor: "#84a9ff" };
+      const sCellToday = { outline: "1px dashed #aaa" };
+      const sActions = {
+        display: "flex",
+        gap: "6px",
+        justifyContent: "flex-end",
+        paddingTop: "8px",
+        flexWrap: "wrap",
+      };
+      const sAction = {
+        flex: 1,
+        border: "1px solid #ccc",
+        background: "#f7f7f7",
+        borderRadius: "6px",
+        padding: "4px 8px",
+        minHeight: "28px",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        cursor: "pointer",
+        font: `600 13px/1 ${fontFamily}`,
+      };
+
+      // ===== posicionamento =====
+      function computePosition() {
+        const rect = dpWrapper.value?.getBoundingClientRect?.();
+        const popEl = dpPopRef.value;
+        if (!rect || !popEl) return;
+
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+        const pw = popEl.offsetWidth || 280;
+        const ph = popEl.offsetHeight || 320;
+        const margin = 8;
+
+        let left = rect.left;
+        let top = rect.bottom;
+
+        if (left + pw + margin > vw) left = rect.right - pw;
+        if (left < margin) left = margin;
+        if (left + pw > vw - margin) left = vw - margin - pw;
+
+        if (top + ph + margin > vh) top = rect.top - ph;
+
+        if (top < margin || top + ph > vh - margin) {
+          const centerY = rect.top + rect.height / 2;
+          top = Math.min(vh - margin - ph, Math.max(margin, centerY - ph / 2));
+        }
+
+        dpPopPos.value = { left: Math.round(left), top: Math.round(top + 80) };
+      }
+
+      function openDp() {
+        if (dpOpen.value || props.disabled) return;
+
+        const base = selectedDate.value
+          ? parseYMD(selectedDate.value)
+          : new Date();
+        dpMonth.value = base.getMonth();
+        dpYear.value = base.getFullYear();
+
+        const rect = dpWrapper.value?.getBoundingClientRect?.();
+        if (rect) {
+          const vw = window.innerWidth,
+            vh = window.innerHeight;
+          const margin = 8,
+            approxW = 280,
+            approxH = 320;
+          let left = rect.left,
+            top = rect.bottom;
+
+          if (left + approxW + margin > vw) left = rect.right - approxW;
+          if (left < margin) left = margin;
+          if (top + approxH + margin > vh) top = rect.top - approxH;
+          if (top < margin) top = margin;
+
+          dpPopPos.value = { left: Math.round(left), top: Math.round(top) };
+        }
+
+        dpOpen.value = true;
+
+        nextTick(() => {
+          computePosition();
+          window.addEventListener("scroll", computePosition, true);
+          window.addEventListener("resize", computePosition, true);
+        });
+      }
+
+      function closeDp() {
+        if (!dpOpen.value) return;
+        dpOpen.value = false;
+        window.removeEventListener("scroll", computePosition, true);
+        window.removeEventListener("resize", computePosition, true);
+      }
+
+      onBeforeUnmount(() => {
+        window.removeEventListener("scroll", computePosition, true);
+        window.removeEventListener("resize", computePosition, true);
+      });
+
+      function prevMonth() {
+        if (dpMonth.value === 0) {
+          dpMonth.value = 11;
+          dpYear.value -= 1;
+        } else {
+          dpMonth.value -= 1;
+        }
+        nextTick(computePosition);
+      }
+      function nextMonth() {
+        if (dpMonth.value === 11) {
+          dpMonth.value = 0;
+          dpYear.value += 1;
+        } else {
+          dpMonth.value += 1;
+        }
+        nextTick(computePosition);
+      }
+
+      function selectDay(d) {
+        if (!d.inMonth) return;
+        selectedDate.value = d.dateStr;
+        if (!props.showTime) {
+          emitValue();
+          closeDp();
+        }
+      }
+      function pickToday() {
+        selectedDate.value = toYMD(new Date());
+        emitValue();
+        closeDp();
+      }
+      function clearDate() {
+        selectedDate.value = "";
+        emitValue();
+        closeDp();
+      }
+      function onTimeInput() {
+        emitValue();
+      }
+
+      function emitValue() {
+        let out = "";
+        if (selectedDate.value) {
+          out = props.showTime
+            ? `${selectedDate.value}T${timePart.value}`
+            : selectedDate.value;
+        }
+        if (out !== (props.modelValue || "")) {
+          syncLock = true;
+          emit("update:modelValue", out);
+          Promise.resolve().then(() => {
+            syncLock = false;
+          });
+        }
+      }
+
+      const displayDate = computed(() => {
+        if (!selectedDate.value) return "";
+        const base = formatDateByStyle(selectedDate.value, formatStyle);
+        return props.showTime ? `${base} ${timePart.value}` : base;
+      });
+
+      // ===== render =====
+      return () => {
+        const localChildren = [
+          h("input", {
+            class: "dp-input",
+            type: "text",
+            value: displayDate.value,
+            readonly: true,
+            disabled: props.disabled,
+            onClick: (e) => {
+              e.stopPropagation();
+              if (!props.disabled) openDp();
+            },
+            "aria-haspopup": "dialog",
+            "aria-expanded": dpOpen.value ? "true" : "false",
+            style: {
+              width: "160px",
+              padding: "8px 10px",
+              border: "1px solid #d0d5dd",
+              borderRadius: "8px",
+              background: props.disabled ? "#f2f4f7" : "#fff",
+              color: props.disabled ? "#98a2b3" : "inherit",
+              cursor: props.disabled ? "not-allowed" : "pointer",
+              font: `13px/1.2 ${fontFamily}`,
+              boxSizing: "border-box",
+            },
+          }),
+          !props.disabled &&
+            h(
+              "button",
+              {
+                type: "button",
+                class: "dp-icon",
+                onClick: (e) => {
+                  e.stopPropagation();
+                  openDp();
+                },
+                style: {
+                  border: "none",
+                  background: "transparent",
+                  cursor: "pointer",
+                  padding: "4px",
+                  borderRadius: "6px",
+                },
+              },
+              [h("span", { class: "material-symbols-outlined" }, "calendar_month")]
+            ),
+        ];
+
+        const teleported = dpOpen.value
+          ? h(Teleport, { to: "body" }, [
+              h("div", {
+                class: "dp-backdrop",
+                onClick: () => closeDp(),
+                style: styleBackdrop,
+              }),
+              h(
+                "div",
+                {
+                  class: "datepicker-pop",
+                  ref: dpPopRef,
+                  role: "dialog",
+                  "aria-modal": "true",
+                  "data-grid-popup": "datepicker",
+
+                  style: {
+                    ...stylePopupBase,
+                    left: `${dpPopPos.value.left}px`,
+                    top: `${dpPopPos.value.top}px`,
+                  },
+                },
+                [
+                  h("div", { class: "dp-header", style: sHeader }, [
+                    h(
+                      "button",
+                      {
+                        type: "button",
+                        class: "dp-nav",
+                        onClick: (e) => {
+                          e.stopPropagation();
+                          prevMonth();
+                        },
+                        style: sNav,
+                      },
+                      "<"
+                    ),
+                    h("div", { class: "dp-title", style: sTitle }, monthLabel.value),
+                    h(
+                      "button",
+                      {
+                        type: "button",
+                        class: "dp-nav",
+                        onClick: (e) => {
+                          e.stopPropagation();
+                          nextMonth();
+                        },
+                        style: sNav,
+                      },
+                      ">"
+                    ),
+                  ]),
+                  h(
+                    "div",
+                    { class: "dp-weekdays", style: sWeek },
+                    weekdayAbbrs.value.map((d) =>
+                      h("div", { class: "dp-weekday", style: sWeekday }, d)
+                    )
+                  ),
+                  h(
+                    "div",
+                    { class: "dp-grid", style: sGrid },
+                    gridDays.value.map((d) =>
+                      h(
+                        "button",
+                        {
+                          key: d.dateStr,
+                          type: "button",
+                          class: "dp-cell",
+                          onClick: (e) => {
+                            e.stopPropagation();
+                            selectDay(d);
+                          },
+                          style: {
+                            ...sCell,
+                            ...(d.inMonth ? null : sCellMuted),
+                            ...(d.isSelected ? sCellSel : null),
+                            ...(d.isToday ? sCellToday : null),
+                          },
+                        },
+                        String(d.label)
+                      )
+                    )
+                  ),
+                  props.showTime &&
+                    h("div", { class: "dp-time", style: { marginTop: "6px" } }, [
+                      h("input", {
+                        type: "time",
+                        value: timePart.value,
+                        onInput: (e) => {
+                          e.stopPropagation();
+                          timePart.value = e.target.value;
+                          onTimeInput();
+                        },
+                        style: {
+                          width: "100%",
+                          height: "32px",
+                          border: "1px solid #ccc",
+                          borderRadius: "6px",
+                          padding: "0 8px",
+                          font: `13px/1 ${fontFamily}`,
+                          boxSizing: "border-box",
+                        },
+                      }),
+                    ]),
+                  h("div", { class: "dp-actions", style: sActions }, [
+                    h(
+                      "button",
+                      {
+                        type: "button",
+                        class: "dp-action",
+                        onClick: (e) => {
+                          e.stopPropagation();
+                          pickToday();
+                        },
+                        style: sAction,
+                      },
+                      labelToday.value
+                    ),
+                    h(
+                      "button",
+                      {
+                        type: "button",
+                        class: "dp-action",
+                        onClick: (e) => {
+                          e.stopPropagation();
+                          clearDate();
+                        },
+                        style: sAction,
+                      },
+                      labelClear.value
+                    ),
+                  ]),
+                ]
+              ),
+            ])
+          : null;
+
+        return h(
+          "div",
+          {
+            class: "dp-wrapper",
+            ref: dpWrapper,
+            style: {
+              position: "relative",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "6px",
+            },
+          },
+          teleported ? [...localChildren, teleported] : localChildren
+        );
+      };
+    },
+  };
+})();
+
+export default class DeadlineFilterRenderer {
+  constructor() {
+    this.selected = null;
+    this.customFrom = "";
+    this.customTo = "";
+    this.customMode = "equals";
+
+    this.searchText = "";
+    this.options = [
+      { label: "Today", value: "today" },
+      { label: "Yesterday", value: "yesterday" },
+      { label: "This week", value: "this_week" },
+      { label: "This month", value: "this_month" },
+      { label: "Last 30 days", value: "last_30_days" },
+      { label: translatePhrase("Customize"), value: "custom" },
+      { label: "Clear", value: "clear" },
+    ];
+
+    this.eGui = null;
+    this.listEl = null;
+    this.searchContainer = null;
+    this.filteredOptions = [...this.options];
+
+    this._Vue = getVueRuntime();
+    this.fromApp = null;
+    this.toApp = null;
+  }
+
+  _unmountPickers() {
+    try { this.fromApp?.unmount?.(); } catch {}
+    try { this.toApp?.unmount?.(); } catch {}
+    this.fromApp = null;
+    this.toApp = null;
+  }
+  _closeAndNotify() {
+    this._setSearchVisibility(true);
+    this.params?.filterChangedCallback?.();
+    this.closePopup();
+  }
+
+  init(params) {
+    this.params = params;
+
+    this.eGui = document.createElement("div");
+    this.eGui.className = "list-filter deadline-filter";
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" placeholder="${translatePhrase("Search...")}" class="search-input" />
+        <span class="search-icon" aria-hidden="true">
+          <i class="material-symbols-outlined-search">search</i>
+        </span>
+      </div>
+      <div class="filter-list"></div>
+    `;
+
+    const searchInput = this.eGui.querySelector(".search-input");
+    this.searchContainer = this.eGui.querySelector(".field-search");
+    this.listEl = this.eGui.querySelector(".filter-list");
+
+    searchInput.addEventListener("input", (e) => {
+      this.searchText = (e.target.value || "").toLowerCase();
+      this.filteredOptions = this.options.filter((o) =>
+        o.label.toLowerCase().includes(this.searchText)
+      );
+      this.render();
+    });
+
+    this.render();
+  }
+
+  getGui() { return this.eGui; }
+  afterGuiAttached(params) { this.hidePopup = params?.hidePopup; }
+  destroy() { this._unmountPickers(); }
+  closePopup() {
+    if (typeof this.hidePopup === "function") this.hidePopup();
+    else if (this.params?.api?.hidePopupMenu) this.params.api.hidePopupMenu();
+  }
+
+  _setSearchVisibility(show) {
+    if (!this.searchContainer) return;
+    this.searchContainer.style.display = show ? "" : "none";
+  }
+
+  render() {
+    this._setSearchVisibility(true);
+    this._unmountPickers();
+
+    this.listEl.innerHTML = this.filteredOptions
+      .map((opt) => {
+        const isCustom = opt.value === "custom";
+        const isClear = opt.value === "clear";
+        const classes = ["filter-item"];
+
+        if (isCustom) classes.push("custom");
+        if (isClear) classes.push("clear");
+        if (this.selected === opt.value && !isCustom && !isClear) {
+          classes.push("selected");
+        }
+
+        const arrow = isCustom ? '<span class="arrow-icon">›</span>' : "";
+
+        return `<div class="${classes.join(" ")}" data-value="${opt.value}">
+          <span class="filter-label">${opt.label}</span>
+          ${arrow}
+        </div>`;
+      })
+      .join("");
+
+    this.listEl.querySelectorAll(".filter-item").forEach((el) => {
+      el.addEventListener("click", (e) => {
+        e.stopPropagation();
+        const value = el.getAttribute("data-value");
+
+        if (value === "custom") {
+          this.selected = value;
+          this.showCustomInputs();
+          return;
+        }
+
+        if (value === "clear") {
+          this.selected = null;
+          this.customFrom = "";
+          this.customTo = "";
+          this.customMode = "equals";
+          this._closeAndNotify();
+          return;
+        }
+
+        this.selected = value;
+        this._closeAndNotify();
+      });
+    });
+  }
+
+  showCustomInputs() {
+    this._setSearchVisibility(false);
+    this._unmountPickers();
+
+    this.listEl.innerHTML = `
+      <div class="custom-header">
+        <button class="back-btn" type="button" aria-label="Back">‹</button>
+        <span class="custom-title">${translatePhrase("Customize")}</span>
+      </div>
+
+      <label class="custom-row">
+        <span class="custom-label">${translatePhrase("Mode")}</span>
+        <select class="custom-select">
+          <option value="equals">${translatePhrase("Equals")}</option>
+          <option value="before">${translatePhrase("Before")}</option>
+          <option value="after">${translatePhrase("After")}</option>
+          <option value="between">${translatePhrase("Between")}</option>
+        </select>
+      </label>
+
+      <div class="custom-range"></div>
+
+      <div class="custom-actions">
+        <button type="button" class="apply-btn" disabled>${translatePhrase("Apply")}</button>
+        <button type="button" class="cancel-btn">${translatePhrase("Cancel")}</button>
+      </div>
+    `;
+
+    const backBtn = this.listEl.querySelector(".back-btn");
+    const select = this.listEl.querySelector(".custom-select");
+    const rangeHost = this.listEl.querySelector(".custom-range");
+    const applyBtn = this.listEl.querySelector(".apply-btn");
+    const cancelBtn = this.listEl.querySelector(".cancel-btn");
+
+    backBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.render();
+    });
+    select.value = this.customMode;
+    select.addEventListener("change", (e) => {
+      e.stopPropagation();
+      this.customMode = e.target.value;
+      this._renderRangePickers(rangeHost, applyBtn);
+    });
+    cancelBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.render();
+    });
+
+    this._renderRangePickers(rangeHost, applyBtn);
+  }
+
+  _renderRangePickers(rangeHost, applyBtn) {
+    this._unmountPickers();
+    rangeHost.innerHTML = "";
+
+    const needFrom =
+      this.customMode === "equals" ||
+      this.customMode === "after" ||
+      this.customMode === "between";
+    const needTo =
+      this.customMode === "before" || this.customMode === "between";
+
+    const makePickerRow = (labelText, mountClass) => {
+      const wrap = document.createElement("div");
+      wrap.className = "picker-row";
+
+      const labelEl = document.createElement("div");
+      labelEl.className = "picker-label";
+      labelEl.textContent = labelText;
+      labelEl.style.fontFamily = getResolvedFontFamily();
+      labelEl.style.fontSize = "13px";
+      labelEl.style.fontWeight = "500";
+      labelEl.style.lineHeight = "1.2";
+      labelEl.style.display = "block";
+      labelEl.style.marginBottom = "4px";
+
+      const mountEl = document.createElement("div");
+      mountEl.className = `picker-mount ${mountClass}`;
+
+      wrap.appendChild(labelEl);
+      wrap.appendChild(mountEl);
+      rangeHost.appendChild(wrap);
+
+      return mountEl;
+    };
+
+    let fromMount = null;
+    if (needFrom) {
+      fromMount = makePickerRow("From", "from-mount");
+    } else {
+      this.customFrom = "";
+    }
+
+    let toMount = null;
+    if (needTo) {
+      toMount = makePickerRow("To", "to-mount");
+    } else {
+      this.customTo = "";
+    }
+
+    const mountPicker = (mountEl, initial, onChange) => {
+      const runtime = this._Vue || getVueRuntime();
+      if (runtime && runtime !== this._Vue) {
+        this._Vue = runtime;
+      }
+
+      if (!runtime || !CustomDatePicker) {
+        const fallbackFont = getResolvedFontFamily();
+        mountEl.innerHTML =
+          `<div class="dp-fallback" title="${translatePhrase("Vue unavailable")}" style="font: 13px/1 ${fallbackFont};">${translatePhrase("Select date")}</div>`;
+        return { unmount: () => {} };
+      }
+      const { createApp, h } = runtime;
+      const app = createApp({
+        data: () => ({ val: initial || "" }),
+        render() {
+          return h(CustomDatePicker, {
+            modelValue: this.val,
+            "onUpdate:modelValue": (v) => {
+              const only = (v || "").split("T")[0] || "";
+              if (only !== this.val) {
+                this.val = only;
+                onChange(only);
+              }
+            },
+            showTime: false,
+          });
+        },
+      });
+      return app.mount(mountEl);
+    };
+
+    if (needFrom && fromMount) {
+      const initFrom = this.customFrom || "";
+      this.fromApp = mountPicker(fromMount, initFrom, (v) => {
+        if (v !== this.customFrom) {
+          this.customFrom = v;
+          this._refreshApplyState(applyBtn);
+        }
+      });
+    }
+
+    if (needTo && toMount) {
+      const initTo = this.customTo || "";
+      this.toApp = mountPicker(toMount, initTo, (v) => {
+        if (v !== this.customTo) {
+          this.customTo = v;
+          this._refreshApplyState(applyBtn);
+        }
+      });
+    }
+
+    applyBtn.onclick = (e) => {
+      e.stopPropagation();
+      if (applyBtn.disabled) return;
+      if (this.customMode === "equals") this.customTo = this.customFrom;
+      if (this.customMode === "before") this.customFrom = "";
+      if (this.customMode === "after") this.customTo = "";
+      this.selected = "custom";
+      this._closeAndNotify();
+    };
+
+    this._refreshApplyState(applyBtn);
+  }
+
+  _refreshApplyState(applyBtn) {
+    const valid = (() => {
+      switch (this.customMode) {
+        case "equals":
+          return !!this.customFrom;
+        case "before":
+          return !!this.customTo;
+        case "after":
+          return !!this.customFrom;
+        case "between":
+          return !!this.customFrom || !!this.customTo;
+        default:
+          return false;
+      }
+    })();
+    applyBtn.disabled = !valid;
+  }
+
+  // Presets em horário local
+  _startOfDay(d) {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+  }
+  _endOfDay(d) {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate(), 23, 59, 59, 999);
+  }
+
+  // Custom em UTC
+  _ymdToUTC(ymd) {
+    if (!ymd) return null;
+    const [y, m, d] = ymd.split("-").map(Number);
+    if (!y || !m || !d) return null;
+    return new Date(Date.UTC(y, m - 1, d));
+  }
+  _startOfDayUTC(dUTC) {
+    return new Date(
+      Date.UTC(
+        dUTC.getUTCFullYear(),
+        dUTC.getUTCMonth(),
+        dUTC.getUTCDate(),
+        0,
+        0,
+        0,
+        0
+      )
+    );
+  }
+  _endOfDayUTC(dUTC) {
+    return new Date(
+      Date.UTC(
+        dUTC.getUTCFullYear(),
+        dUTC.getUTCMonth(),
+        dUTC.getUTCDate(),
+        23,
+        59,
+        59,
+        999
+      )
+    );
+  }
+
+  _parseDateValue(raw) {
+    if (raw instanceof Date) {
+      return isNaN(raw.getTime()) ? null : new Date(raw.getTime());
+    }
+    if (typeof raw === "number") {
+      const fromNumber = new Date(raw);
+      return isNaN(fromNumber.getTime()) ? null : fromNumber;
+    }
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (!trimmed) return null;
+      let candidate = trimmed;
+      if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?$/.test(trimmed) && !/[\+\-]\d{2}$/.test(trimmed)) {
+        candidate = trimmed.replace(" ", "T");
+      } else if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[\+\-]\d{2}$/.test(trimmed)) {
+        candidate = trimmed.replace(" ", "T").replace(/([\+\-]\d{2})$/, "$1:00");
+      }
+      const fromString = new Date(candidate);
+      return isNaN(fromString.getTime()) ? null : fromString;
+    }
+    return null;
+  }
+
+  getSelectedRange() {
+    const now =
+      window.gridDeadlineNow instanceof Date
+        ? new Date(window.gridDeadlineNow)
+        : new Date();
+    const todayStart = this._startOfDay(now);
+
+    switch (this.selected) {
+      case "today":
+        return { from: todayStart, to: this._endOfDay(todayStart) };
+      case "yesterday": {
+        const y = new Date(todayStart);
+        y.setDate(y.getDate() - 1);
+        return { from: y, to: this._endOfDay(y) };
+      }
+      case "this_week": {
+        const day = todayStart.getDay(),
+          diff = day === 0 ? -6 : 1 - day;
+        const start = new Date(todayStart);
+        start.setDate(start.getDate() + diff);
+        const end = new Date(start);
+        end.setDate(start.getDate() + 6);
+        return { from: start, to: this._endOfDay(end) };
+      }
+      case "this_month": {
+        const start = new Date(now.getFullYear(), now.getMonth(), 1);
+        const end = new Date(now.getFullYear(), now.getMonth() + 1, 0);
+        return { from: start, to: this._endOfDay(end) };
+      }
+      case "last_30_days": {
+        const start = new Date(todayStart);
+        start.setDate(start.getDate() - 29);
+        return { from: start, to: this._endOfDay(todayStart) };
+      }
+      case "custom": {
+        let fromUTC = this.customFrom
+          ? this._startOfDayUTC(this._ymdToUTC(this.customFrom))
+          : null;
+        let toUTC = this.customTo
+          ? this._endOfDayUTC(this._ymdToUTC(this.customTo))
+          : null;
+
+        switch (this.customMode) {
+          case "equals":
+            if (!fromUTC) return null;
+            toUTC = this._endOfDayUTC(this._ymdToUTC(this.customFrom));
+            break;
+          case "before":
+            if (!toUTC) return null;
+            fromUTC = null;
+            break;
+          case "after":
+            if (!fromUTC) return null;
+            toUTC = null;
+            break;
+          case "between":
+            if (!fromUTC && !toUTC) return null;
+            break;
+        }
+        return { from: fromUTC, to: toUTC };
+      }
+      default:
+        return null;
+    }
+  }
+
+  doesFilterPass(params) {
+    const field = this.params?.colDef?.field;
+    const rawValue = params?.data ? params.data[field] : undefined;
+    const dateValue = this._parseDateValue(rawValue);
+    if (!dateValue) return false;
+    const range = this.getSelectedRange();
+    if (!range) return true;
+    const { from, to } = range;
+    if (from && dateValue < from) return false;
+    if (to && dateValue > to) return false;
+    return true;
+  }
+
+  isFilterActive() {
+    return !!this.getSelectedRange();
+  }
+
+  getModel() {
+    const range = this.getSelectedRange();
+    if (!range) return null;
+    const { from, to } = range;
+    return {
+      option: this.selected,
+      from: from ? from.toISOString() : null,
+      to: to ? to.toISOString() : null,
+      mode: this.customMode,
+    };
+  }
+
+  setModel(model) {
+    if (!model) {
+      this.selected = null;
+      this.customFrom = "";
+      this.customTo = "";
+      this.customMode = "equals";
+      this.render();
+      return;
+    }
+    this.selected = model.option || null;
+    this.customFrom = model.from ? model.from.slice(0, 10) : "";
+    this.customTo = model.to ? model.to.slice(0, 10) : "";
+    this.customMode = model.mode || "equals";
+    if (this.selected === "custom") this.showCustomInputs();
+    else this.render();
+  }
+}

--- a/Project/TicketGrid/src/components/FixedListCellEditor.js
+++ b/Project/TicketGrid/src/components/FixedListCellEditor.js
@@ -1,0 +1,388 @@
+import { translatePhrase } from "../translation";
+
+export default class FixedListCellEditor {
+  init(params) {
+    this.params = params;
+    const colDef = params.colDef || {};
+    this.rendererParams =
+      typeof colDef.cellRendererParams === 'function'
+        ? colDef.cellRendererParams(params)
+        : colDef.cellRendererParams || {};
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'list-editor';
+    this.eGui.innerHTML = `
+      <span class="editor-close">&times;</span>
+      <div class="field-search">
+        <input type="text" class="search-input" placeholder="${translatePhrase("Search...")}" />
+        <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
+      </div>
+      <div class="filter-list"></div>
+    `;
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.listEl = this.eGui.querySelector('.filter-list');
+    this.closeBtn = this.eGui.querySelector('.editor-close');
+
+    // log API calls triggered while loading list options
+    this.restoreApiLogger = this.setupApiLogger();
+
+
+    const tag =
+      (params.colDef.TagControl ||
+        params.colDef.tagControl ||
+        params.colDef.tagcontrol ||
+        '').toUpperCase();
+    const identifier = (params.colDef.FieldDB || '').toUpperCase();
+    this.isResponsibleUser =
+      tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+    this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+
+
+    // Fixed list options (supports promises)
+    const normalize = opt =>
+      typeof opt === 'object' ? opt : { value: opt, label: String(opt) };
+
+    const resolveOptions = arr => {
+      
+
+      this.options = (arr || []).map(normalize);
+      this.filteredOptions = [...this.options];
+      this.renderOptions();
+    };
+
+    this.getColumnFieldKey = () => {
+      if (!this.params) return null;
+      const col = this.params.column;
+      if (col && typeof col.getColId === 'function') {
+        const id = col.getColId();
+        if (id) return id;
+      }
+      return this.params.colDef?.field || this.params.colDef?.colId || null;
+    };
+
+    this.extractOptionLabel = value => {
+      if (!this.options || !this.options.length) return undefined;
+      const match = this.options.find(opt => String(opt.value) === String(value));
+      if (!match) return undefined;
+      const label =
+        match.label ??
+        match.name ??
+        match.text ??
+        match.descricao ??
+        match.description ??
+        match.Valor ??
+        match.value;
+      return label != null ? label : undefined;
+    };
+
+    this.updateDisplayLabel = (value, { refresh = true } = {}) => {
+      const fieldKey = this.getColumnFieldKey();
+      const rowData = this.params?.node?.data;
+      if (!fieldKey || !rowData) return;
+      const labelField = `${fieldKey}__displayLabel`;
+      const label = this.extractOptionLabel(value);
+      if (label != null) {
+        rowData[labelField] = String(label);
+      } else if (value != null && value !== '') {
+        rowData[labelField] = String(value);
+      } else {
+        delete rowData[labelField];
+      }
+      if (refresh && this.params.api && this.params.node) {
+        this.params.api.refreshCells({
+          rowNodes: [this.params.node],
+          columns: [fieldKey],
+          force: true,
+        });
+      }
+    };
+
+    let optionsPromise;
+    if (typeof params.options === 'function') {
+     
+      try {
+        const result = params.options(params);
+        
+        optionsPromise =
+          result && typeof result.then === 'function'
+            ? result
+            : Promise.resolve(result);
+      } catch (err) {
+        
+        optionsPromise = Promise.resolve([]);
+      }
+    } else if (params.options && typeof params.options.then === 'function') {
+
+      
+      optionsPromise = params.options;
+    } else if (Array.isArray(params.options)) {
+      
+      optionsPromise = Promise.resolve(params.options);
+    } else if (typeof params.colDef.options === 'function') {
+     
+      try {
+        const result = params.colDef.options(params);
+        
+        optionsPromise =
+          result && typeof result.then === 'function'
+            ? result
+            : Promise.resolve(result);
+      } catch (err) {
+        
+        optionsPromise = Promise.resolve([]);
+      }
+
+    } else if (Array.isArray(params.colDef.options)) {
+      
+      optionsPromise = Promise.resolve(params.colDef.options);
+    } else if (Array.isArray(params.colDef.listOptions)) {
+      
+      optionsPromise = Promise.resolve(params.colDef.listOptions);
+    } else if (
+      typeof params.colDef.listOptions === 'function'
+    ) {
+     
+      try {
+        const result = params.colDef.listOptions(params);
+        
+        optionsPromise =
+          result && typeof result.then === 'function'
+            ? result
+            : Promise.resolve(result);
+      } catch (err) {
+        
+        optionsPromise = Promise.resolve([]);
+      }
+
+    } else if (
+      typeof params.colDef.listOptions === 'string' &&
+      params.colDef.listOptions.trim() !== ''
+    ) {
+      
+
+      optionsPromise = Promise.resolve(
+        params.colDef.listOptions.split(',').map(o => o.trim())
+      );
+    } else if (
+      params.colDef.dataSource &&
+      typeof params.colDef.dataSource.list_options === 'string' &&
+      params.colDef.dataSource.list_options.trim() !== ''
+    ) {
+
+      optionsPromise = Promise.resolve(
+        params.colDef.dataSource.list_options
+          .split(',')
+          .map(o => o.trim())
+      );
+    } else {
+      optionsPromise = Promise.resolve([]);
+    }
+
+    optionsPromise
+      .then(res => {
+        resolveOptions(res);
+      })
+      .catch(err => {
+        resolveOptions([]);
+      });
+
+
+    this.value = params.value;
+
+    this.searchInput.addEventListener('input', e => {
+      this.filterOptions(e.target.value);
+    });
+
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener('click', () => {
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing(true);
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing(true);
+        }
+      });
+    }
+  }
+
+  setupApiLogger() {
+    const origFetch = window.fetch;
+    const origAxiosReq = window.axios && window.axios.request;
+    const XHR = window.XMLHttpRequest;
+    const origXHROpen = XHR && XHR.prototype.open;
+    const origXHRSend = XHR && XHR.prototype.send;
+    if (origFetch) {
+      window.fetch = (input, init = {}) => {
+     
+        return origFetch(input, init);
+      };
+    }
+    if (origAxiosReq) {
+      window.axios.request = function (config) {
+        
+        return origAxiosReq.apply(this, arguments);
+      };
+    }
+    if (origXHROpen && origXHRSend) {
+      XHR.prototype.open = function (method, url) {
+        this.__flcMethod = method;
+        this.__flcUrl = url;
+        return origXHROpen.apply(this, arguments);
+      };
+      XHR.prototype.send = function (body) {
+        
+        return origXHRSend.call(this, body);
+      };
+    }
+    return () => {
+      if (origFetch) window.fetch = origFetch;
+      if (origAxiosReq) window.axios.request = origAxiosReq;
+       if (origXHROpen) XHR.prototype.open = origXHROpen;
+       if (origXHRSend) XHR.prototype.send = origXHRSend;
+    };
+
+  }
+
+  filterOptions(text) {
+    const t = text.toLowerCase();
+    this.filteredOptions = this.options.filter(opt => {
+      const label = this.stripHtml(String(this.formatOption(opt)));
+      return label.toLowerCase().includes(t);
+    });
+    this.renderOptions();
+  }
+
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' || fieldName === 'CategoryLevel3ID' || fieldName === 'CategoryID' || fieldName === 'SubCategoryID' ? '4px' : '12px';
+    const fontweight = fieldName === 'ImpactID' ? "" : 'font-weight:bold;';
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+      const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(
+        new Date(dateValue)
+      );
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(
+        new Date(dateValue)
+      );
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  formatOption(opt) {
+    const value = opt.label != null ? opt.label : opt.value;
+    if (this.isCategoryField) {
+      return `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+    }
+    const colDef = this.params.colDef || {};
+    const params = this.rendererParams || {};
+    try {
+      if (params.useCustomFormatter && typeof params.formatter === 'string') {
+        const fn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          params.formatter
+        );
+        return fn(
+          value,
+          {},
+          colDef,
+          this.getRoundedSpanColor.bind(this),
+          this.dateFormatter.bind(this)
+        );
+      } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+        const styled = this.getRoundedSpanColor(
+          value,
+          params.styleArray,
+          colDef.FieldDB
+        );
+        if (styled) return styled;
+      }
+    } catch (e) {
+      
+    }
+    return value;
+  }
+
+  renderOptions() {
+    this.listEl.innerHTML = this.filteredOptions
+      .map(opt => {
+        const formatted = this.formatOption(opt);
+        const selected = opt.value == this.value ? ' selected' : '';
+        if (this.isResponsibleUser) {
+          const photo = opt.photo || opt.image || opt.img || '';
+          const name = this.stripHtml(String(formatted));
+          const initial = name ? name.trim().charAt(0).toUpperCase() : '';
+          const avatar = photo
+            ? `<img src="${photo}" alt="" />`
+            : `<span class="user-initial">${initial}</span>`;
+          return `
+            <div class="filter-item${selected}" data-value="${opt.value}">
+              <span class="user-option">
+                <span class="avatar-outer"><span class="avatar-middle"><span class="user-avatar">${avatar}</span></span></span>
+                <span class="filter-label">${formatted}</span>
+              </span>
+            </div>`;
+        }
+
+        return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+      })
+      .join('');
+    this.listEl.querySelectorAll('.filter-item').forEach(el => {
+      el.addEventListener('click', () => {
+        const selectedValue = el.getAttribute('data-value');
+        this.value = selectedValue;
+        this.updateDisplayLabel(selectedValue, { refresh: false });
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing();
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing();
+        }
+      });
+    });
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  afterGuiAttached() {
+    if (this.searchInput) this.searchInput.focus();
+  }
+
+  getValue() {
+    this.updateDisplayLabel(this.value);
+    return this.value;
+  }
+
+  destroy() {
+    if (this.restoreApiLogger) {
+      try {
+        this.restoreApiLogger();
+      } finally {
+        this.restoreApiLogger = null;
+      }
+    }
+  }
+
+  isPopup() {
+    return true;
+  }
+}

--- a/Project/TicketGrid/src/components/FormatterCellRenderer.vue
+++ b/Project/TicketGrid/src/components/FormatterCellRenderer.vue
@@ -1,0 +1,344 @@
+<template>
+  <div
+    class="formatter-cell"
+    v-if="params.useCustomFormatter"
+    v-html="formattedValue"
+    :style="[cellStyle, pointerStyle]"
+  ></div>
+  <div class="formatter-cell" v-else :style="[cellStyle, pointerStyle]">
+    {{ formattedValue }}
+  </div>
+</template>
+ 
+<script>
+import { ref, onMounted, onUnmounted, computed } from 'vue';
+import { readTypographyVariable, DEFAULT_FONT_FAMILY } from '../utils/fontFamily.js';
+import { translatePhrase } from '../translation';
+  // Função global original
+function getRoundedSpanColor(value, colorArray, fieldName, isBold) {
+
+  if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+  const matchingStyle = colorArray.find(item => item.Valor === value);
+  if (!matchingStyle) return value;
+  // O border-radius será definido dinamicamente no formatter
+  const borderRadius = fieldName === 'StatusID' || fieldName === 'CategoryLevel3ID' || fieldName === 'CategoryID' || fieldName === 'SubCategoryID' ? '4px' : '12px';
+  const fontweight = fieldName === 'ImpactID' ? "" : 'font-weight:bold;';
+  return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+}
+
+function dateFormatter(dateValue, lang) {
+  try {
+    if (!dateValue) return '';
+
+    let dateStr = dateValue;
+
+    // Verifica se há hora na string (padrão ISO ou outro)
+    const hasTime = /[T\s]\d{2}:\d{2}/.test(dateValue);
+
+    // Se não tem hora, assume meia-noite UTC para evitar erro de fuso
+    if (!hasTime) {
+      dateStr += 'T00:00:00Z';
+    }
+
+    const date = new Date(dateStr);
+    const dateOptions = {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+      timeZone: 'UTC'
+    };
+
+    return new Intl.DateTimeFormat(lang || 'en', dateOptions).format(date);
+  } catch (error) {
+    return dateValue;
+  }
+}
+
+function dateTimeFormater(dateValue, lang)
+{
+  if(dateValue == null || dateValue == "")
+  return "";
+const isAmerican = window.wwLib?.wwVariable?.getValue('21a41590-e7d8-46a5-af76-bb3542da1df3').toUpperCase() == "AMERICAN";
+
+const dateOptions = {
+  timeZone: window.wwLib?.wwVariable?.getValue('7509df4b-d0bc-40c3-a542-bfe0e22f5ec6'),      
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    };
+const timeOptions = {
+      timeZone: window.wwLib?.wwVariable?.getValue('7509df4b-d0bc-40c3-a542-bfe0e22f5ec6'),
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: isAmerican
+    };
+    var newDate = new Date(dateValue);
+lang = isAmerican ? "en-us" : "en-gb";
+
+    const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(new Date(newDate));
+    const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(new Date(newDate.setMinutes(newDate.getMinutes() + window.wwLib?.wwVariable?.getValue('5d9d5372-4189-4152-bb1d-da6800cd0b65'))));
+
+ 
+    return `${datePart} ${timePart}`;
+
+}
+
+function resolveGridFontFamily() {
+  try {
+    if (typeof window !== 'undefined' && window.getComputedStyle) {
+      const value = window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue('--grid-view-dinamica-font-family');
+      if (value && value.trim().length > 0) {
+        return value.trim();
+      }
+    }
+  } catch (error) {
+    
+  }
+
+  const typographyFont = readTypographyVariable();
+  return typographyFont || DEFAULT_FONT_FAMILY;
+}
+
+export default {
+  name: "FormatterCellRenderer",
+  props: {
+    params: {
+      type: Object,
+      required: true,
+    },
+  },
+  setup(props) {
+    // Timer reativo para atualizar a cada segundo
+    const now = ref(new Date());
+    let timer = null;
+    onMounted(() => {
+      timer = setInterval(() => {
+        now.value = new Date();
+      }, 1000); // Atualiza a cada segundo
+    });
+    onUnmounted(() => {
+      if (timer) clearInterval(timer);
+    });
+    return { now };
+  },
+  computed: {
+    formattedValue() {
+      try {
+        const rawValue = this.params.value;
+        const fontFamily = resolveGridFontFamily();
+        let displayValue = rawValue;
+
+        const fieldKey = this.params.colDef?.colId || this.params.colDef?.field;
+        if (fieldKey && this.params.data) {
+          const storedLabel = this.params.data[`${fieldKey}__displayLabel`];
+          if (storedLabel !== undefined && storedLabel !== null) {
+            displayValue = storedLabel;
+          }
+        }
+
+if (
+  this.params.colDef?.TagControl === 'DATETIME' ||
+  this.params.colDef?.tagControl === 'DATETIME' ||
+  this.params.colDef?.cellDataType === 'dateTime'
+)
+  return dateTimeFormater(rawValue, "");
+
+        if (Array.isArray(this.params.options)) {
+          const match = this.params.options.find(
+            opt => String(opt.value) === String(rawValue)
+          );
+          if (match) displayValue = match.label;
+        }
+
+        const colorCategory = window.wwLib?.wwVariable?.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726').categoryColor;
+
+        const tag = (this.params.colDef?.TagControl || this.params.colDef?.tagControl || this.params.colDef?.tagcontrol || '').toString().toUpperCase();
+        const identifier = (this.params.colDef?.FieldDB || '').toString().toUpperCase();
+        const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+        if (categoryTags.includes(tag) || categoryTags.includes(identifier)) {
+          const hasValue = displayValue != null && String(displayValue).trim() !== '';
+          const background = hasValue ? colorCategory : '#ffffff';
+          const borderColor = hasValue ? colorCategory : '#bdbdbd';
+          const textColor = hasValue ? '#303030' : '#9e9e9e';
+          const content = hasValue ? displayValue : '';
+          return `<span style="height:25px; color:${textColor}; background:${background}; border:1px solid ${borderColor}; border-radius:5px; font-weight:normal; font-family:${fontFamily}; display:inline-flex; align-items:center; justify-content:center; padding:0 12px;">${content}</span>`;
+        }
+        // DEADLINE: barra proporcional
+        if (this.params.colDef?.TagControl === 'DEADLINE' || this.params.colDef?.tagControl === 'DEADLINE') {
+          const value = this.params.value;
+          const isClosedRaw = this.params.data?.IsClosed;
+          const isClosed =
+            typeof isClosedRaw === 'string'
+              ? isClosedRaw.toLowerCase() === 'true'
+              : Boolean(isClosedRaw);
+
+          if (isClosed && value) {
+            const formattedDate = dateTimeFormater(value, '') || value;
+            return `
+              <span style="display:inline-flex;align-items:center;justify-content:center;gap:6px;height:26px;min-width:100px;padding:0 12px;border:1px solid #424242;border-radius:12px;background:#424242;color:#ffffff;font-size:12px;font-weight:500;font-family:${fontFamily};text-transform:none;box-sizing:border-box;">
+                ${formattedDate}
+              </span>
+            `;
+          }
+          if (!value) {
+            return `<span style="display:inline-flex;align-items:center;justify-content:center;gap:6px;height:26px;min-width:100px;padding:0 12px;border:1px solid #bdbdbd;border-radius:12px;background:#ffffff;color:#9e9e9e;font-size:12px;font-weight:500;font-family:${fontFamily};text-transform:none;box-sizing:border-box;">
+              <span class="material-symbols-outlined" style="font-size:16px;line-height:1;font-variation-settings:'OPSZ' 24;">calendar_today</span>
+              ${translatePhrase("Select")}
+            </span>`;
+          }
+          // Parse data DEADLINE
+          let dateStr = value;
+          if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value)) {
+            dateStr = value;
+          } else if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\+\d{2}/.test(value)) {
+            dateStr = value.replace(' ', 'T').replace(/([\+\-]\d{2})$/, '$1:00');
+          }
+          const deadline = new Date(dateStr);
+          if (isNaN(deadline.getTime())) return value;
+          // Use o now reativo
+          const now = this.now instanceof Date ? this.now : (this.now?.value || new Date());
+          const diffMs = deadline - now;
+          const diffDays = diffMs / (24 * 60 * 60 * 1000);
+          // Faixas
+          // limites para a barra de cores
+          const yellowThreshold = 5; // dias para trocar de azul para amarelo
+          const blueRange = 30; // intervalo em dias para preencher o azul
+          const blueLimit = yellowThreshold + blueRange; // 35 dias
+          let percent = 0;
+          let cor = '#e6ffed';
+          let border = '#1b5e20';
+          let textColor = '#1b5e20';
+          let label = '';
+          // Label amigável
+          const abs = Math.abs(diffMs);
+          const isPast = diffMs < 0;
+          if (abs < 60 * 1000) {
+            const s = Math.floor(abs / 1000);
+            label = `${isPast ? '-' : ''}${s}s`;
+          } else if (abs < 60 * 60 * 1000) {
+            const m = Math.floor(abs / (60 * 1000));
+            label = `${isPast ? '-' : ''}${m}m`;
+          } else if (abs < 24 * 60 * 60 * 1000) {
+            const h = Math.floor(abs / (60 * 60 * 1000));
+            const m = Math.floor((abs % (60 * 60 * 1000)) / (60 * 1000));
+            label = `${isPast ? '-' : ''}${h}h`;
+            if (m > 0) label += ` ${m}m`;
+          } else {
+            const d = Math.floor(abs / (24 * 60 * 60 * 1000));
+            const h = Math.floor((abs % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+            label = `${isPast ? '-' : ''}${d}d`;
+            if (h > 0) label += ` ${h}h`;
+          }
+          // Lógica de cor e preenchimento
+          const safeDiffDays = Number(diffDays);
+          let debugLabel = label;
+          if (safeDiffDays > yellowThreshold) {
+            const capped = Math.min(blueLimit, Math.max(yellowThreshold, safeDiffDays));
+            percent = ((capped - yellowThreshold) / blueRange) * 100;
+            percent = Math.max(0, Math.min(100, percent));
+            cor = '#d0e3ff';
+            border = '#1976d2';
+            textColor = '#1976d2';
+            debugLabel += ' (azul)';
+          } else if (safeDiffDays > 0) {
+            percent = (safeDiffDays / yellowThreshold) * 100;
+            percent = Math.max(0, Math.min(100, percent));
+            cor = '#ffe066';
+            border = '#b59f00';
+            textColor = '#b59f00';
+            debugLabel += ' (amarelo)';
+          } else {
+            percent = 100;
+            cor = '#ffdddd';
+            border = '#b71c1c';
+            textColor = '#b71c1c';
+            debugLabel += ' (vermelho)';
+          }
+          
+          // Barra HTML
+          return `
+            <div class="deadline-bar-bg" style="width:100%;height:22px;position:relative;background:#f5f5f5;border-radius:8px;overflow:hidden;display:block;">
+              <div class="deadline-bar-fill" style="position:absolute;left:0;top:0;height:100%;width:${percent}%;background:${cor};border-radius:8px;transition:width 0.4s;z-index:1;"></div>
+              <span class="deadline-label" style="position:absolute;left:0;top:0;width:100%;height:100%;display:flex;align-items:center;justify-content:center;font-size:13px;color:${textColor};font-weight:bold;font-family:${fontFamily};z-index:2;">${label}</span>
+              <div style="position:absolute;left:0;top:0;width:100%;height:100%;border:1.5px solid ${border};border-radius:8px;pointer-events:none;z-index:3;"></div>
+            </div>
+          `;
+        }
+        if (!this.params.formatter) {
+          // Check if we should use style array from column config or from the global config
+          const styleArray = this.params.useStyleArray ? 
+            (this.params.styleArray || []) : // Use column-specific style array if available
+            null; // No style array to use
+
+          if (styleArray && Array.isArray(styleArray)) {
+            // Defina o raio de acordo com o FieldDB
+            let borderRadius = '12px';
+            if (this.params.colDef?.FieldDB === 'StatusID' || this.params.colDef?.FieldDB === 'CategoryID' || this.params.colDef?.FieldDB === 'SubCategoryID' || this.params.colDef?.FieldDB === 'CategoryLevel3ID') borderRadius = '5px';
+            // Função inline para aplicar o raio
+            function getRoundedSpanColorWithRadius(matchVal, textVal, colorArray) {
+              if (!colorArray || !Array.isArray(colorArray) || !matchVal) return textVal;
+              const matchingStyle = colorArray.find(item => item.Valor === matchVal);
+              if (!matchingStyle) return textVal;
+              return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; display: inline-flex; align-items: center; padding: 0 12px;">${textVal}</span>`;
+            }
+            const styledValue = getRoundedSpanColorWithRadius(rawValue, displayValue, styleArray);
+            if (styledValue) return styledValue;
+          }
+          return displayValue;
+        }
+
+        // Create a function from the formatter code with getRoundedSpanColor available
+        const formatterFn = new Function(
+          'value', 
+          'row', 
+          'colDef', 
+          'getRoundedSpanColor',
+          'dateFormatter',
+          this.params.formatter
+        );
+
+        // Execute the formatter with the cell value, row data, and helper functions
+        return formatterFn(
+          displayValue,
+          this.params.data,
+          this.params.colDef,
+          getRoundedSpanColor,
+          dateFormatter
+        );
+      } catch (error) {
+        
+        return `Error: ${error.message}`;
+      }
+    },
+    isEditable() {
+      const editable = this.params.colDef?.editable;
+      if (typeof editable === 'function') {
+        try {
+          return !!editable(this.params);
+        } catch (e) {
+          return false;
+        }
+      }
+      return !!editable;
+    },
+    pointerStyle() {
+      return this.isEditable ? { cursor: 'pointer' } : {};
+    },
+    cellStyle() {
+      // Get text alignment from column definition if available
+      const textAlign = this.params.colDef?.cellStyle?.({})?.textAlign;
+      return textAlign ? { textAlign } : {};
+    }
+  }
+};
+</script>
+
+<style scoped>
+  .formatter-cell {
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
+</style>

--- a/Project/TicketGrid/src/components/ImageCellRenderer.vue
+++ b/Project/TicketGrid/src/components/ImageCellRenderer.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="image-cell">
+        <img v-if="params?.value" :src="params.value" :style="{ width: params.width, height: params.height }" />
+    </div>
+</template>
+
+<script>
+export default {
+    name: "ImageCellRenderer",
+    props: {
+        params: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>
+
+<style scoped>
+.image-cell {
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+.image-cell img {
+    object-fit: contain;
+}
+</style>

--- a/Project/TicketGrid/src/components/ListCellEditor.js
+++ b/Project/TicketGrid/src/components/ListCellEditor.js
@@ -1,0 +1,288 @@
+import { translatePhrase } from "../translation";
+
+export default class ListCellEditor {
+  init(params) {
+    this.params = params;
+    const colDef = params.colDef || {};
+    this.rendererParams =
+      typeof colDef.cellRendererParams === 'function'
+        ? colDef.cellRendererParams(params)
+        : colDef.cellRendererParams || {};
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'list-editor';
+    this.eGui.innerHTML = `
+      <span class="editor-close">&times;</span>
+      <div class="field-search">
+        <input type="text" class="search-input" placeholder="${translatePhrase("Search...")}" />
+        <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
+      </div>
+      <div class="filter-list"></div>
+    `;
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.listEl = this.eGui.querySelector('.filter-list');
+    this.closeBtn = this.eGui.querySelector('.editor-close');
+
+    const tag =
+      (params.colDef.TagControl ||
+        params.colDef.tagControl ||
+        params.colDef.tagcontrol ||
+        '').toUpperCase();
+    const identifier = (params.colDef.FieldDB || '').toUpperCase();
+    this.isResponsibleUser =
+      tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+    const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+    this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+
+    // Build option array (supports promises)
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
+        const labelKey = findKey('label') || findKey('name');
+        const valueKey = findKey('value') || findKey('id');
+        return {
+          ...opt,
+          value: valueKey ? opt[valueKey] : opt.value,
+          label: labelKey ? opt[labelKey] : opt.label || opt.name
+        };
+      }
+      return { value: opt, label: String(opt) };
+    };
+
+    const resolveOptions = (arr) => {
+      this.options = (arr || []).map(normalize);
+      this.filteredOptions = [...this.options];
+      this.renderOptions();
+    };
+
+    let optionsPromise;
+    if (params.options && typeof params.options.then === 'function') {
+      optionsPromise = params.options;
+    } else if (Array.isArray(params.options)) {
+      optionsPromise = Promise.resolve(params.options);
+    } else if (Array.isArray(params.colDef.options)) {
+      optionsPromise = Promise.resolve(params.colDef.options);
+    } else if (Array.isArray(params.colDef.listOptions)) {
+      optionsPromise = Promise.resolve(params.colDef.listOptions);
+    } else if (
+      typeof params.colDef.listOptions === 'string' &&
+      params.colDef.listOptions.trim() !== ''
+    ) {
+      optionsPromise = Promise.resolve(
+        params.colDef.listOptions.split(',').map(o => o.trim())
+      );
+    } else if (
+      params.colDef.dataSource &&
+      typeof params.colDef.dataSource.list_options === 'string' &&
+      params.colDef.dataSource.list_options.trim() !== ''
+    ) {
+      optionsPromise = Promise.resolve(
+        params.colDef.dataSource.list_options.split(',').map(o => o.trim())
+      );
+    } else {
+      optionsPromise = Promise.resolve([]);
+    }
+
+    optionsPromise.then(resolveOptions);
+
+    this.value = params.value;
+
+    this.searchInput.addEventListener('input', e => {
+      this.filterOptions(e.target.value);
+    });
+
+    if (this.closeBtn) {
+      this.closeBtn.addEventListener('click', () => {
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing(true);
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing(true);
+        }
+      });
+    }
+  }
+
+  filterOptions(text) {
+    const t = text.toLowerCase();
+    this.filteredOptions = this.options.filter(opt => {
+      const label = this.stripHtml(String(this.formatOption(opt)));
+      return label.toLowerCase().includes(t);
+    });
+    this.renderOptions();
+  }
+
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' || fieldName === 'CategoryLevel3ID' || fieldName === 'CategoryID' || fieldName === 'SubCategoryID' ? '4px' : '12px';
+    const fontweight = fieldName === 'ImpactID' ? "" : 'font-weight:bold;';
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+      const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(
+        new Date(dateValue)
+      );
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(
+        new Date(dateValue)
+      );
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  formatOption(opt) {
+    const value = opt.label != null ? opt.label : opt.value;
+    if (this.isCategoryField) {
+      const colorCategory = window.wwLib?.wwVariable?.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726').categoryColor;
+      return `<span style="height:25px; color:#303030; background:${colorCategory}; border:1px solid ${colorCategory}; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+    }
+    const colDef = this.params.colDef || {};
+    const params = this.rendererParams || {};
+    try {
+      if (params.useCustomFormatter && typeof params.formatter === 'string') {
+        const fn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          params.formatter
+        );
+        return fn(
+          value,
+          {},
+          colDef,
+          this.getRoundedSpanColor.bind(this),
+          this.dateFormatter.bind(this)
+        );
+      } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+        const styled = this.getRoundedSpanColor(
+          value,
+          params.styleArray,
+          colDef.FieldDB
+        );
+        if (styled) return styled;
+      }
+    } catch (e) {
+      
+    }
+    return value;
+  }
+
+  getColumnFieldKey() {
+    if (!this.params) return null;
+    const col = this.params.column;
+    if (col && typeof col.getColId === 'function') {
+      const id = col.getColId();
+      if (id) return id;
+    }
+    return this.params.colDef?.field || this.params.colDef?.colId || null;
+  }
+
+  extractOptionLabel(value) {
+    if (!this.options || !this.options.length) return undefined;
+    const match = this.options.find(opt => String(opt.value) === String(value));
+    if (!match) return undefined;
+    const label =
+      match.label ??
+      match.name ??
+      match.text ??
+      match.descricao ??
+      match.description ??
+      match.Valor ??
+      match.value;
+    return label != null ? label : undefined;
+  }
+
+  updateDisplayLabel(value, { refresh = true } = {}) {
+    const fieldKey = this.getColumnFieldKey();
+    const rowData = this.params?.node?.data;
+    if (!fieldKey || !rowData) return;
+    const labelField = `${fieldKey}__displayLabel`;
+    const label = this.extractOptionLabel(value);
+    if (label != null) {
+      rowData[labelField] = String(label);
+    } else if (value != null && value !== '') {
+      rowData[labelField] = String(value);
+    } else {
+      delete rowData[labelField];
+    }
+    if (refresh && this.params.api && this.params.node) {
+      this.params.api.refreshCells({
+        rowNodes: [this.params.node],
+        columns: [fieldKey],
+        force: true,
+      });
+    }
+  }
+
+  renderOptions() {
+    this.listEl.innerHTML = this.filteredOptions
+      .map(opt => {
+        const formatted = this.formatOption(opt);
+        const selected = opt.value == this.value ? ' selected' : '';
+      
+        if (this.isResponsibleUser) {
+          const photo = opt.photo || opt.image || opt.img || '';
+          const name = this.stripHtml(String(formatted));
+          const initial = name ? name.trim().charAt(0).toUpperCase() : '';
+          const avatar = photo
+            ? `<img src="${photo}" alt="" />`
+            : `<span class="user-initial">${initial}</span>`;
+          return `
+            <div class="filter-item${selected}" data-value="${opt.value}">
+              <span class="user-option">
+                <span class="avatar-outer"><span class="avatar-middle"><span class="user-avatar">${avatar}</span></span></span>
+                <span class="filter-label">${formatted}</span>
+              </span>
+            </div>`;
+        }
+      
+        return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+      })
+      .join('');
+    this.listEl.querySelectorAll('.filter-item').forEach(el => {
+      el.addEventListener('click', () => {
+        const selectedValue = el.getAttribute('data-value');
+        this.value = selectedValue;
+        this.updateDisplayLabel(selectedValue, { refresh: false });
+        if (this.params.api && this.params.api.stopEditing) {
+          this.params.api.stopEditing();
+        } else if (this.params.stopEditing) {
+          this.params.stopEditing();
+        }
+      });
+    });
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  afterGuiAttached() {
+    if (this.searchInput) this.searchInput.focus();
+  }
+
+  getValue() {
+    this.updateDisplayLabel(this.value);
+    return this.value;
+  }
+
+  destroy() {}
+
+  isPopup() {
+    return true;
+  }
+}

--- a/Project/TicketGrid/src/components/ListFilterRenderer.js
+++ b/Project/TicketGrid/src/components/ListFilterRenderer.js
@@ -1,0 +1,975 @@
+import { translatePhrase } from "../translation";
+
+export default class ListFilterRenderer {
+  constructor() {
+    this.searchText = '';
+    this.selectedValues = [];
+    this.allValues = [];
+    this.filteredValues = [];
+    this.selectAll = false;
+    this.formattedValues = [];
+    this.rendererConfig = {};
+    this.statusLookupMap = null;
+    this.isStatusField = false;
+  
+    // Ensure methods keep the correct 'this' even inside async/promises
+    this.loadValues = this.loadValues.bind(this);
+    this.populateFromRows = this.populateFromRows.bind(this);
+    if (typeof this.resolveEditorLikeOptions === 'function') {
+      this.resolveEditorLikeOptions = this.resolveEditorLikeOptions.bind(this);
+    }
+    
+  }
+
+  init(params) {
+    this.params = params;
+    const maybePromise = this.loadValues();
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      maybePromise
+        .then(() => {
+          this.createGui();
+        })
+        .catch(() => {
+          this.createGui();
+        });
+    } else {
+      this.createGui();
+    }
+  }
+
+
+  createGui() {
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'list-filter';
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" placeholder="${translatePhrase("Search...")}" class="search-input" />
+        <span class="search-icon">
+          <i class="material-symbols-outlined-search">search</i>
+        </span>
+      </div>
+      <div class="select-all-row">
+        <label>
+          <input type="checkbox" class="select-all-checkbox" />
+          <span>${translatePhrase("Select all")}</span>
+        </label>
+      </div>
+      <div class="filter-list"></div>
+    `;
+
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.filterList = this.eGui.querySelector('.filter-list');
+    this.selectAllCheckbox = this.eGui.querySelector('.select-all-checkbox');
+
+    this.setupEventListeners();
+    this.renderFilterList();
+  }
+
+  setupEventListeners() {
+    this.searchInput.addEventListener('input', (e) => {
+      this.searchText = e.target.value;
+      this.filterValues();
+    });
+
+    this.selectAllCheckbox.addEventListener('change', (e) => {
+      if (e.target.checked) {
+        this.selectedValues = [...this.filteredValues];
+      } else {
+        this.selectedValues = [];
+      }
+      this.renderFilterList();
+      this.applyFilter();
+    });
+  }
+
+  // Função utilitária para acessar campos aninhados
+  getNestedValue(obj, path) {
+    return path.split('.').reduce((o, p) => (o && o[p] !== undefined ? o[p] : undefined), obj);
+  }
+
+  // Função auxiliar igual ao FormatterCellRenderer
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' || fieldName === 'CategoryLevel3ID' || fieldName === 'CategoryID' || fieldName === 'SubCategoryID' ? '4px' : '12px';
+    const fontweight = fieldName === 'ImpactID' ? "" : 'font-weight:bold;';
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric'
+      };
+      const timeOptions = {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(new Date(dateValue));
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(new Date(dateValue));
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  loadValues() {
+    const api = this.params.api;
+    const column = this.params.column;
+    const colDef = column.getColDef();
+
+    const tag = (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toString().toUpperCase();
+    const identifier = (colDef.FieldDB || '').toString().toUpperCase();
+    this.isStatusField = identifier === 'STATUSID';
+    this.statusLookupMap = this.isStatusField ? new Map() : null;
+    const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+    this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+
+    this.rendererConfig = this.buildRendererConfig(colDef);
+
+    let optionsSource = null;
+
+    if (identifier === 'STATUSID') {
+      optionsSource = this.resolveStatusCollectionOptions(colDef);
+    }
+
+    if (optionsSource == null) {
+      optionsSource = this.resolveFilterOptions();
+    }
+
+    if (optionsSource && typeof optionsSource.then === 'function') {
+      return optionsSource
+        .then(options => {
+          const populated = this.populateFromExplicitOptions(options, colDef);
+          if (!populated) {
+            this.populateFromRows(api, column, colDef);
+          }
+        })
+        .catch(error => {
+          
+          this.populateFromRows(api, column, colDef);
+        });
+    }
+
+    const populated = this.populateFromExplicitOptions(optionsSource, colDef);
+    if (!populated) {
+      this.populateFromRows(api, column, colDef);
+    }
+
+    return null;
+  }
+
+  resolveFilterOptions() {
+    const filterParams = this.params?.filterParams || {};
+    if (typeof filterParams.getFilterOptions === 'function') {
+      try {
+        return filterParams.getFilterOptions(this.params);
+      } catch (error) {
+
+        
+      }
+    }
+    if (Array.isArray(filterParams.options)) {
+      return filterParams.options;
+    }
+    return null;
+  }
+
+  buildRendererConfig(colDef) {
+    const rendererParams = this.getRendererParams(colDef);
+
+    const derivedConfig = {};
+    if (rendererParams.useCustomFormatter && typeof rendererParams.formatter === 'string') {
+      derivedConfig.useCustomFormatter = true;
+      derivedConfig.formatter = rendererParams.formatter;
+    }
+    if (rendererParams.useStyleArray && Array.isArray(rendererParams.styleArray)) {
+      derivedConfig.useStyleArray = true;
+      derivedConfig.styleArray = rendererParams.styleArray;
+    }
+
+    const filterConfig = this.params.filterParams?.rendererConfig || {};
+
+    return {
+      ...derivedConfig,
+      ...filterConfig,
+    };
+  }
+
+  getRendererParams(colDef) {
+    try {
+      if (typeof colDef.cellRendererParams === 'function') {
+        return colDef.cellRendererParams({ data: {}, value: undefined, colDef }) || {};
+      }
+      return colDef.cellRendererParams || {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  resolveStatusCollectionOptions(colDef) {
+    const COLLECTION_ID = '95233031-3746-48c8-8c3c-8722b0075d61';
+
+    try {
+      const collection = window?.wwLib?.wwCollection?.getCollection?.(COLLECTION_ID);
+      const data = collection?.data;
+
+      if (!Array.isArray(data)) {
+        return null;
+      }
+
+      const sampleValue = this.findSampleValue(colDef);
+      const normalizeValueType = (value) => {
+        if (sampleValue === undefined || sampleValue === null) return value;
+
+        const sampleType = typeof sampleValue;
+        if (sampleType === 'number') {
+          const numeric = Number(value);
+          return Number.isNaN(numeric) ? value : numeric;
+        }
+
+        if (sampleType === 'boolean') {
+          if (typeof value === 'boolean') return value;
+          if (typeof value === 'string') {
+            const lowered = value.toLowerCase();
+            if (lowered === 'true') return true;
+            if (lowered === 'false') return false;
+          }
+          return value;
+        }
+
+        if (sampleType === 'string') {
+          return value != null ? String(value) : value;
+        }
+
+        return value;
+      };
+
+      const mapped = data
+        .map(item => {
+          const hasStatusLabel = item?.status != null && item.status !== '';
+          const baseValue = hasStatusLabel ? item.status : item?.id;
+          if (baseValue === undefined || baseValue === null || baseValue === '') {
+            return null;
+          }
+
+          const displayText = this.ensureDisplayText(baseValue);
+          const normalizedValue = hasStatusLabel
+            ? this.ensureDisplayText(item.status)
+            : normalizeValueType(baseValue);
+
+          if (this.statusLookupMap) {
+            this.registerStatusLookupKey(normalizedValue, normalizedValue);
+            if (hasStatusLabel) {
+              this.registerStatusLookupKey(item.status, normalizedValue);
+            }
+            if (item?.id !== undefined && item?.id !== null && item.id !== '') {
+              this.registerStatusLookupKey(item.id, normalizedValue);
+            }
+          }
+
+          return {
+            value: normalizedValue,
+            label: displayText,
+          };
+        })
+        .filter(option => option && option.value !== undefined && option.value !== null);
+
+      return mapped;
+    } catch (error) {
+     
+      return null;
+    }
+  }
+
+  registerStatusLookupKey(rawValue, canonicalValue) {
+    if (!this.statusLookupMap || rawValue === undefined || rawValue === null) return;
+    if (canonicalValue === undefined || canonicalValue === null) return;
+
+    const variations = new Set();
+    variations.add(rawValue);
+
+    if (typeof rawValue === 'string') {
+      variations.add(rawValue.trim());
+      variations.add(rawValue.trim().toLowerCase());
+    } else {
+      const stringValue = String(rawValue);
+      variations.add(stringValue);
+      variations.add(stringValue.trim());
+      variations.add(stringValue.trim().toLowerCase());
+    }
+
+    variations.forEach(variation => {
+      if (variation !== undefined && variation !== null && variation !== '') {
+        this.statusLookupMap.set(variation, canonicalValue);
+      }
+    });
+  }
+
+  resolveStatusCanonicalValue(value) {
+    if (!this.statusLookupMap) return value;
+    if (value === undefined || value === null) return value;
+
+    const attempts = [];
+    attempts.push(value);
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (trimmed !== value) attempts.push(trimmed);
+      attempts.push(trimmed.toLowerCase());
+    } else {
+      const stringValue = String(value);
+      attempts.push(stringValue);
+      const trimmed = stringValue.trim();
+      if (trimmed !== stringValue) attempts.push(trimmed);
+      attempts.push(trimmed.toLowerCase());
+    }
+
+    for (const attempt of attempts) {
+      if (attempt === undefined || attempt === null) continue;
+      if (this.statusLookupMap.has(attempt)) {
+        return this.statusLookupMap.get(attempt);
+      }
+    }
+
+    return value;
+  }
+
+  findSampleValue(colDef) {
+    const api = this.params?.api;
+    if (!api) return undefined;
+
+    const field = colDef.field || this.params.column.getColId();
+    let sample = undefined;
+
+    api.forEachNode(node => {
+      if (sample !== undefined) return;
+      if (!node?.data) return;
+      const candidate = this.getNestedValue(node.data, field);
+      if (candidate !== undefined && candidate !== null) {
+        sample = candidate;
+      }
+    });
+
+    return sample;
+  }
+
+  populateFromExplicitOptions(optionsInput, colDef) {
+    const options = Array.isArray(optionsInput) ? optionsInput : [];
+    if (!options.length) {
+      this.allValues = [];
+      this.formattedValues = [];
+      this.filteredValues = [];
+      return false;
+    }
+
+    const normalized = options
+      .map(opt => this.normalizeOption(opt))
+      .filter(opt => opt && (opt.value !== undefined || opt.value === null));
+
+    if (!normalized.length) {
+      this.allValues = [];
+      this.formattedValues = [];
+      this.filteredValues = [];
+      return false;
+    }
+
+    const zipped = normalized.map(opt => {
+      const rawValue = opt.value;
+      const display = opt.label != null ? opt.label : opt.value;
+      const formatted = this.formatDisplayValue(this.ensureDisplayText(display), colDef);
+      return { raw: rawValue, formatted };
+    });
+
+    const uniqueMap = new Map();
+    zipped.forEach(item => {
+      const key = this.buildRawKey(item.raw);
+      if (!uniqueMap.has(key)) {
+        uniqueMap.set(key, item);
+      }
+    });
+
+    const unique = Array.from(uniqueMap.values());
+    unique.sort((a, b) => this.compareFormattedValues(a.formatted, b.formatted));
+
+    this.allValues = unique.map(item => item.raw);
+    this.formattedValues = unique.map(item => item.formatted);
+    this.filteredValues = [...this.allValues];
+    this.selectedValues = this.selectedValues.map(value => this.resolveRawValue(value));
+    return true;
+  }
+
+  populateFromRows(api, column, colDef) {
+    const field = colDef.field || column.getColId();
+
+    this.allValues = [];
+    this.formattedValues = [];
+
+    api.forEachNode(node => {
+      if (!node.data) return;
+      const rawValue = this.getNestedValue(node.data, field);
+      if (rawValue === undefined || rawValue === null) return;
+
+      const rendererParams = typeof colDef.cellRendererParams === 'function'
+        ? colDef.cellRendererParams({ data: node.data, value: rawValue, colDef })
+        : colDef.cellRendererParams || {};
+
+      let optionsArr = [];
+      if (Array.isArray(rendererParams.options)) {
+        optionsArr = rendererParams.options;
+      } else if (Array.isArray(colDef.options)) {
+        optionsArr = colDef.options;
+      } else if (Array.isArray(colDef.listOptions)) {
+        optionsArr = colDef.listOptions;
+      } else if (typeof colDef.listOptions === 'string' && colDef.listOptions.trim() !== '') {
+        optionsArr = colDef.listOptions.split(',').map(o => o.trim());
+      } else if (colDef.dataSource && typeof colDef.dataSource.list_options === 'string' && colDef.dataSource.list_options.trim() !== '') {
+        optionsArr = colDef.dataSource.list_options.split(',').map(o => o.trim());
+      }
+
+      const options = (optionsArr || []).map(opt => this.normalizeOption(opt));
+      const match = options.find(o => o.value == rawValue);
+      const baseDisplay = match ? (match.label != null ? match.label : match.value) : rawValue;
+      const display = this.ensureDisplayText(baseDisplay);
+
+      let formatted = display;
+      try {
+        if (this.isCategoryField) {
+          const colorCategory = window.wwLib?.wwVariable?.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726').categoryColor;
+          formatted = `<span style="height:25px; color:#303030; background:${colorCategory}; border:1px solid ${colorCategory}; border-radius:5px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${display}</span>`;
+        } else if (rendererParams.useCustomFormatter && typeof rendererParams.formatter === 'string') {
+          const formatterFn = new Function(
+            'value',
+            'row',
+            'colDef',
+            'getRoundedSpanColor',
+            'dateFormatter',
+            rendererParams.formatter
+          );
+          formatted = formatterFn(
+            display,
+            node.data,
+            colDef,
+            this.getRoundedSpanColor,
+            this.dateFormatter
+          );
+        } else if (rendererParams.useStyleArray && Array.isArray(rendererParams.styleArray)) {
+          const styled = this.getRoundedSpanColor(display, rendererParams.styleArray, colDef.FieldDB);
+          if (styled) formatted = styled;
+        }
+      } catch (e) {
+        // se der erro, mantém valor calculado
+      }
+
+      this.allValues.push(rawValue);
+      this.formattedValues.push(formatted);
+    });
+
+    const seen = new Map();
+    const unique = [];
+    this.allValues.forEach((raw, idx) => {
+      const key = this.buildRawKey(raw);
+      if (!seen.has(key)) {
+        seen.set(key, true);
+        unique.push({ raw, formatted: this.formattedValues[idx] });
+      }
+    });
+
+    unique.sort((a, b) => this.compareFormattedValues(a.formatted, b.formatted));
+
+    this.allValues = unique.map(item => item.raw);
+    this.formattedValues = unique.map(item => item.formatted);
+    this.filteredValues = [...this.allValues];
+    this.selectedValues = this.selectedValues.map(value => this.resolveRawValue(value));
+  }
+
+  normalizeOption(opt) {
+    if (opt === undefined) return null;
+    if (opt === null) return { value: null, label: '' };
+
+    if (typeof opt === 'object') {
+      const lowerKeyMap = Object.keys(opt).reduce((acc, key) => {
+        acc[key.toLowerCase()] = key;
+        return acc;
+      }, {});
+
+      const findKey = candidates => {
+        for (const candidate of candidates) {
+          const actual = lowerKeyMap[candidate];
+          if (actual) return actual;
+        }
+        return null;
+      };
+
+      const valueKey = findKey([
+        'value',
+        'id',
+        'key',
+        'valor',
+        'codigo',
+        'code',
+        'statusid',
+        'userid',
+      ]);
+
+      const labelKey = findKey([
+        'label',
+        'name',
+        'displayname',
+        'descricao',
+        'description',
+        'text',
+        'valor',
+        'title',
+      ]);
+
+      const rawValue = valueKey != null ? opt[valueKey] : undefined;
+      const labelSource = labelKey != null ? opt[labelKey] : undefined;
+
+      let finalValue = rawValue;
+      if (finalValue === undefined) {
+        if (labelSource !== undefined) {
+          finalValue = labelSource;
+        } else if (Array.isArray(opt.options) && opt.options.length === 1) {
+          finalValue = opt.options[0];
+        } else if (valueKey == null && labelKey == null) {
+          const firstKey = Object.keys(opt)[0];
+          if (firstKey) {
+            finalValue = opt[firstKey];
+          }
+        }
+      }
+
+      let finalLabel = labelSource;
+      if (finalLabel === undefined) {
+        finalLabel = finalValue;
+      }
+
+      let normalizedValue = finalValue !== undefined ? finalValue : '';
+      if (typeof normalizedValue === 'object') {
+        normalizedValue = this.ensureDisplayText(normalizedValue);
+      }
+
+      let normalizedLabel = finalLabel != null ? finalLabel : normalizedValue;
+      if (typeof normalizedLabel === 'object') {
+        normalizedLabel = this.ensureDisplayText(normalizedLabel);
+      }
+
+      return {
+        value: normalizedValue,
+        label: normalizedLabel,
+      };
+    }
+
+    return { value: opt, label: opt == null ? '' : String(opt) };
+  }
+
+  formatDisplayValue(display, colDef) {
+    let formatted = this.ensureDisplayText(display);
+    try {
+      if (this.isCategoryField) {
+        const colorCategory = window.wwLib?.wwVariable?.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726').categoryColor;
+        formatted = `<span style="height:25px; color:#303030; background:${colorCategory}; border:1px solid ${colorCategory}; border-radius:5px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${display}</span>`;
+      } else if (this.rendererConfig.useCustomFormatter && typeof this.rendererConfig.formatter === 'string') {
+        const formatterFn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          this.rendererConfig.formatter
+        );
+        formatted = formatterFn(
+          display,
+          {},
+          colDef,
+          this.getRoundedSpanColor,
+          this.dateFormatter
+        );
+      } else if (this.rendererConfig.useStyleArray && Array.isArray(this.rendererConfig.styleArray)) {
+        const styled = this.getRoundedSpanColor(display, this.rendererConfig.styleArray, colDef.FieldDB);
+        if (styled) formatted = styled;
+      }
+    } catch (e) {
+      // se der erro, mantém valor calculado
+    }
+    return formatted;
+  }
+
+  buildRawKey(raw) {
+    if (raw === null) return 'raw:null';
+    if (raw === undefined) return 'raw:undefined';
+    if (typeof raw === 'object') {
+      try {
+        return `raw:object:${JSON.stringify(raw)}`;
+      } catch (error) {
+        return `raw:object:${String(raw)}`;
+      }
+    }
+    return `raw:${typeof raw}:${String(raw)}`;
+  }
+
+  compareFormattedValues(a, b) {
+    const textA = this.stripHtml(String(a)).toLowerCase();
+    const textB = this.stripHtml(String(b)).toLowerCase();
+    return textA.localeCompare(textB, undefined, { sensitivity: 'base' });
+  }
+
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  ensureDisplayText(value) {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    if (value instanceof Date) return this.dateFormatter(value);
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      return String(value);
+    }
+  }
+
+
+  normalizeOption(opt) {
+    if (opt === undefined) return null;
+    if (opt === null) return { value: null, label: '' };
+
+    if (typeof opt === 'object') {
+      const lowerKeyMap = Object.keys(opt).reduce((acc, key) => {
+        acc[key.toLowerCase()] = key;
+        return acc;
+      }, {});
+
+      const findKey = candidates => {
+        for (const candidate of candidates) {
+          const actual = lowerKeyMap[candidate];
+          if (actual) return actual;
+        }
+        return null;
+      };
+
+      const valueKey = findKey([
+        'value',
+        'id',
+        'key',
+        'valor',
+        'codigo',
+        'code',
+        'statusid',
+        'userid',
+      ]);
+
+      const labelKey = findKey([
+        'label',
+        'name',
+        'displayname',
+        'descricao',
+        'description',
+        'text',
+        'valor',
+        'title',
+      ]);
+
+      const rawValue = valueKey != null ? opt[valueKey] : undefined;
+      const labelSource = labelKey != null ? opt[labelKey] : undefined;
+
+      let finalValue = rawValue;
+      if (finalValue === undefined) {
+        if (labelSource !== undefined) {
+          finalValue = labelSource;
+        } else if (Array.isArray(opt.options) && opt.options.length === 1) {
+          finalValue = opt.options[0];
+        } else if (valueKey == null && labelKey == null) {
+          const firstKey = Object.keys(opt)[0];
+          if (firstKey) {
+            finalValue = opt[firstKey];
+          }
+        }
+      }
+
+      let finalLabel = labelSource;
+      if (finalLabel === undefined) {
+        finalLabel = finalValue;
+      }
+
+      let normalizedValue = finalValue !== undefined ? finalValue : '';
+      if (typeof normalizedValue === 'object') {
+        normalizedValue = this.ensureDisplayText(normalizedValue);
+      }
+
+      let normalizedLabel = finalLabel != null ? finalLabel : normalizedValue;
+      if (typeof normalizedLabel === 'object') {
+        normalizedLabel = this.ensureDisplayText(normalizedLabel);
+      }
+
+      return {
+        value: normalizedValue,
+        label: normalizedLabel,
+      };
+    }
+
+
+    return { value: opt, label: opt == null ? '' : String(opt) };
+  }
+
+  formatDisplayValue(display, colDef) {
+    let formatted = this.ensureDisplayText(display);
+
+    try {
+      if (this.isCategoryField) {
+        const colorCategory = window.wwLib?.wwVariable?.getValue('61c1b425-10e8-40dc-8f1f-b117c08b9726').categoryColor;
+        formatted = `<span style="height:25px; color:#303030; background:${colorCategory}; border:1px solid ${colorCategory}; border-radius:5px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${display}</span>`;
+      } else if (this.rendererConfig.useCustomFormatter && typeof this.rendererConfig.formatter === 'string') {
+        const formatterFn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          this.rendererConfig.formatter
+        );
+        formatted = formatterFn(
+          display,
+          {},
+          colDef,
+          this.getRoundedSpanColor,
+          this.dateFormatter
+        );
+      } else if (this.rendererConfig.useStyleArray && Array.isArray(this.rendererConfig.styleArray)) {
+        const styled = this.getRoundedSpanColor(display, this.rendererConfig.styleArray, colDef.FieldDB);
+        if (styled) formatted = styled;
+      }
+    } catch (e) {
+      // se der erro, mantém valor calculado
+    }
+    return formatted;
+  }
+
+  buildRawKey(raw) {
+    if (raw === null) return 'raw:null';
+    if (raw === undefined) return 'raw:undefined';
+    if (typeof raw === 'object') {
+      try {
+        return `raw:object:${JSON.stringify(raw)}`;
+      } catch (error) {
+        return `raw:object:${String(raw)}`;
+      }
+    }
+    return `raw:${typeof raw}:${String(raw)}`;
+  }
+
+  compareFormattedValues(a, b) {
+    const textA = this.stripHtml(String(a)).toLowerCase();
+    const textB = this.stripHtml(String(b)).toLowerCase();
+    return textA.localeCompare(textB, undefined, { sensitivity: 'base' });
+  }
+
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+  
+  ensureDisplayText(value) {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    if (value instanceof Date) return this.dateFormatter(value);
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      return String(value);
+    }
+  }
+
+  filterValues() {
+    if (!this.searchText) {
+      this.filteredValues = [...this.allValues];
+    } else {
+      this.filteredValues = this.allValues.filter((raw, idx) => {
+        const formatted = this.formattedValues[idx];
+        return String(formatted).toLowerCase().includes(this.searchText.toLowerCase());
+      });
+    }
+    this.renderFilterList();
+  }
+
+  resolveRawValue(value) {
+    if (this.isStatusField && this.statusLookupMap) {
+      const canonical = this.resolveStatusCanonicalValue(value);
+      if (canonical !== value) {
+        const canonicalIndex = this.allValues.indexOf(canonical);
+        if (canonicalIndex !== -1) {
+          return this.allValues[canonicalIndex];
+        }
+        return canonical;
+      }
+    }
+
+    const directIndex = this.allValues.indexOf(value);
+    if (directIndex !== -1) return this.allValues[directIndex];
+
+    if (value === null) {
+      const nullIndex = this.allValues.indexOf(null);
+      return nullIndex !== -1 ? this.allValues[nullIndex] : value;
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      const lower = trimmed.toLowerCase();
+
+      if (lower === 'null') {
+        const nullIndex = this.allValues.indexOf(null);
+        if (nullIndex !== -1) return this.allValues[nullIndex];
+      }
+
+      if (lower === 'true' || lower === 'false') {
+        const boolValue = lower === 'true';
+        const boolIndex = this.allValues.indexOf(boolValue);
+        if (boolIndex !== -1) return this.allValues[boolIndex];
+      }
+
+      if (trimmed !== '') {
+        const numValue = Number(trimmed);
+        if (!Number.isNaN(numValue)) {
+          const numIndex = this.allValues.indexOf(numValue);
+          if (numIndex !== -1) return this.allValues[numIndex];
+        }
+      }
+
+      const strIndex = this.allValues.findIndex(raw => {
+        if (raw === value) return true;
+        if (typeof raw === 'number' || typeof raw === 'boolean') {
+          return String(raw) === trimmed;
+        }
+        return false;
+      });
+      if (strIndex !== -1) return this.allValues[strIndex];
+    }
+
+    if (typeof value === 'number') {
+      const strValue = String(value);
+      const strIndex = this.allValues.findIndex(raw => typeof raw === 'string' && raw === strValue);
+      if (strIndex !== -1) return this.allValues[strIndex];
+    }
+
+    if (typeof value === 'boolean') {
+      const boolStr = value ? 'true' : 'false';
+      const boolIndex = this.allValues.findIndex(raw => typeof raw === 'string' && raw.toLowerCase && raw.toLowerCase() === boolStr);
+      if (boolIndex !== -1) return this.allValues[boolIndex];
+    }
+
+    return value;
+  }
+
+  renderFilterList() {
+    this.selectAllCheckbox.checked =
+      this.filteredValues.length > 0 &&
+      this.filteredValues.every(v => this.selectedValues.includes(v));
+
+    this.filterList.innerHTML = this.filteredValues.map((rawValue) => {
+      const idx = this.allValues.indexOf(rawValue);
+      const formattedValue = this.formattedValues[idx] || rawValue;
+      const checked = this.selectedValues.includes(rawValue) ? 'checked' : '';
+      const itemClass = this.selectedValues.includes(rawValue) ? ' selected' : '';
+      const title = this.stripHtml(this.ensureDisplayText(formattedValue)).replace(/"/g, '&quot;');
+      return `
+        <label class="filter-item${itemClass}">
+          <input type="checkbox" value="${idx}" data-raw-index="${idx}" ${checked} />
+          <span class="filter-label" title="${title}">${formattedValue}</span>
+        </label>
+      `;
+    }).join('');
+
+    this.filterList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+      checkbox.addEventListener('change', (e) => {
+        const rawIndexAttr = e.target.getAttribute('data-raw-index');
+        const rawIndex = rawIndexAttr != null ? Number(rawIndexAttr) : -1;
+        const rawValue = (rawIndex >= 0 && rawIndex < this.allValues.length)
+          ? this.allValues[rawIndex]
+          : this.resolveRawValue(e.target.value);
+        if (e.target.checked) {
+          if (!this.selectedValues.includes(rawValue)) {
+            this.selectedValues.push(rawValue);
+          }
+        } else {
+          this.selectedValues = this.selectedValues.filter(v => v !== rawValue);
+        }
+        this.selectAllCheckbox.checked =
+          this.filteredValues.length > 0 &&
+          this.filteredValues.every(v => this.selectedValues.includes(v));
+        this.applyFilter();
+      });
+    });
+  }
+
+  applyFilter() {
+    this.params.filterChangedCallback();
+  }
+
+  clearFilter() {
+    this.selectedValues = [];
+    this.searchText = '';
+    this.searchInput.value = '';
+    this.filteredValues = [...this.allValues];
+    this.renderFilterList();
+    this.params.filterChangedCallback();
+  }
+
+  isFilterActive() {
+    return this.selectedValues.length > 0;
+  }
+
+  doesFilterPass(params) {
+    if (this.selectedValues.length === 0) return true;
+    const field = this.params.column.getColDef().field || this.params.column.getColId();
+    const value = this.getNestedValue(params.data, field);
+    const resolvedValue = this.resolveRawValue(value);
+    return this.selectedValues.includes(resolvedValue);
+  }
+
+  getModel() {
+    if (this.selectedValues.length === 0) return null;
+    return {
+      type: 'list',
+      values: this.selectedValues
+    };
+  }
+
+  setModel(model) {
+    if (model && Array.isArray(model.values)) {
+      this.selectedValues = model.values.map(value => this.resolveRawValue(value));
+    } else {
+      this.selectedValues = [];
+    }
+    this.renderFilterList();
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+  
+  onNewRowsLoaded() {
+    const maybePromise = this.loadValues();
+    if (maybePromise && typeof maybePromise.then === 'function') {
+      maybePromise
+        .then(() => {
+          this.filterValues();
+        })
+        .catch(() => {
+          this.filterValues();
+        });
+    } else {
+      this.filterValues();
+    }
+  }
+}

--- a/Project/TicketGrid/src/components/ResponsibleUserCellEditor.js
+++ b/Project/TicketGrid/src/components/ResponsibleUserCellEditor.js
@@ -1,0 +1,842 @@
+export default class ResponsibleUserCellEditor {
+  init(params) { 
+    this.params = params;
+
+    // Renderer params (mantém compatibilidade com seu formatter/styleArray)
+    const colDef = params.colDef || {};
+    this.rendererParams =
+      typeof colDef.cellRendererParams === 'function'
+        ? colDef.cellRendererParams(params)
+        : colDef.cellRendererParams || {};
+
+    // Estado
+    this.value = params.value;
+    this.searchTerm = '';
+    this.currentGroup = null;         // grupo em drill-in
+    this.currentGroupUsers = [];      // membros do grupo atual
+    this.groupStack = [];
+    this.groupBy = 'type';            // igual ao componente fornecido
+    this.searchPlaceholder = 'Search user or group...';
+
+    const tag =
+      (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toUpperCase();
+    const identifier = (colDef.FieldDB || '').toUpperCase();
+    this.isResponsibleUser = tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+
+    // Normalização das opções (mantém chaves extras intactas)
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
+        const labelKey = findKey('label') || findKey('name');
+        const valueKey = findKey('value') || findKey('id');
+        return {
+          ...opt,
+          value: valueKey ? opt[valueKey] : opt.value,
+          label: labelKey ? opt[labelKey] : opt.label || opt.name
+        };
+      }
+      return { value: opt, label: String(opt) };
+    };
+    const resolveOptions = (opts) => {
+      const arr = (opts || []).map(normalize);
+      this.options = arr;
+      this.filteredRoot = [...arr];
+      this.applyRootFilter();
+      this.render();
+    };
+
+    let optionsPromise;
+    if (params.options && typeof params.options.then === 'function') {
+      optionsPromise = params.options;
+    } else if (Array.isArray(params.options)) {
+      optionsPromise = Promise.resolve(params.options);
+    } else if (Array.isArray(colDef.listOptions)) {
+      optionsPromise = Promise.resolve(colDef.listOptions);
+    } else if (typeof colDef.listOptions === 'string' && colDef.listOptions.trim() !== '') {
+      optionsPromise = Promise.resolve(colDef.listOptions.split(',').map(o => o.trim()));
+    } else if (colDef.dataSource && typeof colDef.dataSource.list_options === 'string' && colDef.dataSource.list_options.trim() !== '') {
+      optionsPromise = Promise.resolve(colDef.dataSource.list_options.split(',').map(o => o.trim()));
+    } else {
+      optionsPromise = Promise.resolve([]);
+    }
+
+    this.options = [];
+    this.filteredRoot = [];
+    optionsPromise.then(resolveOptions);
+
+    // DOM
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'user-selector-dropdown'; // wrapper (mesmas classes)
+    this.applyAvatarTheme();
+    this.eGui.innerHTML = `
+      <div class="user-selector__dropdown" data-role="dropdown">
+        <div class="user-selector__search" data-role="search-row">
+          <input type="text" class="user-selector__input" placeholder="${this.searchPlaceholder}" />
+          <span class="material-symbols-outlined user-selector__icon">search</span>
+        </div>
+
+        <div class="user-selector__group-header" data-role="group-header" style="display:none;">
+          <span class="material-symbols-outlined user-selector__back" data-role="back-btn">chevron_left</span>
+          <span class="user-selector__group-title" data-role="group-title"></span>
+        </div>
+        <div class="user-selector__group-count" data-role="group-count" style="display:none;"></div>
+
+        <div class="user-selector__list" data-role="list"></div>
+        <div class="user-selector__no-results" data-role="no-results" style="display:none;">No user found</div>
+      </div>
+    `;
+
+    // Close (X) no topo da dropdown
+    const closeBtn = document.createElement('span');
+    closeBtn.className = 'editor-close';
+    closeBtn.innerHTML = '&times;';
+    closeBtn.addEventListener('click', () => {
+      if (this.params.api && this.params.api.stopEditing) this.params.api.stopEditing(true);
+      else if (this.params.stopEditing) this.params.stopEditing(true);
+    });
+    this.eGui.querySelector('[data-role="dropdown"]').prepend(closeBtn);
+
+    // Refs
+    this.searchRow   = this.eGui.querySelector('[data-role="search-row"]');
+    this.searchInput = this.eGui.querySelector('.user-selector__input');
+    this.groupHeader = this.eGui.querySelector('[data-role="group-header"]');
+    this.backBtn     = this.eGui.querySelector('[data-role="back-btn"]');
+    this.groupTitle  = this.eGui.querySelector('[data-role="group-title"]');
+    this.groupCount  = this.eGui.querySelector('[data-role="group-count"]');
+    this.listEl      = this.eGui.querySelector('[data-role="list"]');
+    this.noResultsEl = this.eGui.querySelector('[data-role="no-results"]');
+
+    // Eventos
+    this.searchInput.addEventListener('input', (e) => {
+      this.searchTerm = (e.target.value || '').toLowerCase();
+      this.applyRootFilter();
+      this.render();
+    });
+
+    this.backBtn.addEventListener('click', () => this.backToRoot());
+
+    // CSS (ajustado: 14px, wght 400, ícone groups centralizado)
+    this.injectCSSOnce();
+
+    // Render inicial (root)
+    this.applyRootFilter();
+    this.render();
+  }
+
+  // --------- HELPERS DE RESOLUÇÃO (nomes por id) ----------
+  findOptionById(id) {
+    if (id == null) return null;
+    const sid = String(id);
+    return (this.options || []).find(o => String(o.id ?? o.value) === sid) || null;
+  }
+  getGroupNameById(id) {
+    const opt = this.findOptionById(id);
+    return opt?.name || opt?.label || null;
+  }
+  getUserNameById(id) {
+    if (id == null) return null;
+    const sid = String(id);
+
+    // usuários na raiz
+    const rootUser = (this.options || []).find(
+      o => String(o.id ?? o.value) === sid && String(o?.type || '').toLowerCase() !== 'group'
+    );
+    if (rootUser) return rootUser.name || rootUser.label || null;
+
+    // membros de grupos
+    for (const g of (this.options || [])) {
+      if (String(g?.type || '').toLowerCase() === 'group' && Array.isArray(g.groupUsers)) {
+        const m = g.groupUsers.find(x => String(x.id ?? x.value ?? x.UserID) === sid);
+        if (m) return m.name || m.DisplayName || m.label || null;
+      }
+    }
+    return null;
+  }
+
+  // Busca na raiz (considera grupos e membros)
+  applyRootFilter() {
+    if (!this.searchTerm) {
+      this.filteredRoot = [...this.options];
+      return;
+    }
+    const q = this.searchTerm;
+    this.filteredRoot = this.options.filter(item => {
+      const type = String(item?.[this.groupBy] || '').toLowerCase();
+      const name = String(item?.name || item?.label || '').toLowerCase();
+
+      if (type === 'group') {
+        const groupNameMatch = name.includes(q);
+        const hasMemberMatch = (Array.isArray(item.groupUsers) ? item.groupUsers : [])
+          .some(m => String(m.name || m.DisplayName || m.label || '').toLowerCase().includes(q));
+        return groupNameMatch || hasMemberMatch;
+      }
+      return name.includes(q);
+    });
+  }
+
+  // Abrir grupo: "Assign to team" só em ResponsibleUser
+  openGroup(group) {
+    if (!group || !Array.isArray(group.groupUsers)) return;
+    this.groupStack.push(this.currentGroup);
+    this.currentGroup = group;
+
+    const members = group.groupUsers || [];
+    this.currentGroupUsers = this.isResponsibleUser
+      ? [{ id: null, name: 'Assign to team', isAssignToTeam: true }, ...members]
+      : members.slice();
+
+    // Em modo grupo, esconde busca (igual ao Vue)
+    this.searchTerm = '';
+    if (this.searchInput) this.searchInput.value = '';
+    this.render();
+  }
+
+  // Voltar
+  backToRoot() {
+    this.currentGroup = this.groupStack.pop() || null;
+    if (this.currentGroup) {
+      const members = this.currentGroup.groupUsers || [];
+      this.currentGroupUsers = this.isResponsibleUser
+        ? [{ id: null, name: 'Assign to team', isAssignToTeam: true }, ...members]
+        : members.slice();
+    } else {
+      this.currentGroupUsers = [];
+      this.applyRootFilter();
+    }
+    this.render();
+  }
+
+  // Helpers visuais / formatters
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const it = colorArray.find(item => item.Valor === value);
+    if (!it) return value;
+    const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+    const fontweight = 'font-weight:bold;';
+    return `<span style="height:25px; color:${it.CorFonte}; background:${it.CorFundo}; border:1px solid ${it.CorFundo}; border-radius:${borderRadius}; ${fontweight} display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+      const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+      const d = new Date(dateValue);
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(d);
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(d);
+      return `${datePart} ${timePart}`;
+    } catch {
+      return dateValue;
+    }
+  }
+
+  formatOption(opt) {
+    const value = opt.label != null ? opt.label : opt.value;
+    const colDef = this.params.colDef || {};
+    const params = this.rendererParams || {};
+    try {
+      if (params.useCustomFormatter && typeof params.formatter === 'string') {
+        const fn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          params.formatter
+        );
+        return fn(value, {}, colDef, this.getRoundedSpanColor.bind(this), this.dateFormatter.bind(this));
+      } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+        const styled = this.getRoundedSpanColor(value, params.styleArray, colDef.FieldDB);
+        if (styled) return styled;
+      }
+    } catch (e) {
+      
+    }
+    return value;
+  }
+
+  getInitial(name) {
+    return name ? String(name).trim().charAt(0).toUpperCase() : '';
+  }
+
+  isGroupLabelText(label) {
+    const v = String(label || '').toUpperCase();
+    return ['GROUP', 'GROUPS', 'GRUPO', 'GRUPOS'].includes(v);
+  }
+
+  // Agrupamento por this.groupBy (root)
+  groupRootItems(items) {
+    if (!items || !items.length) return { groups: [], ungrouped: [] };
+    const groups = new Map();
+    const ungrouped = [];
+
+    for (const u of items) {
+      const key = u?.[this.groupBy];
+      if (key === undefined || key === null || key === '') {
+        ungrouped.push(u);
+      } else {
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(u);
+      }
+    }
+
+    return {
+      groups: Array.from(groups, ([label, items]) => ({ label, items })),
+      ungrouped
+    };
+  }
+
+  // Render master
+  render() {
+    if (this.currentGroup) {
+      this.searchRow.style.display = 'none';
+      this.groupHeader.style.display = '';
+      this.groupTitle.textContent = this.currentGroup.name || '';
+      const count = (this.currentGroup.groupUsers || []).length || 0;
+      this.groupCount.style.display = '';
+      this.groupCount.textContent = `${count} ${count === 1 ? 'member' : 'members'}`;
+      this.renderGroupView();
+    } else {
+      this.searchRow.style.display = '';
+      this.groupHeader.style.display = 'none';
+      this.groupCount.style.display = 'none';
+      this.renderRootView();
+    }
+  }
+
+  // ROOT VIEW
+  renderRootView() {
+    const { groups, ungrouped } = this.groupRootItems(this.filteredRoot);
+    let html = '';
+
+    // Grupos (Users / Group)
+    for (const group of groups) {
+      const showLabel = !['USERS', 'USER', 'USUARIOS', 'USUÁRIO', 'USUÁRIOS'].includes(String(group.label || '').toUpperCase());
+      html += `
+        <div class="user-selector__group">
+          <div class="user-selector__group-label">${showLabel ? (group.label || '') : ''}</div>
+          <div class="user-selector__group-items">
+            ${group.items.map(u => this.renderRootItem(u, group.label)).join('')}
+          </div>
+        </div>
+      `;
+    }
+
+    // Itens sem grupo
+    html += ungrouped.map(u => this.renderRootItem(u, '')).join('');
+
+    this.listEl.innerHTML = html || '';
+    this.noResultsEl.style.display = (html.trim() === '') ? '' : 'none';
+
+    // Bind cliques (root)
+    this.listEl.querySelectorAll('[data-action="open-group"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.getAttribute('data-id');
+        const grp = this.filteredRoot.find(x => String(x.id || x.value) === id);
+        if (grp) this.openGroup(grp);
+      });
+    });
+
+    this.listEl.querySelectorAll('[data-action="select-user"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const val = btn.getAttribute('data-id');
+        // callback opcional
+        if (typeof this.params.colDef?.onSelect === 'function') {
+          try { this.params.colDef.onSelect({ userid: val, groupid: null }, this.params); } catch {}
+        }
+        this.postGroupAndUser({ p_groupid: null, p_responsibleuserid: val });
+        const selected = this.options.find(u => String(u.id || u.value) === String(val));
+        this.commitSelection({ userid: val, groupid: null }, {
+          userName: selected?.name || selected?.label || '',
+          groupName: null,
+        });
+      });
+    });
+  }
+
+  // Item na raiz (agrupado): avatar só quando for ResponsibleUser
+  renderRootItem(user, groupLabel) {
+    const formatted = this.formatOption(user);
+    const plain = this.stripHtml(String(formatted));
+    const hasChildren = Array.isArray(user.groupUsers) && user.groupUsers.length > 0;
+    const isGroupType = this.isGroupLabelText(groupLabel) || String(user?.[this.groupBy] || '').toUpperCase() === 'GROUP';
+
+    const actionAttr = (hasChildren || isGroupType)
+      ? 'data-action="open-group"'
+      : 'data-action="select-user"';
+    const chevron = hasChildren
+      ? `<span class="material-symbols-outlined user-selector__chevron" ${actionAttr} data-id="${user.id || user.value}">chevron_right</span>`
+      : '';
+
+    // NÃO ResponsibleUser: só label (mantém HTML do formatter)
+    if (!this.isResponsibleUser) {
+      return `
+        <div class="user-selector__item" ${actionAttr} data-id="${user.id || user.value}">
+          <span class="user-selector__name">${formatted}</span>
+          ${chevron}
+        </div>
+      `;
+    }
+
+    // ResponsibleUser: avatar/inicial/ícone de grupo
+    const photo = user.photoUrl || user.PhotoURL || user.PhotoUrl || user.photo || user.image || user.img || '';
+    const avatarHTML = isGroupType
+      ? `<span style="font-size: 19px; padding-top:3px; padding-left:3px" class="material-symbols-outlined user-selector__group-icon">groups</span>`
+      : (photo
+          ? `<img src="${photo}" alt="User Photo" />`
+          : `<span class="user-selector__initial">${this.getInitial(user.name || plain)}</span>`);
+
+    return `
+      <div class="user-selector__item" ${actionAttr} data-id="${user.id || user.value}">
+        <div class="avatar-outer">
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">${avatarHTML}</div>
+          </div>
+        </div>
+        <span class="user-selector__name">${formatted}</span>
+        ${chevron}
+      </div>
+    `;
+  }
+
+  // GROUP VIEW
+  renderGroupView() {
+    // renderiza a lista do grupo atual (com "Assign to team" no topo apenas em ResponsibleUser)
+    const list = this.currentGroupUsers || [];
+    this.listEl.innerHTML = list.map(member => this.renderGroupMember(member)).join('') || '';
+    this.noResultsEl.style.display = (list.length === 0) ? '' : 'none';
+
+    // Bind cliques (grupo)
+    this.listEl.querySelectorAll('[data-action="assign-team"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const payload = { userid: null, groupid: this.currentGroup.id };
+        if (typeof this.params.colDef?.onSelect === 'function') {
+          try { this.params.colDef.onSelect(payload, this.params); } catch {}
+        }
+        this.postGroupAndUser({ p_groupid: this.currentGroup.id, p_responsibleuserid: null });
+        this.commitSelection(payload, {
+          userName: null,
+          groupName: this.currentGroup?.name || '',
+        });
+      });
+    });
+
+    this.listEl.querySelectorAll('[data-action="select-user"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const userId = btn.getAttribute('data-id');
+        const payload = { userid: userId, groupid: this.currentGroup.id };
+        if (typeof this.params.colDef?.onSelect === 'function') {
+          try { this.params.colDef.onSelect(payload, this.params); } catch {}
+        }
+        this.postGroupAndUser({ p_groupid: this.currentGroup.id, p_responsibleuserid: userId });
+
+        const member = (this.currentGroup.groupUsers || []).find(m => String(m.id || m.UserID || m.value) === String(userId));
+        this.commitSelection(payload, {
+          userName: member?.name || member?.DisplayName || member?.label || '',
+          groupName: this.currentGroup?.name || '',
+        });
+      });
+    });
+  }
+
+  // Item de membro do grupo: avatar só quando for ResponsibleUser
+  renderGroupMember(member) {
+    const isAssign = !!member.isAssignToTeam;
+    const name = isAssign ? 'Assign to team' : (member.name || member.DisplayName || member.label || '');
+    const actionAttr = isAssign ? 'data-action="assign-team"' : 'data-action="select-user"';
+    const idAttr = isAssign ? '' : `data-id="${member.id || member.UserID || member.value}"`;
+
+    // NÃO ResponsibleUser: só label
+    if (!this.isResponsibleUser) {
+      return `
+        <div class="user-selector__item" ${actionAttr} ${idAttr}>
+          <span class="user-selector__name">${name}</span>
+        </div>
+      `;
+    }
+
+    // ResponsibleUser: avatar/inicial/ícone de grupo
+    const photo = isAssign ? '' : (member.photoUrl || member.PhotoURL || member.PhotoUrl || member.photo || member.image || member.img || '');
+    const avatarHTML = isAssign
+      ? `<span style="font-size: 19px; " class="material-symbols-outlined user-selector__group-icon">groups</span>`
+      : (photo
+          ? `<img src="${photo}" alt="User Photo" />`
+          : `<span class="user-selector__initial">${this.getInitial(name)}</span>`);
+
+    return `
+      <div class="user-selector__item" ${actionAttr} ${idAttr}>
+        <div class="avatar-outer">
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">${avatarHTML}</div>
+          </div>
+        </div>
+        <span class="user-selector__name">${name}</span>
+      </div>
+    `;
+  }
+
+  // ---------------- Commit & AG Grid hooks (corrigido) ----------------
+  commitSelection(sel, meta = {}) {
+    // Normaliza o payload interno completo
+    const payload = (sel && typeof sel === 'object' && ('userid' in sel || 'groupid' in sel))
+      ? { userid: sel.userid ?? null, groupid: sel.groupid ?? null }
+      : { userid: sel ?? null, groupid: null };
+
+    const userId  = payload.userid ?? null;
+    const groupId = payload.groupid ?? null;
+
+    // Mantém payload completo internamente (para getValue/efeitos)
+    this.value = payload;
+
+    // Valor que vai para a célula desta coluna:
+    // - ResponsibleUserID: somente o userid
+    // - outras colunas: payload inteiro (mantém compatibilidade)
+    const nextCellValue = this.isResponsibleUser ? userId : payload;
+
+    // Atualiza dados da linha (campos auxiliares)
+    const row = this.params.data || {};
+    if (this.isResponsibleUser) {
+      // IDs
+      row.ResponsibleUserID = userId;
+      row.AssignedGroupID   = groupId;
+
+      // Nomes (usa meta se veio, senão resolve por datasource)
+      const resolvedUserName  = meta.userName  ?? this.getUserNameById(userId);
+      const resolvedGroupName = meta.groupName ?? this.getGroupNameById(groupId);
+
+      row.ResponsibleUser   = userId  ? resolvedUserName  : null;
+      row.AssignedGroupName = groupId ? resolvedGroupName : null;
+    }
+
+    // Atualiza a célula no grid
+    const colId = this.params.column?.getColId
+      ? this.params.column.getColId()
+      : this.params.column?.colId;
+
+    if (colId != null) {
+      if (this.params.node?.setDataValue) {
+        this.params.node.setDataValue(colId, nextCellValue);
+      } else if (this.params.data) {
+        this.params.data[colId] = nextCellValue;
+      }
+    }
+
+    // Força re-render de toda a linha (para refletir campos auxiliares)
+    if (this.params.api?.refreshCells) {
+      this.params.api.refreshCells({
+        rowNodes: this.params.node ? [this.params.node] : undefined,
+        force: true,
+      });
+    }
+
+    // Fecha o editor
+    if (this.params.api && this.params.api.stopEditing) {
+      this.params.api.stopEditing();
+    } else if (this.params.stopEditing) {
+      this.params.stopEditing();
+    }
+  }
+
+  async postGroupAndUser({ p_groupid, p_responsibleuserid }) {
+    try {
+      const p_ticketid = this.params?.data?.TicketID;
+      const p_loggeduserid = window?.wwLib?.wwVariable?.getValue?.('fc54ab80-1a04-4cfe-a504-793bdcfce5dd');
+      const sb = window?.wwLib?.wwPlugins?.supabase;
+      if (sb?.callPostgresFunction) {
+        await sb.callPostgresFunction({
+          functionName: 'postGroupAndUser',
+          params: {
+            p_ticketid,
+            p_groupid,
+            p_responsibleuserid,
+            p_loggeduserid,
+          },
+        });
+      }
+    } catch (e) {
+      
+    }
+  }
+
+  applyAvatarTheme() {
+    if (!this.eGui) return;
+    const theme = window?.wwLib?.wwVariable?.getValue?.('61c1b425-10e8-40dc-8f1f-b117c08b9726') || {};
+    const avatarBackground = theme?.bgButtonPrimary || '#4B6CB7';
+    const avatarShadow = theme?.primary || '#3A4663';
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-bg', avatarBackground);
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-shadow', avatarShadow);
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  afterGuiAttached() {
+    if (this.searchInput) this.searchInput.focus();
+  }
+
+  getValue() {
+    // Para ResponsibleUserID devolvemos apenas o userid.
+    if (this.isResponsibleUser) {
+      if (this.value && typeof this.value === 'object') {
+        return this.value.userid ?? null;
+      }
+      return this.value ?? null;
+    }
+    // Outras colunas podem continuar devolvendo o payload completo, se preciso
+    return this.value;
+  }
+
+  destroy() {}
+
+  isPopup() {
+    return true;
+  }
+
+  // CSS injetado (14px, wght 400, ícone groups centralizado)
+  injectCSSOnce() {
+    const id = '__fixed_list_user_selector_css_v2__';
+    const old = document.getElementById('__fixed_list_user_selector_css__');
+    if (old) old.remove();
+    if (document.getElementById(id)) return;
+
+    const style = document.createElement('style');
+    style.id = id;
+    style.textContent = `
+.user-selector-dropdown {
+  position: relative;
+  width: auto;
+  display: inline-block;
+  font-family: inherit;
+}
+.user-selector__dropdown {
+  position: relative;
+  width: 260px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px #0002;
+  z-index: 10;
+  padding: 8px 0 4px 0;
+  border: none;
+  display: flex;
+  flex-direction: column;
+}
+.editor-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  color: #6b7280;
+  z-index: 20;
+}
+
+/* Busca */
+.user-selector__search {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  position: relative;
+  padding: 0 12px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.user-selector__input {
+  flex: 1;
+  width: 100%;
+  padding: 8px 36px 8px 12px;
+  border-radius: 20px;
+  font-size: 14px;            /* 14px */
+  border: 1px solid #E0E0E0 !important;
+  background: #fff;
+  outline: none !important;
+  box-shadow: none !important;
+  transition: border 0.2s;
+  box-sizing: border-box;
+  font-weight: 400;           /* sem bold */
+}
+.user-selector__input:focus {
+  border: 1.5px solid #E0E0E0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+.user-selector__icon {
+  position: absolute;
+  right: 22px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 20px;
+  color: #888;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Cabeçalho do grupo (drill-in) */
+.user-selector__group-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px 4px;
+}
+.user-selector__back {
+  cursor: pointer;
+  font-size: 18px;
+  color: #444;
+}
+.user-selector__group-title {
+  flex: 1;
+  font-size: 14px;            /* 14px */
+  font-weight: 400;           /* sem bold */
+}
+.user-selector__group-count {
+  font-size: 12px;
+  padding: 0 12px 8px;
+  color: #888;
+}
+
+/* Lista */
+.user-selector__list {
+  max-height: 400px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+  font-size: 14px; 
+}
+.user-selector__list::-webkit-scrollbar { width: 6px; background: transparent; border-radius: 12px; }
+.user-selector__list::-webkit-scrollbar-thumb { background: #bdbdbd; border-radius: 12px; }
+.user-selector__list::-webkit-scrollbar-corner { background: transparent; }
+.user-selector__list::-webkit-scrollbar-button { display: none; height: 0; }
+
+/* Rótulo do agrupamento */
+.user-selector__group-label {
+  padding: 4px 12px;
+  color: #444;
+  font-size: 14px;            /* 14px */
+  font-weight: 400;           /* sem bold */
+}
+
+/* Itens dentro do agrupamento */
+.user-selector__group-items {
+  max-height: 130px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+.user-selector__group-items::-webkit-scrollbar { width: 6px; background: transparent; border-radius: 12px; }
+.user-selector__group-items::-webkit-scrollbar-thumb { background: #bdbdbd; border-radius: 12px; }
+.user-selector__group-items::-webkit-scrollbar-corner { background: transparent; }
+.user-selector__group-items::-webkit-scrollbar-button { display: none; height: 0; }
+
+/* Linha de item */
+.user-selector__item {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 6px;
+  transition: background 0.2s;
+  gap: 10px;
+  border: none;
+}
+.user-selector__item:hover { background: #f5f5f5; }
+
+/* Nome do usuário/grupo */
+.user-selector__name {
+  font-size: 13px;            /* 13px */
+  font-weight: 400;           /* sem bold */
+  color: #444;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 100%;
+  padding-left: 3px;
+}
+
+/* Avatares (usados só em ResponsibleUser) */
+.avatar-outer {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #FFFFFF;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  box-shadow: 0 0 0 1px var(--grid-view-dinamica-avatar-shadow, #3A4663);
+}
+.avatar-middle {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+.user-selector__avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--grid-view-dinamica-avatar-bg, #4B6CB7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.user-selector__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+/* Letra inicial */
+.user-selector__initial {
+  width: 100%; height: 100%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 15px;            /* 14px */
+  font-weight: 400;           /* sem bold */
+  background: transparent; color: #fff; border-radius: 50%; letter-spacing: .5px;
+}
+
+/* Ícone de grupo (centralizado) */
+.user-selector__group-icon {
+  font-size: 14px;            /* ajuste aqui se quiser 12/16/20 */
+  line-height: 1;
+  display: inline-block;
+  color: #fff;
+  font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+  padding-right: 2px;
+  padding-bottom: 1px;
+}
+
+/* Chevron direita */
+.user-selector__chevron {
+  margin-left: auto;
+  font-size: 18px;
+  color: #888;
+  cursor: pointer;
+}
+
+/* Sem resultados */
+.user-selector__no-results {
+  color: #aaa;
+  text-align: center;
+  padding: 8px 0;
+  font-size: 14px;
+}
+`;
+    document.head.appendChild(style);
+  }
+}

--- a/Project/TicketGrid/src/components/ResponsibleUserCellEditor.vue
+++ b/Project/TicketGrid/src/components/ResponsibleUserCellEditor.vue
@@ -1,0 +1,840 @@
+export default class ResponsibleUserCellEditor {
+  init(params) { 
+    this.params = params;
+
+    // Renderer params (mantém compatibilidade com seu formatter/styleArray)
+    const colDef = params.colDef || {};
+    this.rendererParams =
+      typeof colDef.cellRendererParams === 'function'
+        ? colDef.cellRendererParams(params)
+        : colDef.cellRendererParams || {};
+
+    // Estado
+    this.value = params.value;
+    this.searchTerm = '';
+    this.currentGroup = null;         // grupo em drill-in
+    this.currentGroupUsers = [];      // membros do grupo atual
+    this.groupStack = [];
+    this.groupBy = 'type';            // igual ao componente fornecido
+    this.searchPlaceholder = 'Search user or group...';
+
+    const tag =
+      (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toUpperCase();
+    const identifier = (colDef.FieldDB || '').toUpperCase();
+    this.isResponsibleUser = tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+
+    // Normalização das opções (mantém chaves extras intactas)
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
+        const labelKey = findKey('label') || findKey('name');
+        const valueKey = findKey('value') || findKey('id');
+        return {
+          ...opt,
+          value: valueKey ? opt[valueKey] : opt.value,
+          label: labelKey ? opt[labelKey] : opt.label || opt.name
+        };
+      }
+      return { value: opt, label: String(opt) };
+    };
+    const resolveOptions = (opts) => {
+      const arr = (opts || []).map(normalize);
+      this.options = arr;
+      this.filteredRoot = [...arr];
+      this.applyRootFilter();
+      this.render();
+    };
+
+    let optionsPromise;
+    if (params.options && typeof params.options.then === 'function') {
+      optionsPromise = params.options;
+    } else if (Array.isArray(params.options)) {
+      optionsPromise = Promise.resolve(params.options);
+    } else if (Array.isArray(colDef.listOptions)) {
+      optionsPromise = Promise.resolve(colDef.listOptions);
+    } else if (typeof colDef.listOptions === 'string' && colDef.listOptions.trim() !== '') {
+      optionsPromise = Promise.resolve(colDef.listOptions.split(',').map(o => o.trim()));
+    } else if (colDef.dataSource && typeof colDef.dataSource.list_options === 'string' && colDef.dataSource.list_options.trim() !== '') {
+      optionsPromise = Promise.resolve(colDef.dataSource.list_options.split(',').map(o => o.trim()));
+    } else {
+      optionsPromise = Promise.resolve([]);
+    }
+
+    this.options = [];
+    this.filteredRoot = [];
+    optionsPromise.then(resolveOptions);
+
+    // DOM
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'user-selector-dropdown'; // wrapper (mesmas classes)
+    this.applyAvatarTheme();
+    this.eGui.innerHTML = `
+      <div class="user-selector__dropdown" data-role="dropdown">
+        <div class="user-selector__search" data-role="search-row">
+          <input type="text" class="user-selector__input" placeholder="${this.searchPlaceholder}" />
+          <span class="material-symbols-outlined user-selector__icon">search</span>
+        </div>
+
+        <div class="user-selector__group-header" data-role="group-header" style="display:none;">
+          <span class="material-symbols-outlined user-selector__back" data-role="back-btn">chevron_left</span>
+          <span class="user-selector__group-title" data-role="group-title"></span>
+        </div>
+        <div class="user-selector__group-count" data-role="group-count" style="display:none;"></div>
+
+        <div class="user-selector__list" data-role="list"></div>
+        <div class="user-selector__no-results" data-role="no-results" style="display:none;">No user found</div>
+      </div>
+    `;
+
+    // Close (X) no topo da dropdown
+    const closeBtn = document.createElement('span');
+    closeBtn.className = 'editor-close';
+    closeBtn.innerHTML = '&times;';
+    closeBtn.addEventListener('click', () => {
+      if (this.params.api && this.params.api.stopEditing) this.params.api.stopEditing(true);
+      else if (this.params.stopEditing) this.params.stopEditing(true);
+    });
+    this.eGui.querySelector('[data-role="dropdown"]').prepend(closeBtn);
+
+    // Refs
+    this.searchRow   = this.eGui.querySelector('[data-role="search-row"]');
+    this.searchInput = this.eGui.querySelector('.user-selector__input');
+    this.groupHeader = this.eGui.querySelector('[data-role="group-header"]');
+    this.backBtn     = this.eGui.querySelector('[data-role="back-btn"]');
+    this.groupTitle  = this.eGui.querySelector('[data-role="group-title"]');
+    this.groupCount  = this.eGui.querySelector('[data-role="group-count"]');
+    this.listEl      = this.eGui.querySelector('[data-role="list"]');
+    this.noResultsEl = this.eGui.querySelector('[data-role="no-results"]');
+
+    // Eventos
+    this.searchInput.addEventListener('input', (e) => {
+      this.searchTerm = (e.target.value || '').toLowerCase();
+      this.applyRootFilter();
+      this.render();
+    });
+
+    this.backBtn.addEventListener('click', () => this.backToRoot());
+
+    // CSS (ajustado: 14px, wght 400, ícone groups centralizado)
+    this.injectCSSOnce();
+
+    // Render inicial (root)
+    this.applyRootFilter();
+    this.render();
+  }
+
+  // --------- HELPERS DE RESOLUÇÃO (nomes por id) ----------
+  findOptionById(id) {
+    if (id == null) return null;
+    const sid = String(id);
+    return (this.options || []).find(o => String(o.id ?? o.value) === sid) || null;
+  }
+  getGroupNameById(id) {
+    const opt = this.findOptionById(id);
+    return opt?.name || opt?.label || null;
+  }
+  getUserNameById(id) {
+    if (id == null) return null;
+    const sid = String(id);
+
+    // usuários na raiz
+    const rootUser = (this.options || []).find(
+      o => String(o.id ?? o.value) === sid && String(o?.type || '').toLowerCase() !== 'group'
+    );
+    if (rootUser) return rootUser.name || rootUser.label || null;
+
+    // membros de grupos
+    for (const g of (this.options || [])) {
+      if (String(g?.type || '').toLowerCase() === 'group' && Array.isArray(g.groupUsers)) {
+        const m = g.groupUsers.find(x => String(x.id ?? x.value ?? x.UserID) === sid);
+        if (m) return m.name || m.DisplayName || m.label || null;
+      }
+    }
+    return null;
+  }
+
+  // Busca na raiz (considera grupos e membros)
+  applyRootFilter() {
+    if (!this.searchTerm) {
+      this.filteredRoot = [...this.options];
+      return;
+    }
+    const q = this.searchTerm;
+    this.filteredRoot = this.options.filter(item => {
+      const type = String(item?.[this.groupBy] || '').toLowerCase();
+      const name = String(item?.name || item?.label || '').toLowerCase();
+
+      if (type === 'group') {
+        const groupNameMatch = name.includes(q);
+        const hasMemberMatch = (Array.isArray(item.groupUsers) ? item.groupUsers : [])
+          .some(m => String(m.name || m.DisplayName || m.label || '').toLowerCase().includes(q));
+        return groupNameMatch || hasMemberMatch;
+      }
+      return name.includes(q);
+    });
+  }
+
+  // Abrir grupo: "Assign to team" só em ResponsibleUser
+  openGroup(group) {
+    if (!group || !Array.isArray(group.groupUsers)) return;
+    this.groupStack.push(this.currentGroup);
+    this.currentGroup = group;
+
+    const members = group.groupUsers || [];
+    this.currentGroupUsers = this.isResponsibleUser
+      ? [{ id: null, name: 'Assign to team', isAssignToTeam: true }, ...members]
+      : members.slice();
+
+    // Em modo grupo, esconde busca (igual ao Vue)
+    this.searchTerm = '';
+    if (this.searchInput) this.searchInput.value = '';
+    this.render();
+  }
+
+  // Voltar
+  backToRoot() {
+    this.currentGroup = this.groupStack.pop() || null;
+    if (this.currentGroup) {
+      const members = this.currentGroup.groupUsers || [];
+      this.currentGroupUsers = this.isResponsibleUser
+        ? [{ id: null, name: 'Assign to team', isAssignToTeam: true }, ...members]
+        : members.slice();
+    } else {
+      this.currentGroupUsers = [];
+      this.applyRootFilter();
+    }
+    this.render();
+  }
+
+  // Helpers visuais / formatters
+  stripHtml(html) {
+    const tmp = document.createElement('div');
+    tmp.innerHTML = html;
+    return tmp.textContent || tmp.innerText || '';
+  }
+
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const it = colorArray.find(item => item.Valor === value);
+    if (!it) return value;
+    const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+    const fontweight = 'font-weight:bold;';
+    return `<span style="height:25px; color:${it.CorFonte}; background:${it.CorFundo}; border:1px solid ${it.CorFundo}; border-radius:${borderRadius}; ${fontweight} display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+      const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+      const d = new Date(dateValue);
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(d);
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(d);
+      return `${datePart} ${timePart}`;
+    } catch {
+      return dateValue;
+    }
+  }
+
+  formatOption(opt) {
+    const value = opt.label != null ? opt.label : opt.value;
+    const colDef = this.params.colDef || {};
+    const params = this.rendererParams || {};
+    try {
+      if (params.useCustomFormatter && typeof params.formatter === 'string') {
+        const fn = new Function(
+          'value',
+          'row',
+          'colDef',
+          'getRoundedSpanColor',
+          'dateFormatter',
+          params.formatter
+        );
+        return fn(value, {}, colDef, this.getRoundedSpanColor.bind(this), this.dateFormatter.bind(this));
+      } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+        const styled = this.getRoundedSpanColor(value, params.styleArray, colDef.FieldDB);
+        if (styled) return styled;
+      }
+    } catch {
+    }
+    return value;
+  }
+
+  getInitial(name) {
+    return name ? String(name).trim().charAt(0).toUpperCase() : '';
+  }
+
+  isGroupLabelText(label) {
+    const v = String(label || '').toUpperCase();
+    return ['GROUP', 'GROUPS', 'GRUPO', 'GRUPOS'].includes(v);
+  }
+
+  // Agrupamento por this.groupBy (root)
+  groupRootItems(items) {
+    if (!items || !items.length) return { groups: [], ungrouped: [] };
+    const groups = new Map();
+    const ungrouped = [];
+
+    for (const u of items) {
+      const key = u?.[this.groupBy];
+      if (key === undefined || key === null || key === '') {
+        ungrouped.push(u);
+      } else {
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(u);
+      }
+    }
+
+    return {
+      groups: Array.from(groups, ([label, items]) => ({ label, items })),
+      ungrouped
+    };
+  }
+
+  // Render master
+  render() {
+    if (this.currentGroup) {
+      this.searchRow.style.display = 'none';
+      this.groupHeader.style.display = '';
+      this.groupTitle.textContent = this.currentGroup.name || '';
+      const count = (this.currentGroup.groupUsers || []).length || 0;
+      this.groupCount.style.display = '';
+      this.groupCount.textContent = `${count} ${count === 1 ? 'member' : 'members'}`;
+      this.renderGroupView();
+    } else {
+      this.searchRow.style.display = '';
+      this.groupHeader.style.display = 'none';
+      this.groupCount.style.display = 'none';
+      this.renderRootView();
+    }
+  }
+
+  // ROOT VIEW
+  renderRootView() {
+    const { groups, ungrouped } = this.groupRootItems(this.filteredRoot);
+    let html = '';
+
+    // Grupos (Users / Group)
+    for (const group of groups) {
+      const showLabel = !['USERS', 'USER', 'USUARIOS', 'USUÁRIO', 'USUÁRIOS'].includes(String(group.label || '').toUpperCase());
+      html += `
+        <div class="user-selector__group">
+          <div class="user-selector__group-label">${showLabel ? (group.label || '') : ''}</div>
+          <div class="user-selector__group-items">
+            ${group.items.map(u => this.renderRootItem(u, group.label)).join('')}
+          </div>
+        </div>
+      `;
+    }
+
+    // Itens sem grupo
+    html += ungrouped.map(u => this.renderRootItem(u, '')).join('');
+
+    this.listEl.innerHTML = html || '';
+    this.noResultsEl.style.display = (html.trim() === '') ? '' : 'none';
+
+    // Bind cliques (root)
+    this.listEl.querySelectorAll('[data-action="open-group"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.getAttribute('data-id');
+        const grp = this.filteredRoot.find(x => String(x.id || x.value) === id);
+        if (grp) this.openGroup(grp);
+      });
+    });
+
+    this.listEl.querySelectorAll('[data-action="select-user"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const val = btn.getAttribute('data-id');
+        // callback opcional
+        if (typeof this.params.colDef?.onSelect === 'function') {
+          try { this.params.colDef.onSelect({ userid: val, groupid: null }, this.params); } catch {}
+        }
+        this.postGroupAndUser({ p_groupid: null, p_responsibleuserid: val });
+        const selected = this.options.find(u => String(u.id || u.value) === String(val));
+        this.commitSelection({ userid: val, groupid: null }, {
+          userName: selected?.name || selected?.label || '',
+          groupName: null,
+        });
+      });
+    });
+  }
+
+  // Item na raiz (agrupado): avatar só quando for ResponsibleUser
+  renderRootItem(user, groupLabel) {
+    const formatted = this.formatOption(user);
+    const plain = this.stripHtml(String(formatted));
+    const hasChildren = Array.isArray(user.groupUsers) && user.groupUsers.length > 0;
+    const isGroupType = this.isGroupLabelText(groupLabel) || String(user?.[this.groupBy] || '').toUpperCase() === 'GROUP';
+
+    const actionAttr = (hasChildren || isGroupType)
+      ? 'data-action="open-group"'
+      : 'data-action="select-user"';
+    const chevron = hasChildren
+      ? `<span class="material-symbols-outlined user-selector__chevron" ${actionAttr} data-id="${user.id || user.value}">chevron_right</span>`
+      : '';
+
+    // NÃO ResponsibleUser: só label (mantém HTML do formatter)
+    if (!this.isResponsibleUser) {
+      return `
+        <div class="user-selector__item" ${actionAttr} data-id="${user.id || user.value}">
+          <span class="user-selector__name">${formatted}</span>
+          ${chevron}
+        </div>
+      `;
+    }
+
+    // ResponsibleUser: avatar/inicial/ícone de grupo
+    const photo = user.photoUrl || user.PhotoURL || user.PhotoUrl || user.photo || user.image || user.img || '';
+    const avatarHTML = isGroupType
+      ? `<span style="font-size: 19px; padding-top:3px; padding-left:3px" class="material-symbols-outlined user-selector__group-icon">groups</span>`
+      : (photo
+          ? `<img src="${photo}" alt="User Photo" />`
+          : `<span class="user-selector__initial">${this.getInitial(user.name || plain)}</span>`);
+
+    return `
+      <div class="user-selector__item" ${actionAttr} data-id="${user.id || user.value}">
+        <div class="avatar-outer">
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">${avatarHTML}</div>
+          </div>
+        </div>
+        <span class="user-selector__name">${formatted}</span>
+        ${chevron}
+      </div>
+    `;
+  }
+
+  // GROUP VIEW
+  renderGroupView() {
+    // renderiza a lista do grupo atual (com "Assign to team" no topo apenas em ResponsibleUser)
+    const list = this.currentGroupUsers || [];
+    this.listEl.innerHTML = list.map(member => this.renderGroupMember(member)).join('') || '';
+    this.noResultsEl.style.display = (list.length === 0) ? '' : 'none';
+
+    // Bind cliques (grupo)
+    this.listEl.querySelectorAll('[data-action="assign-team"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const payload = { userid: null, groupid: this.currentGroup.id };
+        if (typeof this.params.colDef?.onSelect === 'function') {
+          try { this.params.colDef.onSelect(payload, this.params); } catch {}
+        }
+        this.postGroupAndUser({ p_groupid: this.currentGroup.id, p_responsibleuserid: null });
+        this.commitSelection(payload, {
+          userName: null,
+          groupName: this.currentGroup?.name || '',
+        });
+      });
+    });
+
+    this.listEl.querySelectorAll('[data-action="select-user"]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const userId = btn.getAttribute('data-id');
+        const payload = { userid: userId, groupid: this.currentGroup.id };
+        if (typeof this.params.colDef?.onSelect === 'function') {
+          try { this.params.colDef.onSelect(payload, this.params); } catch {}
+        }
+        this.postGroupAndUser({ p_groupid: this.currentGroup.id, p_responsibleuserid: userId });
+
+        const member = (this.currentGroup.groupUsers || []).find(m => String(m.id || m.UserID || m.value) === String(userId));
+        this.commitSelection(payload, {
+          userName: member?.name || member?.DisplayName || member?.label || '',
+          groupName: this.currentGroup?.name || '',
+        });
+      });
+    });
+  }
+
+  // Item de membro do grupo: avatar só quando for ResponsibleUser
+  renderGroupMember(member) {
+    const isAssign = !!member.isAssignToTeam;
+    const name = isAssign ? 'Assign to team' : (member.name || member.DisplayName || member.label || '');
+    const actionAttr = isAssign ? 'data-action="assign-team"' : 'data-action="select-user"';
+    const idAttr = isAssign ? '' : `data-id="${member.id || member.UserID || member.value}"`;
+
+    // NÃO ResponsibleUser: só label
+    if (!this.isResponsibleUser) {
+      return `
+        <div class="user-selector__item" ${actionAttr} ${idAttr}>
+          <span class="user-selector__name">${name}</span>
+        </div>
+      `;
+    }
+
+    // ResponsibleUser: avatar/inicial/ícone de grupo
+    const photo = isAssign ? '' : (member.photoUrl || member.PhotoURL || member.PhotoUrl || member.photo || member.image || member.img || '');
+    const avatarHTML = isAssign
+      ? `<span style="font-size: 19px; " class="material-symbols-outlined user-selector__group-icon">groups</span>`
+      : (photo
+          ? `<img src="${photo}" alt="User Photo" />`
+          : `<span class="user-selector__initial">${this.getInitial(name)}</span>`);
+
+    return `
+      <div class="user-selector__item" ${actionAttr} ${idAttr}>
+        <div class="avatar-outer">
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">${avatarHTML}</div>
+          </div>
+        </div>
+        <span class="user-selector__name">${name}</span>
+      </div>
+    `;
+  }
+
+  // ---------------- Commit & AG Grid hooks (corrigido) ----------------
+  commitSelection(sel, meta = {}) {
+    // Normaliza o payload interno completo
+    const payload = (sel && typeof sel === 'object' && ('userid' in sel || 'groupid' in sel))
+      ? { userid: sel.userid ?? null, groupid: sel.groupid ?? null }
+      : { userid: sel ?? null, groupid: null };
+
+    const userId  = payload.userid ?? null;
+    const groupId = payload.groupid ?? null;
+
+    // Mantém payload completo internamente (para getValue/efeitos)
+    this.value = payload;
+
+    // Valor que vai para a célula desta coluna:
+    // - ResponsibleUserID: somente o userid
+    // - outras colunas: payload inteiro (mantém compatibilidade)
+    const nextCellValue = this.isResponsibleUser ? userId : payload;
+
+    // Atualiza dados da linha (campos auxiliares)
+    const row = this.params.data || {};
+    if (this.isResponsibleUser) {
+      // IDs
+      row.ResponsibleUserID = userId;
+      row.AssignedGroupID   = groupId;
+
+      // Nomes (usa meta se veio, senão resolve por datasource)
+      const resolvedUserName  = meta.userName  ?? this.getUserNameById(userId);
+      const resolvedGroupName = meta.groupName ?? this.getGroupNameById(groupId);
+
+      row.ResponsibleUser   = userId  ? resolvedUserName  : null;
+      row.AssignedGroupName = groupId ? resolvedGroupName : null;
+    }
+
+    // Atualiza a célula no grid
+    const colId = this.params.column?.getColId
+      ? this.params.column.getColId()
+      : this.params.column?.colId;
+
+    if (colId != null) {
+      if (this.params.node?.setDataValue) {
+        this.params.node.setDataValue(colId, nextCellValue);
+      } else if (this.params.data) {
+        this.params.data[colId] = nextCellValue;
+      }
+    }
+
+    // Força re-render de toda a linha (para refletir campos auxiliares)
+    if (this.params.api?.refreshCells) {
+      this.params.api.refreshCells({
+        rowNodes: this.params.node ? [this.params.node] : undefined,
+        force: true,
+      });
+    }
+
+    // Fecha o editor
+    if (this.params.api && this.params.api.stopEditing) {
+      this.params.api.stopEditing();
+    } else if (this.params.stopEditing) {
+      this.params.stopEditing();
+    }
+  }
+
+  async postGroupAndUser({ p_groupid, p_responsibleuserid }) {
+    try {
+      const p_ticketid = this.params?.data?.TicketID;
+      const p_loggeduserid = window?.wwLib?.wwVariable?.getValue?.('fc54ab80-1a04-4cfe-a504-793bdcfce5dd');
+      const sb = window?.wwLib?.wwPlugins?.supabase;
+      if (sb?.callPostgresFunction) {
+        await sb.callPostgresFunction({
+          functionName: 'postGroupAndUser',
+          params: {
+            p_ticketid,
+            p_groupid,
+            p_responsibleuserid,
+            p_loggeduserid,
+          },
+        });
+      }
+    } catch {
+    }
+  }
+
+  applyAvatarTheme() {
+    if (!this.eGui) return;
+    const theme = window?.wwLib?.wwVariable?.getValue?.('61c1b425-10e8-40dc-8f1f-b117c08b9726') || {};
+    const avatarBackground = theme?.bgButtonPrimary || '#4B6CB7';
+    const avatarShadow = theme?.primary || '#3A4663';
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-bg', avatarBackground);
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-shadow', avatarShadow);
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  afterGuiAttached() {
+    if (this.searchInput) this.searchInput.focus();
+  }
+
+  getValue() {
+    // Para ResponsibleUserID devolvemos apenas o userid.
+    if (this.isResponsibleUser) {
+      if (this.value && typeof this.value === 'object') {
+        return this.value.userid ?? null;
+      }
+      return this.value ?? null;
+    }
+    // Outras colunas podem continuar devolvendo o payload completo, se preciso
+    return this.value;
+  }
+
+  destroy() {}
+
+  isPopup() {
+    return true;
+  }
+
+  // CSS injetado (14px, wght 400, ícone groups centralizado)
+  injectCSSOnce() {
+    const id = '__fixed_list_user_selector_css_v2__';
+    const old = document.getElementById('__fixed_list_user_selector_css__');
+    if (old) old.remove();
+    if (document.getElementById(id)) return;
+
+    const style = document.createElement('style');
+    style.id = id;
+    style.textContent = `
+.user-selector-dropdown {
+  position: relative;
+  width: auto;
+  display: inline-block;
+  font-family: inherit;
+}
+.user-selector__dropdown {
+  position: relative;
+  width: 260px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px #0002;
+  z-index: 10;
+  padding: 8px 0 4px 0;
+  border: none;
+  display: flex;
+  flex-direction: column;
+}
+.editor-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  color: #6b7280;
+  z-index: 20;
+}
+
+/* Busca */
+.user-selector__search {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  position: relative;
+  padding: 0 12px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.user-selector__input {
+  flex: 1;
+  width: 100%;
+  padding: 8px 36px 8px 12px;
+  border-radius: 20px;
+  font-size: 14px;            /* 14px */
+  border: 1px solid #E0E0E0 !important;
+  background: #fff;
+  outline: none !important;
+  box-shadow: none !important;
+  transition: border 0.2s;
+  box-sizing: border-box;
+  font-weight: 400;           /* sem bold */
+}
+.user-selector__input:focus {
+  border: 1.5px solid #E0E0E0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+.user-selector__icon {
+  position: absolute;
+  right: 22px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 20px;
+  color: #888;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Cabeçalho do grupo (drill-in) */
+.user-selector__group-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px 4px;
+}
+.user-selector__back {
+  cursor: pointer;
+  font-size: 18px;
+  color: #444;
+}
+.user-selector__group-title {
+  flex: 1;
+  font-size: 14px;            /* 14px */
+  font-weight: 400;           /* sem bold */
+}
+.user-selector__group-count {
+  font-size: 12px;
+  padding: 0 12px 8px;
+  color: #888;
+}
+
+/* Lista */
+.user-selector__list {
+  max-height: 400px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+  font-size: 14px; 
+}
+.user-selector__list::-webkit-scrollbar { width: 6px; background: transparent; border-radius: 12px; }
+.user-selector__list::-webkit-scrollbar-thumb { background: #bdbdbd; border-radius: 12px; }
+.user-selector__list::-webkit-scrollbar-corner { background: transparent; }
+.user-selector__list::-webkit-scrollbar-button { display: none; height: 0; }
+
+/* Rótulo do agrupamento */
+.user-selector__group-label {
+  padding: 4px 12px;
+  color: #444;
+  font-size: 14px;            /* 14px */
+  font-weight: 400;           /* sem bold */
+}
+
+/* Itens dentro do agrupamento */
+.user-selector__group-items {
+  max-height: 130px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+.user-selector__group-items::-webkit-scrollbar { width: 6px; background: transparent; border-radius: 12px; }
+.user-selector__group-items::-webkit-scrollbar-thumb { background: #bdbdbd; border-radius: 12px; }
+.user-selector__group-items::-webkit-scrollbar-corner { background: transparent; }
+.user-selector__group-items::-webkit-scrollbar-button { display: none; height: 0; }
+
+/* Linha de item */
+.user-selector__item {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 6px;
+  transition: background 0.2s;
+  gap: 10px;
+  border: none;
+}
+.user-selector__item:hover { background: #f5f5f5; }
+
+/* Nome do usuário/grupo */
+.user-selector__name {
+  font-size: 13px;            /* 13px */
+  font-weight: 400;           /* sem bold */
+  color: #444;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 100%;
+  padding-left: 3px;
+}
+
+/* Avatares (usados só em ResponsibleUser) */
+.avatar-outer {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #FFFFFF;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  box-shadow: 0 0 0 1px var(--grid-view-dinamica-avatar-shadow, #3A4663);
+}
+.avatar-middle {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+.user-selector__avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--grid-view-dinamica-avatar-bg, #4B6CB7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.user-selector__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+/* Letra inicial */
+.user-selector__initial {
+  width: 100%; height: 100%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 15px;            /* 14px */
+  font-weight: 400;           /* sem bold */
+  background: transparent; color: #fff; border-radius: 50%; letter-spacing: .5px;
+}
+
+/* Ícone de grupo (centralizado) */
+.user-selector__group-icon {
+  font-size: 14px;            /* ajuste aqui se quiser 12/16/20 */
+  line-height: 1;
+  display: inline-block;
+  color: #fff;
+  font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24;
+  padding-right: 2px;
+  padding-bottom: 1px;
+}
+
+/* Chevron direita */
+.user-selector__chevron {
+  margin-left: auto;
+  font-size: 18px;
+  color: #888;
+  cursor: pointer;
+}
+
+/* Sem resultados */
+.user-selector__no-results {
+  color: #aaa;
+  text-align: center;
+  padding: 8px 0;
+  font-size: 14px;
+}
+`;
+    document.head.appendChild(style);
+  }
+}

--- a/Project/TicketGrid/src/components/ResponsibleUserCellRenderer.js
+++ b/Project/TicketGrid/src/components/ResponsibleUserCellRenderer.js
@@ -1,0 +1,726 @@
+import { translatePhrase } from "../translation";
+
+export default class ResponsibleUserFilterRenderer {
+  constructor() {
+    this.searchText = '';
+    this.selectedValues = [];
+    this.allValues = [];
+    this.filteredValues = [];
+    this.selectAll = false;
+    // key -> { type: 'responsible'|'group', id, name, photo }
+
+    this.userInfo = {};
+    this.lookupByRawValue = new Map();
+  }
+
+  init(params) {
+    this.params = params;
+    this.loadValues();
+    this.createGui();
+  }
+
+  createGui() {
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'list-filter';
+    this.applyAvatarTheme();
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" placeholder="${translatePhrase("Search...")}" class="search-input" />
+        <span class="search-icon">
+          <i class="material-symbols-outlined-search">search</i>
+        </span>
+      </div>
+      <div class="select-all-row">
+        <label>
+          <input type="checkbox" class="select-all-checkbox" />
+          <span>${translatePhrase("Select all")}</span>
+        </label>
+      </div>
+      <div class="filter-list"></div>
+    `;
+
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.filterList = this.eGui.querySelector('.filter-list');
+    this.selectAllCheckbox = this.eGui.querySelector('.select-all-checkbox');
+
+    this.setupEventListeners();
+    this.renderFilterList();
+  }
+
+  applyAvatarTheme() {
+    if (!this.eGui) return;
+    const theme = window?.wwLib?.wwVariable?.getValue?.('61c1b425-10e8-40dc-8f1f-b117c08b9726') || {};
+    const avatarBackground = theme?.bgButtonPrimary || '#4B6CB7';
+    const avatarShadow = theme?.primary || '#3A4663';
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-bg', avatarBackground);
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-shadow', avatarShadow);
+  }
+
+  setupEventListeners() {
+    this.searchInput.addEventListener('input', (e) => {
+      this.searchText = e.target.value;
+      this.filterValues();
+    });
+
+    this.selectAllCheckbox.addEventListener('change', (e) => {
+      if (e.target.checked) {
+        this.selectedValues = [...this.filteredValues];
+      } else {
+        this.selectedValues = [];
+      }
+      this.renderFilterList();
+      this.applyFilter();
+    });
+  }
+
+  // Função utilitária para acessar campos aninhados
+  getNestedValue(obj, path) {
+    return path.split('.').reduce((o, p) => (o && o[p] !== undefined ? o[p] : undefined), obj);
+  }
+
+  // Função auxiliar igual ao FormatterCellRenderer
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+    const fontweight = "font-weight:bold;";
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric'
+      };
+      const timeOptions = {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(new Date(dateValue));
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(new Date(dateValue));
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  getOptionsArray() {
+    const params = this.params || {};
+    const colDef = params.colDef || params.column?.getColDef?.() || {};
+    let options = [];
+
+    if (Array.isArray(params.options)) options = params.options;
+    else if (Array.isArray(colDef.listOptions)) options = colDef.listOptions;
+    else if (typeof colDef.listOptions === 'string' && colDef.listOptions.trim()) {
+      options = colDef.listOptions.split(',').map(o => o.trim());
+    } else if (
+      colDef.dataSource &&
+      typeof colDef.dataSource.list_options === 'string' &&
+      colDef.dataSource.list_options.trim()
+    ) {
+      options = colDef.dataSource.list_options.split(',').map(o => o.trim());
+    }
+
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = keys => Object.keys(opt).find(k => keys.includes(k.toLowerCase()));
+        const labelKey = findKey(['label', 'name', 'displayname', 'display_name']);
+        const valueKey = findKey(['value', 'id', 'userid', 'user_id']);
+        const typeKey = findKey(['type']);
+        const groupUsersKey = findKey(['groupusers', 'group_users']);
+        const normalized = {
+          ...opt,
+          id: opt.id ?? opt.value ?? (valueKey ? opt[valueKey] : undefined),
+          name: opt.name ?? opt.label ?? (labelKey ? opt[labelKey] : undefined),
+          type: opt.type ?? (typeKey ? opt[typeKey] : undefined)
+        };
+        if (groupUsersKey && Array.isArray(opt[groupUsersKey])) {
+          normalized.groupUsers = opt[groupUsersKey].map(normalize);
+        }
+        return normalized;
+      }
+      return { id: opt, name: String(opt) };
+    };
+
+    return (options || []).map(normalize);
+  }
+
+  shouldUseResponsibleCollection(identifier, tag) {
+    const targets = new Set(['RESPONSIBLEUSERID', 'XXXXXX']);
+    return targets.has(identifier) || targets.has(tag);
+  }
+
+  getResponsibleCollectionOptions() {
+    const COLLECTION_ID = '0e41f029-e1c3-4302-82ca-16aceccdadb1';
+    try {
+      const collection = window?.wwLib?.wwCollection?.getCollection?.(COLLECTION_ID);
+      const data = collection?.data;
+      if (!Array.isArray(data)) {
+        return [];
+      }
+      return data
+        .map(item => this.normalizeCollectionEntry(item))
+        .filter(item => item);
+    } catch (error) {
+      
+      return [];
+    }
+  }
+
+  normalizeCollectionEntry(item) {
+    if (item === undefined || item === null) {
+      return null;
+    }
+
+    if (typeof item !== 'object') {
+      const value = this.ensureDisplayText(item);
+      if (!value) return null;
+      return {
+        id: value,
+        name: value,
+        type: 'responsible',
+        photo: '',
+        matchCandidates: [value],
+      };
+    }
+
+    const name = this.ensureDisplayText(item.name ?? item.Name ?? item.label ?? item.Label);
+    if (!name) {
+      return null;
+    }
+
+    const id = item.id ?? item.Id ?? item.ID ?? item.value ?? item.Value ?? name;
+    const photo = item.photoUrl || item.PhotoUrl || item.PhotoURL || item.photo || item.image || item.img || '';
+    const type = item.type ?? item.Type ?? 'responsible';
+    const matchCandidates = this.extractCollectionMatchCandidates(item);
+
+    return {
+      id,
+      name,
+      type,
+      photo,
+      matchCandidates,
+    };
+  }
+
+  extractCollectionMatchCandidates(item) {
+    if (!item || typeof item !== 'object') return [];
+    const keys = [
+      'id',
+      'Id',
+      'ID',
+      'value',
+      'Value',
+      'name',
+      'Name',
+      'label',
+      'Label',
+      'username',
+      'Username',
+      'userName',
+      'UserName',
+      'displayName',
+      'DisplayName',
+      'userid',
+      'userId',
+      'user_id',
+      'email',
+      'Email',
+    ];
+    const candidates = [];
+    keys.forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(item, key)) {
+        candidates.push(item[key]);
+      }
+    });
+    return candidates;
+  }
+
+  normalizeOptionType(type) {
+    const text = this.ensureDisplayText(type).toLowerCase();
+    if (!text) return 'responsible';
+    if (text.includes('group') || text === 'g' || text.includes('grupo')) {
+      return 'group';
+    }
+    return 'responsible';
+  }
+
+  buildEntryKey(type, id, name) {
+    const baseCandidate = id !== undefined && id !== null && id !== ''
+      ? this.ensureDisplayText(id)
+      : this.ensureDisplayText(name);
+    if (!baseCandidate) return null;
+    return `${type}-${baseCandidate}`;
+  }
+
+  ensureDisplayText(value) {
+    if (value === undefined || value === null) return '';
+    if (typeof value === 'string') {
+      return value.trim();
+    }
+    return String(value).trim();
+  }
+
+  normalizeLookupValue(value) {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      return trimmed.toLowerCase();
+    }
+    try {
+      const str = String(value).trim();
+      if (!str) return null;
+      return str.toLowerCase();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  pickFirstCandidate(candidates) {
+    if (!Array.isArray(candidates)) return '';
+    for (const candidate of candidates) {
+      const display = this.ensureDisplayText(candidate);
+      if (display) return display;
+    }
+    return '';
+  }
+
+  ingestOptionList(options) {
+    if (!Array.isArray(options)) return;
+    options.forEach(opt => this.ingestOption(opt));
+  }
+
+  ingestOption(opt) {
+    if (opt === undefined || opt === null) return;
+
+    if (typeof opt !== 'object') {
+      const value = this.ensureDisplayText(opt);
+      if (!value) return;
+      this.registerEntry({ type: 'responsible', id: value, name: value, photo: '' }, [value]);
+      return;
+    }
+
+    const type = this.normalizeOptionType(opt.type);
+    const idCandidate = opt.id ?? opt.Id ?? opt.ID ?? opt.value ?? opt.Value ?? opt.UserID ?? opt.UserId ?? opt.userid ?? opt.user_id;
+    const optionNames = [
+      opt.name,
+      opt.Name,
+      opt.label,
+      opt.Label,
+      opt.displayName,
+      opt.DisplayName,
+      opt.fullName,
+      opt.FullName,
+      opt.username,
+      opt.Username,
+      opt.userName,
+      opt.UserName,
+    ];
+    const name = this.pickFirstCandidate([...optionNames, idCandidate]);
+    const photo = opt.photoUrl || opt.PhotoUrl || opt.PhotoURL || opt.photo || opt.image || opt.img || '';
+    const extraMatches = Array.isArray(opt.matchCandidates) ? opt.matchCandidates : [];
+    const matchCandidates = [
+      idCandidate,
+      opt.id,
+      opt.Id,
+      opt.ID,
+      opt.value,
+      opt.Value,
+      opt.UserID,
+      opt.UserId,
+      opt.userid,
+      opt.user_id,
+      ...optionNames,
+      ...extraMatches,
+    ];
+
+    this.registerEntry({ type, id: idCandidate ?? name, name, photo }, matchCandidates);
+
+    if (type === 'group' && Array.isArray(opt.groupUsers)) {
+      opt.groupUsers.forEach(user => {
+        if (user === undefined || user === null) return;
+        if (typeof user === 'object') {
+          this.ingestOption({ ...user, type: 'responsible' });
+        } else {
+          const normalizedUser = this.ensureDisplayText(user);
+          if (normalizedUser) {
+            this.registerEntry({ type: 'responsible', id: normalizedUser, name: normalizedUser, photo: '' }, [normalizedUser]);
+          }
+        }
+      });
+    }
+  }
+
+  registerEntry(details, matchCandidates = []) {
+    if (!details) return;
+    const type = this.normalizeOptionType(details.type);
+    const key = this.buildEntryKey(type, details.id, details.name);
+    if (!key) return;
+
+    const resolvedName = this.ensureDisplayText(details.name) || this.ensureDisplayText(details.id);
+    if (!resolvedName) return;
+
+    if (!this.userInfo[key]) {
+      this.userInfo[key] = {
+        type,
+        id: details.id ?? resolvedName,
+        name: resolvedName,
+        photo: details.photo || '',
+        matchValues: new Set(),
+      };
+    } else {
+      const info = this.userInfo[key];
+      info.type = type;
+      if ((!info.name || !info.name.trim()) && resolvedName) info.name = resolvedName;
+      if ((info.id === undefined || info.id === null || info.id === '') && details.id !== undefined && details.id !== null && details.id !== '') {
+        info.id = details.id;
+      }
+      if (!info.photo && details.photo) info.photo = details.photo;
+      if (!info.matchValues) info.matchValues = new Set();
+    }
+
+    const info = this.userInfo[key];
+    const allMatches = [
+      details.id,
+      details.name,
+      resolvedName,
+      ...(Array.isArray(matchCandidates) ? matchCandidates : []),
+    ];
+    allMatches.forEach(value => this.addMatchValue(info, key, value));
+  }
+
+  addMatchValue(info, key, rawValue) {
+    if (!info || rawValue === undefined || rawValue === null) return;
+    if (Array.isArray(rawValue)) {
+      rawValue.forEach(value => this.addMatchValue(info, key, value));
+      return;
+    }
+
+    const normalized = this.normalizeLookupValue(rawValue);
+    if (!normalized) return;
+
+    if (!info.matchValues) info.matchValues = new Set();
+    info.matchValues.add(normalized);
+
+    let matches = this.lookupByRawValue.get(normalized);
+    if (!matches) {
+      matches = new Set();
+      this.lookupByRawValue.set(normalized, matches);
+    }
+    matches.add(key);
+  }
+
+  populateFromRowData(api, colDef) {
+    const field = colDef.field || this.params.column.getColId();
+    if (!api || (api.isDestroyed && api.isDestroyed())) return;
+
+    api.forEachNode(node => {
+      const data = node?.data;
+      if (!data) return;
+
+      const userValue = this.getNestedValue(data, field);
+      const userNameCandidates = [
+        data.ResponsibleUser,
+        data.ResponsibleUserName,
+        data.Username,
+        data.UserName,
+        data.UserFullName,
+        data.AssignedUser,
+        data.AssignedUserName,
+      ];
+      const userPhoto = data.photoUrl || data.PhotoUrl || data.PhotoURL || data.UserPhoto || '';
+      const userName = this.pickFirstCandidate([...userNameCandidates, userValue]);
+      this.registerEntry(
+        { type: 'responsible', id: userValue, name: userName, photo: userPhoto },
+        [userValue, ...userNameCandidates]
+      );
+
+      const groupIdCandidates = [data.AssignedGroupID, data.GroupID, data.groupid];
+      const groupNameCandidates = [
+        data.AssignedGroupName,
+        data.GroupName,
+        data.Group,
+        data.groupname,
+      ];
+      const groupId = this.pickFirstCandidate(groupIdCandidates);
+      const groupName = this.pickFirstCandidate([...groupNameCandidates, groupId]);
+      const groupPhoto = data.groupPhoto || data.GroupPhoto || data.GroupImage || '';
+      this.registerEntry(
+        { type: 'group', id: groupId, name: groupName, photo: groupPhoto },
+        [...groupIdCandidates, ...groupNameCandidates]
+      );
+    });
+  }
+
+  collectMatchesFromValue(value, resultSet) {
+    if (!this.lookupByRawValue || !resultSet) return;
+    if (Array.isArray(value)) {
+      value.forEach(item => this.collectMatchesFromValue(item, resultSet));
+      return;
+    }
+    const normalized = this.normalizeLookupValue(value);
+    if (!normalized) return;
+    const matches = this.lookupByRawValue.get(normalized);
+    if (!matches) return;
+    matches.forEach(key => resultSet.add(key));
+  }
+
+  finalizeUserInfo() {
+    const respKeys = [];
+    const groupKeys = [];
+    Object.keys(this.userInfo).forEach(key => {
+      const info = this.userInfo[key];
+      if (!info) return;
+      if (!info.matchValues) info.matchValues = new Set();
+      if (info.name) {
+        info.name = this.ensureDisplayText(info.name);
+      }
+      if (!info.name) {
+        const fallback = this.ensureDisplayText(info.id);
+        if (fallback) info.name = fallback;
+      }
+      this.addMatchValue(info, key, info.name);
+      this.addMatchValue(info, key, info.id);
+
+      if (info.type === 'group') groupKeys.push(key);
+      else respKeys.push(key);
+    });
+
+    const sortByName = (a, b) => {
+      const na = (this.userInfo[a]?.name || '').toLowerCase();
+      const nb = (this.userInfo[b]?.name || '').toLowerCase();
+      return na.localeCompare(nb, undefined, { sensitivity: 'base' });
+    };
+
+    respKeys.sort(sortByName);
+    groupKeys.sort(sortByName);
+
+    this.allValues = [...respKeys, ...groupKeys];
+    this.filteredValues = [...this.allValues];
+    this.selectedValues = this.selectedValues.filter(value => this.userInfo[value]);
+  }
+
+  loadValues() {
+    const api = this.params.api;
+    this.userInfo = {};
+    this.lookupByRawValue = new Map();
+
+    const column = this.params.column;
+    const colDef = column?.getColDef?.() || {};
+    const identifier = (colDef.FieldDB || '').toString().toUpperCase();
+    const tag = (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toString().toUpperCase();
+
+    let options = [];
+    if (this.shouldUseResponsibleCollection(identifier, tag)) {
+      options = this.getResponsibleCollectionOptions();
+    }
+
+    if (!Array.isArray(options) || !options.length) {
+      options = this.getOptionsArray();
+    }
+
+    this.ingestOptionList(options);
+    this.populateFromRowData(api, colDef);
+    this.finalizeUserInfo();
+  }
+
+  filterValues() {
+    if (!this.searchText) {
+      this.filteredValues = [...this.allValues];
+    } else {
+      const q = this.searchText.toLowerCase();
+      this.filteredValues = this.allValues.filter(key => {
+        const info = this.userInfo[key] || {};
+        const target = (info.name || '').toLowerCase();
+        return target.includes(q);
+
+      });
+    }
+    this.renderFilterList();
+  }
+
+  renderFilterList() {
+    const selected = new Set(this.selectedValues);
+    this.selectAllCheckbox.checked =
+      this.filteredValues.length > 0 &&
+      this.filteredValues.every(v => selected.has(v));
+
+    const respHtml = [];
+
+    const groupHtml = [];
+
+    this.filteredValues.forEach(key => {
+      const info = this.userInfo[key] || {};
+      const checked = selected.has(key) ? 'checked' : '';
+      const name = this.ensureDisplayText(info.name || info.id || '');
+      const photo = info.photo;
+      const initialSource = this.ensureDisplayText(name);
+      const initial = initialSource ? initialSource.charAt(0).toUpperCase() : '';
+      const avatar = photo
+
+        ? `<img src="${photo}" alt="" />`
+        : info.type === 'group'
+          ? `<span class="user-initial material-symbols-outlined">groups</span>`
+          : `<span class="user-initial">${initial}</span>`;
+
+
+      const item = `
+        <label class="filter-item${selected.has(key) ? ' selected' : ''}">
+          <input type="checkbox" value="${key}" ${checked} />
+          <span class="user-option">
+            <span class="avatar-outer"><span class="avatar-middle"><span class="user-avatar${info.type === 'group' ? ' user-group' : ''}">${avatar}</span></span></span>
+            <span class="filter-label">${name}</span>
+          </span>
+        </label>
+      `;
+      if (info.type === 'group') groupHtml.push(item);
+      else respHtml.push(item);
+
+    });
+
+    const sections = [];
+    if (respHtml.length) {
+      sections.push(`<div class="filter-section"><div class="filter-section-title">${translatePhrase("Responsibles")}</div>${respHtml.join('')}</div>`);
+    }
+
+    if (groupHtml.length) {
+      sections.push(`<div class="filter-section"><div class="filter-section-title">${translatePhrase("Groups")}</div>${groupHtml.join('')}</div>`);
+    }
+    this.filterList.innerHTML = sections.join('');
+
+    this.filterList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+      checkbox.addEventListener('change', (e) => {
+        const value = e.target.value;
+        if (e.target.checked) {
+          if (!this.selectedValues.includes(value)) {
+            this.selectedValues.push(value);
+          }
+        } else {
+          this.selectedValues = this.selectedValues.filter(v => v !== value);
+        }
+        const sel = new Set(this.selectedValues);
+        this.selectAllCheckbox.checked =
+          this.filteredValues.length > 0 &&
+          this.filteredValues.every(v => sel.has(v));
+        this.applyFilter();
+      });
+    });
+  }
+
+  applyFilter() {
+    this.params.filterChangedCallback();
+  }
+
+  clearFilter() {
+    this.selectedValues = [];
+    this.searchText = '';
+    this.searchInput.value = '';
+    this.filteredValues = [...this.allValues];
+    this.renderFilterList();
+    this.params.filterChangedCallback();
+  }
+
+  isFilterActive() {
+    return this.selectedValues.length > 0;
+  }
+
+  doesFilterPass(params) {
+    if (this.selectedValues.length === 0) return true;
+    const row = params.data || {};
+    const colDef = this.params.column?.getColDef?.() || {};
+    const fieldName = colDef.field || this.params.column.getColId();
+
+    const matches = new Set();
+    this.collectMatchesFromValue(this.getNestedValue(row, fieldName), matches);
+
+    const userCandidates = [
+      row.ResponsibleUser,
+      row.ResponsibleUserName,
+      row.Username,
+      row.UserName,
+      row.UserFullName,
+      row.AssignedUser,
+      row.AssignedUserName,
+    ];
+    userCandidates.forEach(value => this.collectMatchesFromValue(value, matches));
+
+    const groupCandidates = [
+      row.AssignedGroupID,
+      row.GroupID,
+      row.groupid,
+      row.AssignedGroupName,
+      row.GroupName,
+      row.Group,
+      row.groupname,
+    ];
+    groupCandidates.forEach(value => this.collectMatchesFromValue(value, matches));
+
+    const selectedSet = new Set(this.selectedValues);
+    for (const key of matches) {
+      if (selectedSet.has(key)) {
+        return true;
+      }
+    }
+
+    return this.selectedValues.some(key => {
+      const info = this.userInfo[key];
+      if (!info) return false;
+
+      const normalizedId = this.normalizeLookupValue(info.id);
+      const normalizedName = this.normalizeLookupValue(info.name);
+
+      if (info.type === 'group') {
+        return groupCandidates.some(candidate => {
+          const normalizedCandidate = this.normalizeLookupValue(candidate);
+          if (!normalizedCandidate) return false;
+          if (normalizedId && normalizedCandidate === normalizedId) return true;
+          if (normalizedName && normalizedCandidate === normalizedName) return true;
+          const fallbackMatches = new Set();
+          this.collectMatchesFromValue(candidate, fallbackMatches);
+          return fallbackMatches.has(key);
+        });
+      }
+
+      const fieldValue = this.getNestedValue(row, fieldName);
+      const normalizedField = this.normalizeLookupValue(fieldValue);
+      if (!normalizedField) return false;
+      if (normalizedId && normalizedField === normalizedId) return true;
+      if (normalizedName && normalizedField === normalizedName) return true;
+      const fallbackMatches = new Set();
+      this.collectMatchesFromValue(fieldValue, fallbackMatches);
+      return fallbackMatches.has(key);
+    });
+  }
+
+  getModel() {
+    if (this.selectedValues.length === 0) return null;
+    return {
+      type: 'list',
+      values: this.selectedValues
+    };
+  }
+
+  setModel(model) {
+    if (model && model.values) {
+      this.selectedValues = model.values;
+    } else {
+      this.selectedValues = [];
+    }
+    this.renderFilterList();
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  onNewRowsLoaded() {
+    this.loadValues();
+    this.filterValues();
+  }
+} 

--- a/Project/TicketGrid/src/components/ResponsibleUserFilterRenderer.js
+++ b/Project/TicketGrid/src/components/ResponsibleUserFilterRenderer.js
@@ -1,0 +1,725 @@
+import { translatePhrase } from "../translation";
+
+export default class ResponsibleUserFilterRenderer {
+  constructor() {
+    this.searchText = '';
+    this.selectedValues = [];
+    this.allValues = [];
+    this.filteredValues = [];
+    this.selectAll = false;
+    // key -> { type: 'responsible'|'group', id, name, photo }
+
+    this.userInfo = {};
+    this.lookupByRawValue = new Map();
+  }
+
+  init(params) {
+    this.params = params;
+    this.loadValues();
+    this.createGui();
+  }
+
+  createGui() {
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'list-filter';
+    this.applyAvatarTheme();
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" placeholder="${translatePhrase("Search...")}" class="search-input" />
+        <span class="search-icon">
+          <i class="material-symbols-outlined-search">search</i>
+        </span>
+      </div>
+      <div class="select-all-row">
+        <label>
+          <input type="checkbox" class="select-all-checkbox" />
+          <span>${translatePhrase("Select all")}</span>
+        </label>
+      </div>
+      <div class="filter-list"></div>
+    `;
+
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.filterList = this.eGui.querySelector('.filter-list');
+    this.selectAllCheckbox = this.eGui.querySelector('.select-all-checkbox');
+
+    this.setupEventListeners();
+    this.renderFilterList();
+  }
+
+  applyAvatarTheme() {
+    if (!this.eGui) return;
+    const theme = window?.wwLib?.wwVariable?.getValue?.('61c1b425-10e8-40dc-8f1f-b117c08b9726') || {};
+    const avatarBackground = theme?.bgButtonPrimary || '#4B6CB7';
+    const avatarShadow = theme?.primary || '#3A4663';
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-bg', avatarBackground);
+    this.eGui.style.setProperty('--grid-view-dinamica-avatar-shadow', avatarShadow);
+  }
+
+  setupEventListeners() {
+    this.searchInput.addEventListener('input', (e) => {
+      this.searchText = e.target.value;
+      this.filterValues();
+    });
+
+    this.selectAllCheckbox.addEventListener('change', (e) => {
+      if (e.target.checked) {
+        this.selectedValues = [...this.filteredValues];
+      } else {
+        this.selectedValues = [];
+      }
+      this.renderFilterList();
+      this.applyFilter();
+    });
+  }
+
+  // Função utilitária para acessar campos aninhados
+  getNestedValue(obj, path) {
+    return path.split('.').reduce((o, p) => (o && o[p] !== undefined ? o[p] : undefined), obj);
+  }
+
+  // Função auxiliar igual ao FormatterCellRenderer
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+    const fontweight = "font-weight:bold;";
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric'
+      };
+      const timeOptions = {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(new Date(dateValue));
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(new Date(dateValue));
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  getOptionsArray() {
+    const params = this.params || {};
+    const colDef = params.colDef || params.column?.getColDef?.() || {};
+    let options = [];
+
+    if (Array.isArray(params.options)) options = params.options;
+    else if (Array.isArray(colDef.listOptions)) options = colDef.listOptions;
+    else if (typeof colDef.listOptions === 'string' && colDef.listOptions.trim()) {
+      options = colDef.listOptions.split(',').map(o => o.trim());
+    } else if (
+      colDef.dataSource &&
+      typeof colDef.dataSource.list_options === 'string' &&
+      colDef.dataSource.list_options.trim()
+    ) {
+      options = colDef.dataSource.list_options.split(',').map(o => o.trim());
+    }
+
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = keys => Object.keys(opt).find(k => keys.includes(k.toLowerCase()));
+        const labelKey = findKey(['label', 'name', 'displayname', 'display_name']);
+        const valueKey = findKey(['value', 'id', 'userid', 'user_id']);
+        const typeKey = findKey(['type']);
+        const groupUsersKey = findKey(['groupusers', 'group_users']);
+        const normalized = {
+          ...opt,
+          id: opt.id ?? opt.value ?? (valueKey ? opt[valueKey] : undefined),
+          name: opt.name ?? opt.label ?? (labelKey ? opt[labelKey] : undefined),
+          type: opt.type ?? (typeKey ? opt[typeKey] : undefined)
+        };
+        if (groupUsersKey && Array.isArray(opt[groupUsersKey])) {
+          normalized.groupUsers = opt[groupUsersKey].map(normalize);
+        }
+        return normalized;
+      }
+      return { id: opt, name: String(opt) };
+    };
+
+    return (options || []).map(normalize);
+  }
+
+  shouldUseResponsibleCollection(identifier, tag) {
+    const targets = new Set(['RESPONSIBLEUSERID', 'XXXXXX']);
+    return targets.has(identifier) || targets.has(tag);
+  }
+
+  getResponsibleCollectionOptions() {
+    const COLLECTION_ID = '0e41f029-e1c3-4302-82ca-16aceccdadb1';
+    try {
+      const collection = window?.wwLib?.wwCollection?.getCollection?.(COLLECTION_ID);
+      const data = collection?.data;
+      if (!Array.isArray(data)) {
+        return [];
+      }
+      return data
+        .map(item => this.normalizeCollectionEntry(item))
+        .filter(item => item);
+    } catch {
+      return [];
+    }
+  }
+
+  normalizeCollectionEntry(item) {
+    if (item === undefined || item === null) {
+      return null;
+    }
+
+    if (typeof item !== 'object') {
+      const value = this.ensureDisplayText(item);
+      if (!value) return null;
+      return {
+        id: value,
+        name: value,
+        type: 'responsible',
+        photo: '',
+        matchCandidates: [value],
+      };
+    }
+
+    const name = this.ensureDisplayText(item.name ?? item.Name ?? item.label ?? item.Label);
+    if (!name) {
+      return null;
+    }
+
+    const id = item.id ?? item.Id ?? item.ID ?? item.value ?? item.Value ?? name;
+    const photo = item.photoUrl || item.PhotoUrl || item.PhotoURL || item.photo || item.image || item.img || '';
+    const type = item.type ?? item.Type ?? 'responsible';
+    const matchCandidates = this.extractCollectionMatchCandidates(item);
+
+    return {
+      id,
+      name,
+      type,
+      photo,
+      matchCandidates,
+    };
+  }
+
+  extractCollectionMatchCandidates(item) {
+    if (!item || typeof item !== 'object') return [];
+    const keys = [
+      'id',
+      'Id',
+      'ID',
+      'value',
+      'Value',
+      'name',
+      'Name',
+      'label',
+      'Label',
+      'username',
+      'Username',
+      'userName',
+      'UserName',
+      'displayName',
+      'DisplayName',
+      'userid',
+      'userId',
+      'user_id',
+      'email',
+      'Email',
+    ];
+    const candidates = [];
+    keys.forEach(key => {
+      if (Object.prototype.hasOwnProperty.call(item, key)) {
+        candidates.push(item[key]);
+      }
+    });
+    return candidates;
+  }
+
+  normalizeOptionType(type) {
+    const text = this.ensureDisplayText(type).toLowerCase();
+    if (!text) return 'responsible';
+    if (text.includes('group') || text === 'g' || text.includes('grupo')) {
+      return 'group';
+    }
+    return 'responsible';
+  }
+
+  buildEntryKey(type, id, name) {
+    const baseCandidate = id !== undefined && id !== null && id !== ''
+      ? this.ensureDisplayText(id)
+      : this.ensureDisplayText(name);
+    if (!baseCandidate) return null;
+    return `${type}-${baseCandidate}`;
+  }
+
+  ensureDisplayText(value) {
+    if (value === undefined || value === null) return '';
+    if (typeof value === 'string') {
+      return value.trim();
+    }
+    return String(value).trim();
+  }
+
+  normalizeLookupValue(value) {
+    if (value === undefined || value === null) return null;
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) return null;
+      return trimmed.toLowerCase();
+    }
+    try {
+      const str = String(value).trim();
+      if (!str) return null;
+      return str.toLowerCase();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  pickFirstCandidate(candidates) {
+    if (!Array.isArray(candidates)) return '';
+    for (const candidate of candidates) {
+      const display = this.ensureDisplayText(candidate);
+      if (display) return display;
+    }
+    return '';
+  }
+
+  ingestOptionList(options) {
+    if (!Array.isArray(options)) return;
+    options.forEach(opt => this.ingestOption(opt));
+  }
+
+  ingestOption(opt) {
+    if (opt === undefined || opt === null) return;
+
+    if (typeof opt !== 'object') {
+      const value = this.ensureDisplayText(opt);
+      if (!value) return;
+      this.registerEntry({ type: 'responsible', id: value, name: value, photo: '' }, [value]);
+      return;
+    }
+
+    const type = this.normalizeOptionType(opt.type);
+    const idCandidate = opt.id ?? opt.Id ?? opt.ID ?? opt.value ?? opt.Value ?? opt.UserID ?? opt.UserId ?? opt.userid ?? opt.user_id;
+    const optionNames = [
+      opt.name,
+      opt.Name,
+      opt.label,
+      opt.Label,
+      opt.displayName,
+      opt.DisplayName,
+      opt.fullName,
+      opt.FullName,
+      opt.username,
+      opt.Username,
+      opt.userName,
+      opt.UserName,
+    ];
+    const name = this.pickFirstCandidate([...optionNames, idCandidate]);
+    const photo = opt.photoUrl || opt.PhotoUrl || opt.PhotoURL || opt.photo || opt.image || opt.img || '';
+    const extraMatches = Array.isArray(opt.matchCandidates) ? opt.matchCandidates : [];
+    const matchCandidates = [
+      idCandidate,
+      opt.id,
+      opt.Id,
+      opt.ID,
+      opt.value,
+      opt.Value,
+      opt.UserID,
+      opt.UserId,
+      opt.userid,
+      opt.user_id,
+      ...optionNames,
+      ...extraMatches,
+    ];
+
+    this.registerEntry({ type, id: idCandidate ?? name, name, photo }, matchCandidates);
+
+    if (type === 'group' && Array.isArray(opt.groupUsers)) {
+      opt.groupUsers.forEach(user => {
+        if (user === undefined || user === null) return;
+        if (typeof user === 'object') {
+          this.ingestOption({ ...user, type: 'responsible' });
+        } else {
+          const normalizedUser = this.ensureDisplayText(user);
+          if (normalizedUser) {
+            this.registerEntry({ type: 'responsible', id: normalizedUser, name: normalizedUser, photo: '' }, [normalizedUser]);
+          }
+        }
+      });
+    }
+  }
+
+  registerEntry(details, matchCandidates = []) {
+    if (!details) return;
+    const type = this.normalizeOptionType(details.type);
+    const key = this.buildEntryKey(type, details.id, details.name);
+    if (!key) return;
+
+    const resolvedName = this.ensureDisplayText(details.name) || this.ensureDisplayText(details.id);
+    if (!resolvedName) return;
+
+    if (!this.userInfo[key]) {
+      this.userInfo[key] = {
+        type,
+        id: details.id ?? resolvedName,
+        name: resolvedName,
+        photo: details.photo || '',
+        matchValues: new Set(),
+      };
+    } else {
+      const info = this.userInfo[key];
+      info.type = type;
+      if ((!info.name || !info.name.trim()) && resolvedName) info.name = resolvedName;
+      if ((info.id === undefined || info.id === null || info.id === '') && details.id !== undefined && details.id !== null && details.id !== '') {
+        info.id = details.id;
+      }
+      if (!info.photo && details.photo) info.photo = details.photo;
+      if (!info.matchValues) info.matchValues = new Set();
+    }
+
+    const info = this.userInfo[key];
+    const allMatches = [
+      details.id,
+      details.name,
+      resolvedName,
+      ...(Array.isArray(matchCandidates) ? matchCandidates : []),
+    ];
+    allMatches.forEach(value => this.addMatchValue(info, key, value));
+  }
+
+  addMatchValue(info, key, rawValue) {
+    if (!info || rawValue === undefined || rawValue === null) return;
+    if (Array.isArray(rawValue)) {
+      rawValue.forEach(value => this.addMatchValue(info, key, value));
+      return;
+    }
+
+    const normalized = this.normalizeLookupValue(rawValue);
+    if (!normalized) return;
+
+    if (!info.matchValues) info.matchValues = new Set();
+    info.matchValues.add(normalized);
+
+    let matches = this.lookupByRawValue.get(normalized);
+    if (!matches) {
+      matches = new Set();
+      this.lookupByRawValue.set(normalized, matches);
+    }
+    matches.add(key);
+  }
+
+  populateFromRowData(api, colDef) {
+    const field = colDef.field || this.params.column.getColId();
+    if (!api || (api.isDestroyed && api.isDestroyed())) return;
+
+    api.forEachNode(node => {
+      const data = node?.data;
+      if (!data) return;
+
+      const userValue = this.getNestedValue(data, field);
+      const userNameCandidates = [
+        data.ResponsibleUser,
+        data.ResponsibleUserName,
+        data.Username,
+        data.UserName,
+        data.UserFullName,
+        data.AssignedUser,
+        data.AssignedUserName,
+      ];
+      const userPhoto = data.photoUrl || data.PhotoUrl || data.PhotoURL || data.UserPhoto || '';
+      const userName = this.pickFirstCandidate([...userNameCandidates, userValue]);
+      this.registerEntry(
+        { type: 'responsible', id: userValue, name: userName, photo: userPhoto },
+        [userValue, ...userNameCandidates]
+      );
+
+      const groupIdCandidates = [data.AssignedGroupID, data.GroupID, data.groupid];
+      const groupNameCandidates = [
+        data.AssignedGroupName,
+        data.GroupName,
+        data.Group,
+        data.groupname,
+      ];
+      const groupId = this.pickFirstCandidate(groupIdCandidates);
+      const groupName = this.pickFirstCandidate([...groupNameCandidates, groupId]);
+      const groupPhoto = data.groupPhoto || data.GroupPhoto || data.GroupImage || '';
+      this.registerEntry(
+        { type: 'group', id: groupId, name: groupName, photo: groupPhoto },
+        [...groupIdCandidates, ...groupNameCandidates]
+      );
+    });
+  }
+
+  collectMatchesFromValue(value, resultSet) {
+    if (!this.lookupByRawValue || !resultSet) return;
+    if (Array.isArray(value)) {
+      value.forEach(item => this.collectMatchesFromValue(item, resultSet));
+      return;
+    }
+    const normalized = this.normalizeLookupValue(value);
+    if (!normalized) return;
+    const matches = this.lookupByRawValue.get(normalized);
+    if (!matches) return;
+    matches.forEach(key => resultSet.add(key));
+  }
+
+  finalizeUserInfo() {
+    const respKeys = [];
+    const groupKeys = [];
+    Object.keys(this.userInfo).forEach(key => {
+      const info = this.userInfo[key];
+      if (!info) return;
+      if (!info.matchValues) info.matchValues = new Set();
+      if (info.name) {
+        info.name = this.ensureDisplayText(info.name);
+      }
+      if (!info.name) {
+        const fallback = this.ensureDisplayText(info.id);
+        if (fallback) info.name = fallback;
+      }
+      this.addMatchValue(info, key, info.name);
+      this.addMatchValue(info, key, info.id);
+
+      if (info.type === 'group') groupKeys.push(key);
+      else respKeys.push(key);
+    });
+
+    const sortByName = (a, b) => {
+      const na = (this.userInfo[a]?.name || '').toLowerCase();
+      const nb = (this.userInfo[b]?.name || '').toLowerCase();
+      return na.localeCompare(nb, undefined, { sensitivity: 'base' });
+    };
+
+    respKeys.sort(sortByName);
+    groupKeys.sort(sortByName);
+
+    this.allValues = [...respKeys, ...groupKeys];
+    this.filteredValues = [...this.allValues];
+    this.selectedValues = this.selectedValues.filter(value => this.userInfo[value]);
+  }
+
+  loadValues() {
+    const api = this.params.api;
+    this.userInfo = {};
+    this.lookupByRawValue = new Map();
+
+    const column = this.params.column;
+    const colDef = column?.getColDef?.() || {};
+    const identifier = (colDef.FieldDB || '').toString().toUpperCase();
+    const tag = (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toString().toUpperCase();
+
+    let options = [];
+    if (this.shouldUseResponsibleCollection(identifier, tag)) {
+      options = this.getResponsibleCollectionOptions();
+    }
+
+    if (!Array.isArray(options) || !options.length) {
+      options = this.getOptionsArray();
+    }
+
+    this.ingestOptionList(options);
+    this.populateFromRowData(api, colDef);
+    this.finalizeUserInfo();
+  }
+
+  filterValues() {
+    if (!this.searchText) {
+      this.filteredValues = [...this.allValues];
+    } else {
+      const q = this.searchText.toLowerCase();
+      this.filteredValues = this.allValues.filter(key => {
+        const info = this.userInfo[key] || {};
+        const target = (info.name || '').toLowerCase();
+        return target.includes(q);
+
+      });
+    }
+    this.renderFilterList();
+  }
+
+  renderFilterList() {
+    const selected = new Set(this.selectedValues);
+    this.selectAllCheckbox.checked =
+      this.filteredValues.length > 0 &&
+      this.filteredValues.every(v => selected.has(v));
+
+    const respHtml = [];
+
+    const groupHtml = [];
+
+    this.filteredValues.forEach(key => {
+      const info = this.userInfo[key] || {};
+      const checked = selected.has(key) ? 'checked' : '';
+      const name = this.ensureDisplayText(info.name || info.id || '');
+      const photo = info.photo;
+      const initialSource = this.ensureDisplayText(name);
+      const initial = initialSource ? initialSource.charAt(0).toUpperCase() : '';
+      const avatar = photo
+
+        ? `<img src="${photo}" alt="" />`
+        : info.type === 'group'
+          ? `<span class="user-initial material-symbols-outlined">groups</span>`
+          : `<span class="user-initial">${initial}</span>`;
+
+
+      const item = `
+        <label class="filter-item${selected.has(key) ? ' selected' : ''}">
+          <input type="checkbox" value="${key}" ${checked} />
+          <span class="user-option">
+            <span class="avatar-outer"><span class="avatar-middle"><span class="user-avatar${info.type === 'group' ? ' user-group' : ''}">${avatar}</span></span></span>
+            <span class="filter-label">${name}</span>
+          </span>
+        </label>
+      `;
+      if (info.type === 'group') groupHtml.push(item);
+      else respHtml.push(item);
+
+    });
+
+    const sections = [];
+    if (respHtml.length) {
+      sections.push(`<div class="filter-section"><div class="filter-section-title">${translatePhrase("Responsibles")}</div>${respHtml.join('')}</div>`);
+    }
+
+    if (groupHtml.length) {
+      sections.push(`<div class="filter-section"><div class="filter-section-title">${translatePhrase("Groups")}</div>${groupHtml.join('')}</div>`);
+    }
+    this.filterList.innerHTML = sections.join('');
+
+    this.filterList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+      checkbox.addEventListener('change', (e) => {
+        const value = e.target.value;
+        if (e.target.checked) {
+          if (!this.selectedValues.includes(value)) {
+            this.selectedValues.push(value);
+          }
+        } else {
+          this.selectedValues = this.selectedValues.filter(v => v !== value);
+        }
+        const sel = new Set(this.selectedValues);
+        this.selectAllCheckbox.checked =
+          this.filteredValues.length > 0 &&
+          this.filteredValues.every(v => sel.has(v));
+        this.applyFilter();
+      });
+    });
+  }
+
+  applyFilter() {
+    this.params.filterChangedCallback();
+  }
+
+  clearFilter() {
+    this.selectedValues = [];
+    this.searchText = '';
+    this.searchInput.value = '';
+    this.filteredValues = [...this.allValues];
+    this.renderFilterList();
+    this.params.filterChangedCallback();
+  }
+
+  isFilterActive() {
+    return this.selectedValues.length > 0;
+  }
+
+  doesFilterPass(params) {
+    if (this.selectedValues.length === 0) return true;
+    const row = params.data || {};
+    const colDef = this.params.column?.getColDef?.() || {};
+    const fieldName = colDef.field || this.params.column.getColId();
+
+    const matches = new Set();
+    this.collectMatchesFromValue(this.getNestedValue(row, fieldName), matches);
+
+    const userCandidates = [
+      row.ResponsibleUser,
+      row.ResponsibleUserName,
+      row.Username,
+      row.UserName,
+      row.UserFullName,
+      row.AssignedUser,
+      row.AssignedUserName,
+    ];
+    userCandidates.forEach(value => this.collectMatchesFromValue(value, matches));
+
+    const groupCandidates = [
+      row.AssignedGroupID,
+      row.GroupID,
+      row.groupid,
+      row.AssignedGroupName,
+      row.GroupName,
+      row.Group,
+      row.groupname,
+    ];
+    groupCandidates.forEach(value => this.collectMatchesFromValue(value, matches));
+
+    const selectedSet = new Set(this.selectedValues);
+    for (const key of matches) {
+      if (selectedSet.has(key)) {
+        return true;
+      }
+    }
+
+    return this.selectedValues.some(key => {
+      const info = this.userInfo[key];
+      if (!info) return false;
+
+      const normalizedId = this.normalizeLookupValue(info.id);
+      const normalizedName = this.normalizeLookupValue(info.name);
+
+      if (info.type === 'group') {
+        return groupCandidates.some(candidate => {
+          const normalizedCandidate = this.normalizeLookupValue(candidate);
+          if (!normalizedCandidate) return false;
+          if (normalizedId && normalizedCandidate === normalizedId) return true;
+          if (normalizedName && normalizedCandidate === normalizedName) return true;
+          const fallbackMatches = new Set();
+          this.collectMatchesFromValue(candidate, fallbackMatches);
+          return fallbackMatches.has(key);
+        });
+      }
+
+      const fieldValue = this.getNestedValue(row, fieldName);
+      const normalizedField = this.normalizeLookupValue(fieldValue);
+      if (!normalizedField) return false;
+      if (normalizedId && normalizedField === normalizedId) return true;
+      if (normalizedName && normalizedField === normalizedName) return true;
+      const fallbackMatches = new Set();
+      this.collectMatchesFromValue(fieldValue, fallbackMatches);
+      return fallbackMatches.has(key);
+    });
+  }
+
+  getModel() {
+    if (this.selectedValues.length === 0) return null;
+    return {
+      type: 'list',
+      values: this.selectedValues
+    };
+  }
+
+  setModel(model) {
+    if (model && model.values) {
+      this.selectedValues = model.values;
+    } else {
+      this.selectedValues = [];
+    }
+    this.renderFilterList();
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  onNewRowsLoaded() {
+    this.loadValues();
+    this.filterValues();
+  }
+} 

--- a/Project/TicketGrid/src/components/UserCellRenderer.vue
+++ b/Project/TicketGrid/src/components/UserCellRenderer.vue
@@ -1,0 +1,539 @@
+<template>
+  <div
+    v-if="selectedLabel"
+    class="user-cell"
+    :class="{ 'user-cell--group-user': selectedGroup && selectedUser }"
+    :style="[pointerStyle, avatarThemeStyle]"
+  >
+    <!-- CASO: Grupo + Responsável (stack) -->
+    <template v-if="selectedGroup && selectedUser">
+      <div
+        class="avatar-outer group-avatar-wrapper selected-group-avatar"
+        :title="selectedGroup.name || ''"
+        @mouseenter="onGroupMouseEnter"
+        @mouseleave="onGroupMouseLeave"
+      >
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="groupPhoto">
+              <img :src="groupPhoto" alt="Group Photo" />
+            </template>
+            <template v-else>
+              <span class="material-symbols-outlined user-cell__group-icon">groups</span>
+            </template>
+          </div>
+        </div>
+        <div v-if="showGroupTooltip" class="user-cell__group-tooltip">
+          {{ selectedGroup.name }}
+        </div>
+      </div>
+
+      <div class="avatar-outer selected-user-avatar">
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="userPhoto">
+              <img :src="userPhoto" alt="User Photo" />
+            </template>
+            <template v-else>
+              <span class="user-cell__initial">{{ userInitial }}</span>
+            </template>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- CASO: Só Grupo -->
+    <template v-else-if="selectedGroup">
+      <div
+        class="avatar-outer group-avatar-wrapper"
+        :title="selectedGroup.name || ''"
+        @mouseenter="onGroupMouseEnter"
+        @mouseleave="onGroupMouseLeave"
+      >
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="groupPhoto">
+              <img :src="groupPhoto" alt="Group Photo" />
+            </template>
+            <template v-else>
+              <span class="material-symbols-outlined user-cell__group-icon">groups</span>
+            </template>
+          </div>
+        </div>
+        <div v-if="showGroupTooltip" class="user-cell__group-tooltip">
+          {{ selectedGroup.name }}
+        </div>
+      </div>
+    </template>
+
+    <!-- CASO: Só Responsável -->
+    <template v-else>
+      <div class="avatar-outer">
+        <div class="avatar-middle">
+          <div class="user-cell__avatar">
+            <template v-if="userPhoto">
+              <img :src="userPhoto" alt="User Photo" />
+            </template>
+            <template v-else>
+              <span class="user-cell__initial">{{ userInitial }}</span>
+            </template>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <span class="user-cell__name">{{ selectedLabel }}</span>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'UserCellRenderer',
+  props: {
+    params: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      currentParams: this.params,
+      optionsCache: [],
+      showGroupTooltip: false
+    };
+  },
+  async created() {
+    // Carrega options (se vieram por params ou via API)
+    if (this.currentParams.options && this.currentParams.options.length) {
+      this.optionsCache = this.mapOptions(this.currentParams.options);
+    } else {
+      this.optionsCache = this.mapOptions(await this.fetchOptions());
+    }
+  },
+  computed: {
+    options() {
+      return this.optionsCache;
+    },
+
+    /* -----------------------------
+       GRUPO SELECIONADO
+       - Preferência:
+         1) value.groupid (quando cell value é objeto)
+         2) AssignedGroupID (ID -> lookup em options)
+         3) AssignedGroupName (nome direto)
+    ------------------------------ */
+    selectedGroup() {
+      const val = this.currentParams.value;
+
+      // Caso: valor-objeto com groupid
+      if (val && typeof val === 'object' && val.groupid) {
+        const grp = this.findGroupById(val.groupid);
+        if (grp) return { name: grp.name, photo: this.pickPhoto(grp) };
+      }
+
+      // Caso: temos ID de grupo no rowData
+      const groupId =
+        this.currentParams.data?.AssignedGroupID ||
+        this.currentParams.data?.GroupID ||
+        this.currentParams.data?.GroupId;
+      if (groupId) {
+        const grp = this.findGroupById(groupId);
+        if (grp) return { name: grp.name, photo: this.pickPhoto(grp) };
+      }
+
+      // Caso: temos nome do grupo direto no rowData
+      const name =
+        this.currentParams.data?.AssignedGroupName ||
+        this.currentParams.data?.GroupName ||
+        this.currentParams.data?.Group;
+      if (name) {
+        const photo =
+          this.currentParams.data?.AssignedGroupPhotoUrl ||
+          this.currentParams.data?.AssignedGroupPhotoURL ||
+          this.currentParams.data?.AssignedGroupPhoto ||
+          this.currentParams.data?.GroupPhotoURL ||
+          this.currentParams.data?.GroupPhotoUrl ||
+          this.currentParams.data?.GroupPhoto ||
+          this.currentParams.data?.photoUrl; // último fallback
+        return { name, photo };
+      }
+
+      return null;
+    },
+
+    /* -----------------------------
+       RESPONSÁVEL SELECIONADO
+       - Preferência:
+         1) value.userid (quando cell value é objeto) -> procura dentro do grupo, senão global
+         2) IDs no rowData (Technical responsible / ResponsibleUserID / etc) -> lookup em options
+         3) Nome direto no rowData (ResponsibleUser / Username / UserName)
+    ------------------------------ */
+    selectedUser() {
+      const val = this.currentParams.value;
+
+      // 1) valor-objeto com userid/groupid
+      if (val && typeof val === 'object') {
+        if (val.userid && val.groupid) {
+          const grp = this.findGroupById(val.groupid);
+          if (grp) {
+            const u = (grp.groupUsers || []).find(u => String(u.id) === String(val.userid));
+            if (u) return { name: u.name, photo: this.pickPhoto(u) };
+          }
+        } else if (val.userid) {
+          const u = this.findUserById(val.userid);
+          if (u) return { name: u.name, photo: this.pickPhoto(u) };
+        }
+      }
+
+      // 2) IDs no rowData
+      const technicalRespId =
+        this.currentParams.data?.['Technical responsible'] ||
+        this.currentParams.data?.TechnicalResponsible ||
+        this.currentParams.data?.Technical_responsible ||
+        this.currentParams.data?.TechnicalResponsibleID ||
+        this.currentParams.data?.ResponsibleUserID ||
+        this.currentParams.data?.ResponsibleID ||
+        this.currentParams.data?.UserID;
+
+      if (technicalRespId) {
+        // Se houver AssignedGroupID, tenta dentro do grupo primeiro
+        const groupId =
+          this.currentParams.data?.AssignedGroupID ||
+          this.currentParams.data?.GroupID ||
+          this.currentParams.data?.GroupId;
+        if (groupId) {
+          const grp = this.findGroupById(technicalRespId) || this.findGroupById(groupId);
+          // Se technicalRespId for na verdade um groupid inválido, a busca acima ainda se mantém robusta
+          if (grp) {
+            const u = (grp.groupUsers || []).find(u => String(u.id) === String(technicalRespId));
+            if (u) return { name: u.name, photo: this.pickPhoto(u) };
+          }
+        }
+        // Busca global
+        const u = this.findUserById(technicalRespId);
+        if (u) return { name: u.name, photo: this.pickPhoto(u) };
+      }
+
+      // 3) Nome direto no rowData
+      const name =
+        this.currentParams.data?.ResponsibleUser ||
+        this.currentParams.data?.Username ||
+        this.currentParams.data?.UserName ||
+        this.currentParams.data?.Responsible ||
+        this.currentParams.data?.Assignee;
+
+      if (name) {
+        const photo =
+          this.currentParams.data?.photoUrl ||
+          this.currentParams.data?.PhotoURL ||
+          this.currentParams.data?.PhotoUrl ||
+          this.currentParams.data?.UserPhoto ||
+          this.currentParams.data?.UserPhotoUrl;
+        return { name, photo };
+      }
+
+      return null;
+    },
+
+    /* Rótulo: se houver os dois, mostra o nome do responsável; senão o que existir */
+    selectedLabel() {
+      if (this.selectedGroup && this.selectedUser) return this.selectedUser.name;
+      if (this.selectedGroup) return this.selectedGroup.name;
+      return this.selectedUser ? this.selectedUser.name : '';
+    },
+
+    /* Foto do usuário / grupo (consolidadas) */
+    userPhoto() {
+      const u = this.selectedUser;
+      return (
+        u?.photo ||
+        u?.photoUrl ||
+        u?.PhotoURL ||
+        u?.PhotoUrl ||
+        ''
+      );
+    },
+    groupPhoto() {
+      const g = this.selectedGroup;
+      return (
+        g?.photo ||
+        g?.photoUrl ||
+        g?.PhotoURL ||
+        g?.PhotoUrl ||
+        ''
+      );
+    },
+
+    userInitial() {
+      return this.selectedUser ? this.getInitial(this.selectedUser.name) : '';
+    },
+
+    isEditable() {
+      const editable = this.currentParams.colDef?.editable;
+      if (typeof editable === 'function') {
+        try {
+          return !!editable(this.currentParams);
+        } catch {
+          return false;
+        }
+      }
+      return !!editable;
+    },
+    pointerStyle() {
+      return this.isEditable ? { cursor: 'pointer' } : {};
+    },
+    avatarThemeStyle() {
+      const theme = window?.wwLib?.wwVariable?.getValue?.('61c1b425-10e8-40dc-8f1f-b117c08b9726') || {};
+      return {
+        '--grid-view-dinamica-avatar-bg': theme?.bgButtonPrimary || '#4B6CB7',
+        '--grid-view-dinamica-avatar-shadow': theme?.primary || '#3A4663'
+      };
+    }
+  },
+  methods: {
+    /* Normaliza structure de options (grupos com groupUsers, usuários folha) */
+    mapOptions(list) {
+      const getProp = (obj, ...keys) => {
+        for (const key of keys) {
+          const match = Object.keys(obj || {}).find(
+            k => k.toLowerCase() === String(key).toLowerCase()
+          );
+          if (match) return obj[match];
+        }
+        return undefined;
+      };
+      return (list || []).map(item => {
+        const children = getProp(item, 'groupUsers', 'children', 'users');
+        return {
+          ...item,
+          id: getProp(item, 'id', 'value', 'userId', 'userid', 'groupid'),
+          name: getProp(item, 'name', 'label'),
+          value: getProp(item, 'value', 'id'),
+          label: getProp(item, 'label', 'name'),
+          photoUrl:
+            getProp(item, 'photoUrl', 'PhotoUrl', 'PhotoURL', 'photo', 'image', 'img') || undefined,
+          ...(Array.isArray(children) && children.length
+            ? { groupUsers: this.mapOptions(children) }
+            : {})
+        };
+      });
+    },
+
+    pickPhoto(entity) {
+      return (
+        entity?.photoUrl ||
+        entity?.PhotoUrl ||
+        entity?.PhotoURL ||
+        entity?.photo ||
+        entity?.image ||
+        entity?.img ||
+        undefined
+      );
+    },
+
+    onGroupMouseEnter() {
+      this.showGroupTooltip = true;
+      this.updateRowZIndex(true);
+    },
+    onGroupMouseLeave() {
+      this.showGroupTooltip = false;
+      this.updateRowZIndex(false);
+    },
+    updateRowZIndex(raise) {
+      const cell = this.currentParams?.eGridCell;
+      if (cell) {
+        cell.style.overflow = raise ? 'visible' : '';
+        const row = cell.parentElement;
+        if (row) {
+          row.style.zIndex = raise ? 1000 : '';
+          row.style.overflow = raise ? 'visible' : '';
+        }
+      }
+    },
+
+    async fetchOptions() {
+      try {
+        const lang = window.wwLib?.wwVariable?.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+        const companyId = window.wwLib?.wwVariable?.getValue('5d099f04-cd42-41fd-94ad-22d4de368c3a');
+        const apiUrl = window.wwLib?.wwVariable?.getValue('1195995b-34c3-42a5-b436-693f0f4f8825');
+        const apiKey = window.wwLib?.wwVariable?.getValue('d180be98-8926-47a7-b7f1-6375fbb95fa3');
+        const apiAuth = window.wwLib?.wwVariable?.getValue('dfcde09f-42f3-4b5c-b2e8-4314650655db');
+
+        if (!apiUrl) return [];
+        const fetchOptions = {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...(companyId ? { p_idcompany: companyId } : {}),
+            ...(lang ? { p_language: lang } : {})
+          })
+        };
+        if (apiKey) fetchOptions.headers['apikey'] = apiKey;
+        if (apiAuth) fetchOptions.headers['Authorization'] = apiAuth;
+
+        const baseUrl = apiUrl.endsWith('/') ? apiUrl : apiUrl + '/';
+        const response = await fetch(baseUrl + 'getLookupGroupsAndUsers', fetchOptions);
+        const data = await response.json();
+        return Array.isArray(data)
+          ? data
+          : Array.isArray(data?.data)
+            ? data.data
+            : Array.isArray(data?.result)
+              ? data.result
+              : Array.isArray(data?.results)
+                ? data.results
+                : [];
+      } catch {
+        return [];
+      }
+    },
+
+    /* Busca grupo/usuário em options */
+    findGroupById(id, list = this.options) {
+      const target = String(id);
+      for (const item of list || []) {
+        const hasChildren = Array.isArray(item.groupUsers) && item.groupUsers.length > 0;
+        // Alguns datasets usam o próprio item como grupo (com children)
+        if (String(item.id) === target && hasChildren) {
+          return item;
+        }
+        if (hasChildren) {
+          const found = this.findGroupById(target, item.groupUsers);
+          if (found) return found;
+        }
+      }
+      return null;
+    },
+    findUserById(id, list = this.options) {
+      const target = String(id);
+      for (const item of list || []) {
+        const hasGroup = Array.isArray(item.groupUsers) && item.groupUsers.length > 0;
+        if (!hasGroup && String(item.id) === target) {
+          return item;
+        }
+        if (hasGroup) {
+          const found = this.findUserById(target, item.groupUsers);
+          if (found) return found;
+        }
+      }
+      return null;
+    },
+
+    getInitial(name) {
+      return name ? String(name).trim().charAt(0).toUpperCase() : '';
+    },
+
+    refresh(params) {
+      this.currentParams = params;
+      // Se options mudarem dinamicamente
+      if (params?.options && params.options !== this.optionsCache) {
+        this.optionsCache = this.mapOptions(params.options);
+      }
+      return true;
+    }
+  }
+};
+</script>
+
+<style scoped>
+.user-cell {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.user-cell--group-user {
+  gap: 0;
+}
+.user-cell--group-user .selected-group-avatar {
+  margin-right: -8px;   /* mantém o grupo "um pouco atrás" */
+  position: relative;
+  z-index: 1;
+}
+.user-cell--group-user .selected-user-avatar {
+  position: relative;
+  z-index: 2;
+}
+.group-avatar-wrapper {
+  position: relative;
+}
+
+.avatar-outer {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #FFFFFF;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  box-shadow: 0 0 0 1px var(--grid-view-dinamica-avatar-shadow, #3A4663);
+}
+.avatar-middle {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+.user-cell__avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--grid-view-dinamica-avatar-bg, #4B6CB7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.user-cell__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.user-cell__initial {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  font-weight: 400;
+  background: transparent;
+  color: #fff;
+  border-radius: 50%;
+  letter-spacing: 0.5px;
+}
+.user-cell__group-icon {
+  color: #fff;
+  font-size: 18px;
+}
+.user-cell__name {
+  font-size: 12px;
+  font-weight: 400;
+  color: #444;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-left: 3px;
+}
+
+/* Tooltip do grupo */
+.user-cell__group-tooltip {
+  position: absolute;
+  top: 35px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  white-space: nowrap;
+  z-index: 1000;
+  text-align: center;
+}
+</style>

--- a/Project/TicketGrid/src/components/UserSelector.vue
+++ b/Project/TicketGrid/src/components/UserSelector.vue
@@ -1,0 +1,945 @@
+<template>
+  <div ref="dropdownRoot" class="user-selector-dropdown" :style="avatarThemeStyle">
+    <div
+      class="user-selector__selected"
+      @click="toggleDropdown"
+      :style="containerStyle"
+      :class="{ 'user-selector__selected--group-user': selectedGroup && selectedUser }"
+    >
+
+      <template v-if="!selectedGroup && !selectedUser">
+        <div class="user-selector__avatar-unassigned">
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <circle cx="12" cy="12" r="12" fill="#F3F4F6"/>
+            <path d="M12 12c1.933 0 3.5-1.567 3.5-3.5S13.933 5 12 5s-3.5 1.567-3.5 3.5S10.067 12 12 12zm0 2c-2.33 0-7 1.167-7 3.5V20h14v-2.5c0-2.333-4.67-3.5-7-3.5z" fill="#BDBDBD"/>
+          </svg>
+        </div>
+      </template>
+      <template v-else-if="selectedGroup && selectedUser">
+        <div
+          class="avatar-outer group-avatar-wrapper selected-group-avatar"
+          @mouseenter="showGroupTooltip = true"
+          @mouseleave="showGroupTooltip = false"
+        >
+
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">
+              <template v-if="selectedGroup.photoUrl || selectedGroup.PhotoURL || selectedGroup.PhotoUrl">
+                <img :src="selectedGroup.photoUrl || selectedGroup.PhotoURL || selectedGroup.PhotoUrl" alt="Group Photo" />
+              </template>
+              <template v-else>
+                <span class="material-symbols-outlined user-selector__group-icon">groups</span>
+              </template>
+            </div>
+          </div>
+          <div v-if="showGroupTooltip" class="user-selector__group-tooltip">
+            <div>{{ selectedGroup.name }}</div>
+            <div class="user-selector__group-tooltip-count">{{ selectedGroup.groupUsers?.length || 0 }} {{ (selectedGroup.groupUsers?.length || 0) === 1 ? translatePhrase('member') : translatePhrase('members') }}</div>
+          </div>
+        </div>
+        <div class="avatar-outer selected-user-avatar">
+
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">
+              <template v-if="selectedUser.photoUrl || selectedUser.PhotoURL || selectedUser.PhotoUrl">
+                <img :src="selectedUser.photoUrl || selectedUser.PhotoURL || selectedUser.PhotoUrl" alt="User Photo" />
+              </template>
+              <template v-else>
+                <span class="user-selector__initial" :style="initialStyle">
+                  {{ getInitial(selectedUser.name) }}
+                </span>
+              </template>
+            </div>
+          </div>
+        </div>
+      </template>
+      <template v-else>
+        <div class="avatar-outer group-avatar-wrapper" v-if="selectedGroup" @mouseenter="showGroupTooltip = true" @mouseleave="showGroupTooltip = false">
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">
+              <template v-if="selectedGroup.photoUrl || selectedGroup.PhotoURL || selectedGroup.PhotoUrl">
+                <img :src="selectedGroup.photoUrl || selectedGroup.PhotoURL || selectedGroup.PhotoUrl" alt="Group Photo" />
+              </template>
+              <template v-else>
+                <span class="material-symbols-outlined user-selector__group-icon">groups</span>
+              </template>
+            </div>
+          </div>
+          <div v-if="showGroupTooltip" class="user-selector__group-tooltip">
+            <div>{{ selectedGroup.name }}</div>
+            <div class="user-selector__group-tooltip-count">{{ selectedGroup.groupUsers?.length || 0 }} {{ (selectedGroup.groupUsers?.length || 0) === 1 ? translatePhrase('member') : translatePhrase('members') }}</div>
+          </div>
+        </div>
+        <div class="avatar-outer" v-else>
+          <div class="avatar-middle">
+            <div class="user-selector__avatar">
+              <template v-if="selectedUser && (selectedUser.photoUrl || selectedUser.PhotoURL || selectedUser.PhotoUrl)">
+                <img :src="selectedUser.photoUrl || selectedUser.PhotoURL || selectedUser.PhotoUrl" alt="User Photo" />
+              </template>
+              <template v-else>
+                <span class="user-selector__initial" :style="initialStyle">
+                  {{ selectedUser ? getInitial(selectedUser.name) : '' }}
+                </span>
+              </template>
+            </div>
+          </div>
+        </div>
+      </template>
+      <span class="user-selector__name" :style="nameStyle">
+        {{ selectedLabel }}
+      </span>
+    </div>
+
+    <div v-if="isOpen" class="user-selector__dropdown">
+      <template v-if="currentGroup">
+        <div class="user-selector__group-header">
+          <span
+            class="material-symbols-outlined user-selector__back"
+
+            @click.stop="backToRoot"
+
+            >chevron_left</span
+          >
+          <span class="user-selector__group-title" :style="nameStyle">
+            {{ currentGroup.name }}
+          </span>
+        </div>
+        <div class="user-selector__group-count">{{ currentGroupCountLabel }}</div>
+
+      </template>
+      <template v-else>
+        <div class="user-selector__search">
+          <input
+            v-model="search"
+            type="text"
+            :placeholder="searchPlaceholder"
+            class="user-selector__input"
+            :style="inputStyle"
+          />
+          <span class="material-symbols-outlined user-selector__icon">search</span>
+        </div>
+      </template>
+
+      <div class="user-selector__list">
+        <template v-if="groupBy && !currentGroup">
+          <div
+            class="user-selector__group"
+            v-for="group in groupedUsers.groups"
+            :key="group.label"
+          >
+            <div class="user-selector__group-label" :style="nameStyle">
+              {{ group.label.toUpperCase() != "USERS" &&  group.label.toUpperCase() != "USER" && group.label.toUpperCase() != "USUARIOS" ? group.label : ""}}
+            </div>
+
+            <div class="user-selector__group-items">
+              <div
+                v-for="user in group.items"
+                :key="user.id"
+                class="user-selector__item"
+                :class="{ disabled: user.isEnabled === false }"
+                @click.stop="
+                  user.isEnabled === false
+                    ? null
+                    : isGroupLabel(group.label)
+                      ? openGroup(user)
+                      : selectUser(user)
+                "
+              >
+                <div class="avatar-outer">
+                  <div class="avatar-middle">
+                    <div class="user-selector__avatar">
+                      <template v-if="user.photoUrl || user.PhotoURL || user.PhotoUrl">
+                        <img :src="user.photoUrl || user.PhotoURL || user.PhotoUrl" alt="User Photo" />
+                      </template>
+                      <template v-else>
+                        <span
+                          v-if="isGroupLabel(group.label)"
+                          class="material-symbols-outlined user-selector__group-icon"
+                        >
+                          groups
+                        </span>
+                        <span
+                          v-else
+                          class="user-selector__initial"
+                          :style="initialStyle"
+                        >
+                          {{ getInitial(user.name) }}
+                        </span>
+                      </template>
+                    </div>
+                  </div>
+                </div>
+                <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
+                <span
+                  v-if="user.groupUsers?.length"
+                  class="material-symbols-outlined user-selector__chevron"
+                  @click.stop="openGroup(user)"
+                  >chevron_right</span
+                >
+              </div>
+            </div>
+          </div>
+
+          <div
+            v-for="user in groupedUsers.ungrouped"
+            :key="user.id"
+            class="user-selector__item"
+            :class="{ disabled: user.isEnabled === false }"
+            @click.stop="user.isEnabled === false ? null : selectUser(user)"
+          >
+            <div class="avatar-outer">
+              <div class="avatar-middle">
+                <div class="user-selector__avatar">
+                  <template v-if="user.photoUrl || user.PhotoURL || user.PhotoUrl">
+                    <img :src="user.photoUrl || user.PhotoURL || user.PhotoUrl" alt="User Photo" />
+                  </template>
+                  <template v-else>
+                    <span class="user-selector__initial" :style="initialStyle">
+                      {{ getInitial(user.name) }}
+                    </span>
+                  </template>
+                </div>
+              </div>
+            </div>
+            <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
+            <span
+              v-if="user.groupUsers?.length"
+              class="material-symbols-outlined user-selector__chevron"
+              @click.stop="openGroup(user)"
+              >chevron_right</span
+            >
+          </div>
+        </template>
+
+        <template v-else>
+          <div class="user-selector__current-group-items">
+            <div
+              v-for="user in filteredUsers"
+              :key="user.id !== null ? user.id : 'assign'"
+              class="user-selector__item"
+              :class="{ disabled: user.isEnabled === false }"
+              @click.stop="user.isEnabled === false || user.groupUsers?.length ? null : selectUser(user)"
+            >
+              <div class="avatar-outer">
+                <div class="avatar-middle">
+                  <div class="user-selector__avatar">
+                    <template v-if="user.photoUrl || user.PhotoURL || user.PhotoUrl">
+                      <img :src="user.photoUrl || user.PhotoURL || user.PhotoUrl" alt="User Photo" />
+                    </template>
+                    <template v-else>
+                      <span v-if="user.isAssignToTeam" class="material-symbols-outlined user-selector__group-icon">groups</span>
+                      <span v-else class="user-selector__initial" :style="initialStyle">
+                        {{ getInitial(user.name) }}
+                      </span>
+                    </template>
+                  </div>
+                </div>
+              </div>
+              <span class="user-selector__name" :style="nameStyle">{{ user.name }}</span>
+              <span
+                v-if="user.groupUsers?.length"
+                class="material-symbols-outlined user-selector__chevron"
+                @click.stop="openGroup(user)"
+                >chevron_right</span
+              >
+            </div>
+          </div>
+        </template>
+
+        <div v-if="filteredUsers.length === 0" class="user-selector__no-results" :style="nameStyle">
+          {{ translatePhrase('No user found') }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { translatePhrase } from '../translation';
+export default {
+  name: 'UserSelector',
+  emits: ['trigger-event', 'user-selected'],
+  props: {
+    datasource: { type: Array, default: () => [] },
+    groupBy: String,
+    nameFontFamily: String,
+    nameFontSize: String,
+    nameFontWeight: [String, Number],
+    initialFontFamily: String,
+    initialFontSize: String,
+    initialFontWeight: [String, Number],
+    inputFontFamily: String,
+    inputFontSize: String,
+    inputFontWeight: [String, Number],
+    unassignedLabel: { type: String, default: () => translatePhrase('Unassigned') },
+    searchPlaceholder: { type: String, default: () => translatePhrase('Search user...') },
+    initialSelectedId: [String, Number, Object],
+    initialGroupId: [String, Number],
+    selectedUserId: [String, Number, Object],
+    uid: String,
+    maxWidth: [String, Number],
+    supabaseUrl: String,
+    apiKey: String,
+    authToken: String
+  },
+  data() {
+    return {
+      search: '',
+      isOpen: false,
+      selectedUser: null,
+      selectedGroup: null,
+      currentGroup: null,
+      currentGroupUsers: [],
+      groupStack: [],
+      showGroupTooltip: false
+
+    };
+  },
+  computed: {
+    filteredUsers() {
+      const source = this.currentGroup ? this.currentGroupUsers || [] : this.datasource;
+      const list = Array.isArray(source) ? source : [];
+      if (!this.search) return list;
+      const q = this.search.toLowerCase();
+      if (this.currentGroup) {
+        const assignItem = list[0];
+        const rest = list.slice(1).filter(u => String(u.name || '').toLowerCase().includes(q));
+        return [assignItem, ...rest];
+      }
+      return list.filter(u => String(u.name || '').toLowerCase().includes(q));
+    },
+    groupedUsers() {
+      if (!this.groupBy) {
+        return { groups: [], ungrouped: this.filteredUsers };
+      }
+      const groups = new Map();
+      const ungrouped = [];
+      for (const user of this.filteredUsers) {
+        const key =
+          (typeof wwLib !== 'undefined' && wwLib.resolveObjectPropertyPath)
+            ? wwLib.resolveObjectPropertyPath(user, this.groupBy)
+            : user?.[this.groupBy];
+        if (key === undefined || key === null || key === '') {
+          ungrouped.push(user);
+        } else {
+          if (!groups.has(key)) groups.set(key, []);
+          groups.get(key).push(user);
+        }
+      }
+      return { groups: Array.from(groups, ([label, items]) => ({ label, items })), ungrouped };
+    },
+    nameStyle() {
+      const fallbackFont = "var(--grid-view-dinamica-font-family, inherit)";
+      return {
+        fontFamily: this.nameFontFamily || fallbackFont,
+        fontSize: this.nameFontSize,
+        fontWeight: this.nameFontWeight,
+      };
+    },
+    initialStyle() {
+      const fallbackFont = "var(--grid-view-dinamica-font-family, inherit)";
+      return {
+        fontFamily: this.initialFontFamily || fallbackFont,
+        fontSize: this.initialFontSize,
+        fontWeight: this.initialFontWeight,
+      };
+    },
+    inputStyle() {
+      const fallbackFont = "var(--grid-view-dinamica-font-family, inherit)";
+      return {
+        fontFamily: this.inputFontFamily || fallbackFont,
+        fontSize: this.inputFontSize,
+        fontWeight: this.inputFontWeight,
+      };
+    },
+    containerStyle() {
+      return this.maxWidth ? { maxWidth: typeof this.maxWidth === 'number' ? `${this.maxWidth}px` : this.maxWidth } : {};
+    },
+    avatarThemeStyle() {
+      const theme = window?.wwLib?.wwVariable?.getValue?.('61c1b425-10e8-40dc-8f1f-b117c08b9726') || {};
+      return {
+        '--grid-view-dinamica-avatar-bg': theme?.bgButtonPrimary || '#4B6CB7',
+        '--grid-view-dinamica-avatar-shadow': theme?.primary || '#3A4663'
+      };
+    },
+    currentGroupCountLabel() {
+      const count = this.currentGroup?.groupUsers?.length || 0;
+      return `${count} ${count === 1 ? translatePhrase('member') : translatePhrase('members')}`;
+    },
+    selectedLabel() {
+      if (this.selectedGroup && this.selectedUser) return this.selectedUser.name;
+      if (this.selectedGroup && !this.selectedUser) return this.selectedGroup.name;
+      return this.selectedUser ? this.selectedUser.name : this.unassignedLabel;
+    },
+  },
+  created() {
+    if (
+      this.uid &&
+      typeof wwLib !== 'undefined' &&
+      wwLib.wwVariable &&
+      wwLib.wwVariable.useComponentVariable
+    ) {
+      this.selectedUserIdVar = wwLib.wwVariable.useComponentVariable({
+        uid: this.uid,
+        name: 'selectedUserId',
+        type: 'text',
+        defaultValue: ''
+      });
+    } else {
+      this.selectedUserIdVar = null;
+
+    }
+  },
+  mounted() {
+    document.addEventListener('click', this.handleClickOutside);
+    this.initializeSelectedUser();
+  },
+  beforeUnmount() {
+    document.removeEventListener('click', this.handleClickOutside);
+  },
+  watch: {
+    selectedUserId: {
+      immediate: true,
+      deep: true,
+      handler(newVal) {
+        this.setSelectedFromValue(newVal);
+      }
+    },
+    initialSelectedId: {
+      immediate: true,
+      handler() {
+        this.initializeSelectedUser(true);
+      }
+    },
+    initialGroupId: {
+      immediate: true,
+      handler() {
+        this.initializeSelectedUser(true);
+      }
+
+    },
+    datasource: {
+      handler() {
+        this.initializeSelectedUser();
+      },
+      deep: true
+    },
+    selectedUser() {
+      this.updateComponentVariable();
+    },
+    selectedGroup() {
+      this.updateComponentVariable();
+    }
+  },
+  methods: {
+    translatePhrase,
+    toggleDropdown() {
+      this.isOpen = !this.isOpen;
+      if (!this.isOpen) {
+        this.currentGroup = null;
+        this.currentGroupUsers = [];
+        this.groupStack = [];
+        this.search = '';
+      }
+    },
+    closeDropdown(event) {
+      if (this.isOpen && !(this.$refs.dropdownRoot?.contains?.(event.target))) {
+        this.isOpen = false;
+        this.currentGroup = null;
+        this.currentGroupUsers = [];
+        this.groupStack = [];
+        this.search = '';
+      }
+    },
+    async selectUser(user) {
+      let value;
+      if (this.currentGroup) {
+        if (user.isAssignToTeam) {
+          this.selectedGroup = this.currentGroup;
+          this.selectedUser = null;
+          value = { userid: null, groupid: this.currentGroup.id };
+        } else {
+          this.selectedGroup = this.currentGroup;
+          this.selectedUser = user;
+          value = { userid: user.id, groupid: this.currentGroup.id };
+        }
+      } else {
+        this.selectedGroup = null;
+        this.selectedUser = user;
+        value = { userid: user.id, groupid: null };
+      }
+      this.isOpen = false;
+      this.currentGroup = null;
+      this.currentGroupUsers = [];
+      this.groupStack = [];
+      this.$emit('user-selected', value);
+      this.$emit('trigger-event', {
+        name: 'onChange',
+        event: { value }
+      });
+    },
+    openGroup(group) {
+      if (group.groupUsers && group.groupUsers.length) {
+        this.groupStack.push(this.currentGroup);
+        this.currentGroup = group;
+        this.currentGroupUsers = [{ id: null, name: 'Assign to team', isAssignToTeam: true }, ...group.groupUsers];
+        this.search = '';
+      }
+    },
+    backToRoot() {
+      this.currentGroup = this.groupStack.pop() || null;
+      this.currentGroupUsers = this.currentGroup ? [{ id: null, name: 'Assign to team', isAssignToTeam: true }, ...(this.currentGroup.groupUsers || [])] : [];
+      this.search = '';
+      this.isOpen = true;
+
+    },
+    handleClickOutside(event) {
+      this.closeDropdown(event);
+    },
+    getInitial(name) {
+      return name ? String(name).trim().charAt(0).toUpperCase() : '';
+    },
+    isGroupLabel(label) {
+      const value = String(label || '').toUpperCase();
+      return ['GROUP', 'GROUPS', 'GRUPO', 'GRUPOS'].includes(value);
+    },
+    findGroupById(id, list = this.datasource) {
+      for (const item of list || []) {
+        if (String(item.id) === String(id)) {
+          return item;
+        }
+        if (Array.isArray(item.groupUsers) && item.groupUsers.length) {
+
+          const found = this.findGroupById(id, item.groupUsers);
+          if (found) return found;
+        }
+      }
+      return null;
+    },
+    findUserById(id, list = this.datasource) {
+      for (const item of list || []) {
+        const hasGroup = Array.isArray(item.groupUsers) && item.groupUsers.length > 0;
+        if (String(item.id) === String(id) && !hasGroup) {
+          return item;
+        }
+        if (hasGroup) {
+
+          const found = this.findUserById(id, item.groupUsers);
+          if (found) return found;
+        }
+      }
+      return null;
+    },
+    initializeSelectedUser(force = false) {
+      let target = this.selectedUserId;
+      const hasSelected =
+        !force &&
+        target !== undefined &&
+        target !== null &&
+        target !== '' &&
+        !(typeof target === 'object' && Object.keys(target).length === 0);
+
+      if (!hasSelected) {
+        const groupId =
+          this.initialGroupId !== undefined && this.initialGroupId !== null && this.initialGroupId !== ''
+            ? this.initialGroupId
+            : null;
+        const userId =
+          this.initialSelectedId !== undefined && this.initialSelectedId !== null && this.initialSelectedId !== ''
+            ? this.initialSelectedId
+            : null;
+
+        target = groupId !== null ? { userid: userId, groupid: groupId } : userId;
+
+      }
+      this.setSelectedFromValue(target);
+      this.updateComponentVariable();
+      if (this.selectedGroup || this.selectedUser) {
+        const value = {
+          userid: this.selectedUser ? this.selectedUser.id : null,
+          groupid: this.selectedGroup ? this.selectedGroup.id : null
+        };
+        this.$emit('user-selected', value);
+        this.$emit('trigger-event', { name: 'onChange', event: { value } });
+      }
+    },
+    setSelectedFromValue(value) {
+      if (!value) {
+        this.selectedUser = null;
+        this.selectedGroup = null;
+        return;
+      }
+      if (typeof value === 'object') {
+        const hasGroupId = value.groupid !== undefined && value.groupid !== null && value.groupid !== '';
+
+        const group = hasGroupId ? this.findGroupById(value.groupid) : null;
+
+        this.selectedGroup = group || null;
+
+        const hasUserId = value.userid !== undefined && value.userid !== null && value.userid !== '';
+        if (group && hasUserId) {
+          const user = this.findUserById(value.userid, group.groupUsers || []);
+
+          this.selectedUser = user || null;
+        } else if (group && !hasUserId) {
+          this.selectedUser = null;
+        } else if (hasUserId) {
+          const user = this.findUserById(value.userid);
+
+          this.selectedUser = user || null;
+          this.selectedGroup = null;
+        } else {
+          this.selectedUser = null;
+          this.selectedGroup = null;
+        }
+      } else {
+        const user = this.findUserById(value);
+
+        this.selectedUser = user || null;
+        this.selectedGroup = null;
+      }
+    },
+    updateComponentVariable() {
+    if (!this.selectedUserIdVar) return;
+
+    const val = {
+      userid: this.selectedUser ? this.selectedUser.id : null,
+      groupid: this.selectedGroup ? this.selectedGroup.id : null
+    };
+    this.selectedUserIdVar.setValue(JSON.stringify(val));
+  },
+  }
+};
+</script>
+
+<style scoped>
+.user-selector-dropdown {
+  position: relative;
+  width: auto;
+  display: inline-block;
+  font-family: inherit;
+}
+.user-selector__selected {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  border-radius: 24px;
+  padding: 6px 16px 6px 8px;
+  background: transparent;
+  min-height: 44px;
+  transition: box-shadow 0.2s;
+  gap: 10px;
+  border: none;
+  width: auto;
+  min-width: 0;
+}
+.user-selector__selected:hover, .user-selector__selected:focus {
+  box-shadow: none;
+}
+.avatar-outer {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid #FFFFFF;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  box-shadow: 0 0 0 1px var(--grid-view-dinamica-avatar-shadow, #3A4663);
+}
+.group-avatar-wrapper {
+  position: relative;
+}
+.user-selector__selected--group-user {
+  gap: 0;
+}
+.user-selector__selected--group-user .selected-group-avatar {
+  margin-right: -8px;
+  position: relative;
+  z-index: 1;
+}
+.user-selector__selected--group-user .selected-user-avatar {
+  position: relative;
+  z-index: 2;
+}
+
+.user-selector__group-tooltip {
+  position: absolute;
+  top: 35px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #333;
+  color: #fff;
+  padding: 6px 10px;
+  border-radius: 4px;
+  font-size: 16px;
+  white-space: nowrap;
+  z-index: 101;
+  text-align: center;
+}
+.user-selector__group-tooltip-count {
+  font-size: 12px;
+  color: #ddd;
+}
+.avatar-middle {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  border: 2px solid #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+}
+.user-selector__avatar {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--grid-view-dinamica-avatar-bg, #4B6CB7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.user-selector__avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.user-selector__initial {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 15px;
+  font-weight: 400;
+  background: transparent;
+  color: #fff;
+  border-radius: 50%;
+  letter-spacing: 0.5px;
+}
+.user-selector__group-icon {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  color: #fff;
+}
+.user-selector__name {
+  font-size: 15px;
+  font-weight: 500;
+  color: #444;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 100%;
+  padding-left: 3px;
+}
+.user-selector__placeholder {
+  color: #aaa;
+  font-size: 15px;
+}
+.user-selector__arrow {
+  margin-left: auto;
+  font-size: 16px;
+  color: #888;
+}
+.user-selector__dropdown {
+  position: absolute;
+  top: 110%;
+  left: 0;
+  width: 220px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px #0002;
+  z-index: 10;
+  padding: 8px 0 4px 0;
+  border: none;
+  display: flex;
+  flex-direction: column;
+}
+.user-selector__list {
+  max-height: 400px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+.user-selector__list::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+  border-radius: 12px;
+}
+.user-selector__list::-webkit-scrollbar-thumb {
+  background: #bdbdbd;
+  border-radius: 12px;
+}
+.user-selector__list::-webkit-scrollbar-corner {
+  background: transparent;
+}
+.user-selector__list::-webkit-scrollbar-button {
+  display: none;
+  height: 0;
+}
+.user-selector__search {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  position: relative;
+  padding: 0 12px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.user-selector__input {
+  flex: 1;
+  width: 100%;
+  padding: 8px 36px 8px 12px;
+  border-radius: 20px;
+  font-size: 15px;
+  border: 1px solid #E0E0E0 !important;
+  background: #fff;
+  outline: none !important;
+  box-shadow: none !important;
+  transition: border 0.2s;
+  box-sizing: border-box;
+}
+.user-selector__input:focus {
+  border: 1.5px solid #E0E0E0 !important;
+  outline: none !important;
+  box-shadow: none !important;
+}
+.user-selector__icon {
+  position: absolute;
+  right: 22px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 22px;
+  color: #888;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.user-selector__item {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  padding: 8px 12px;
+  border-radius: 6px;
+  transition: background 0.2s;
+  gap: 10px;
+  border: none;
+}
+.user-selector__item.disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.user-selector__item:hover {
+  background: #f5f5f5;
+}
+.user-selector__chevron {
+  margin-left: auto;
+  font-size: 20px;
+  color: #888;
+  cursor: pointer;
+}
+.user-selector__group-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 12px 4px;
+}
+.user-selector__back {
+  cursor: pointer;
+  font-size: 20px;
+  color: #444;
+}
+.user-selector__group-title {
+  flex: 1;
+}
+.user-selector__group-count {
+  font-size: 12px;
+  padding: 0 12px 8px;
+  color: #888;
+}
+.user-selector__group-label {
+  padding: 4px 12px;
+  font-weight: 600;
+  color: #444;
+}
+
+.user-selector__group-items {
+  max-height: 130px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+
+.user-selector__current-group-items {
+  max-height: 200px;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+
+.user-selector__group-items::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+  border-radius: 12px;
+}
+
+.user-selector__group-items::-webkit-scrollbar-thumb {
+  background: #bdbdbd;
+  border-radius: 12px;
+}
+
+.user-selector__group-items::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.user-selector__group-items::-webkit-scrollbar-button {
+  display: none;
+  height: 0;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+  border-radius: 12px;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar-thumb {
+  background: #bdbdbd;
+  border-radius: 12px;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.user-selector__current-group-items::-webkit-scrollbar-button {
+  display: none;
+  height: 0;
+}
+.user-selector__no-results {
+  color: #aaa;
+  text-align: center;
+  padding: 8px 0;
+  font-size: 14px;
+}
+.user-selector__avatar-unassigned {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed #3A4663;
+}
+</style>

--- a/Project/TicketGrid/src/components/WewebCellRenderer.vue
+++ b/Project/TicketGrid/src/components/WewebCellRenderer.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="ww-cell-renderer">
+        <wwLayoutItemContext
+            is-repeat
+            :index="params.node.sourceRowIndex"
+            :data="{ value: params.value, row: params.data }"
+        >
+            <wwElement v-bind="params.containerId" class="ww-cell-renderer-flexbox"></wwElement>
+        </wwLayoutItemContext>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "WewebCellRenderer",
+    props: {
+        params: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>
+
+<style scoped lang="scss">
+.ww-cell-renderer {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    line-height: normal;
+    :deep(.ww-cell-renderer-flexbox) {
+        flex: 1;
+    }
+}
+</style>

--- a/Project/TicketGrid/src/components/list-filter.css
+++ b/Project/TicketGrid/src/components/list-filter.css
@@ -1,0 +1,454 @@
+/* Filtro customizado para campos do tipo list */
+.list-filter,
+.list-editor {
+  padding: 25px 10px 8px 10px !important;
+  min-width: 260px;
+  max-width: 350px;
+  max-height: 340px;
+  background: #fff;
+  border: 1px solid #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(255, 255, 255, 0.067);
+  font-size: 15px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  overflow: hidden;
+  position: relative;
+}
+
+.filter-list {
+  max-height: 220px;
+  overflow-y: auto;
+  background: transparent;
+  border-radius: 12px;
+  margin-bottom: 10px;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+
+/* Barra de rolagem moderna e sem setas */
+.filter-list::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+  border-radius: 12px;
+}
+
+.filter-list::-webkit-scrollbar-thumb {
+  background: #bdbdbd;
+  border-radius: 12px;
+}
+
+.filter-list::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* Remove as setas (botões) da barra de rolagem no Chrome/Safari/Edge */
+.filter-list::-webkit-scrollbar-button {
+  display: none;
+  height: 0;
+}
+
+:is(.list-filter, .list-editor) .filter-list,
+:is(.list-filter, .list-editor) .filter-item,
+:is(.list-filter, .list-editor) .filter-label {
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  font-size: 13px;
+}
+
+:is(.list-filter, .list-editor) .filter-header { margin-bottom: 10px; }
+
+:is(.list-filter, .list-editor) .field-search {
+  position: relative;
+  padding: 0 0 10px 0;
+}
+
+:is(.list-filter, .list-editor) .search-input {
+  width: 100%;
+  padding: 7px 36px 7px 13px;
+  border: 1px solid #ddd;
+  border-radius: 20px;
+  font-size: 13px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  outline: none;
+  background: #fff;
+  color: #444;
+  box-sizing: border-box;
+}
+
+:is(.list-filter, .list-editor) .search-input::placeholder {
+  color: #aaa;
+  font-size: 13px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+}
+
+:is(.list-filter, .list-editor) .search-icon {
+  position: absolute;
+  right: 12px;
+  top: 16px;
+  transform: translateY(-50%);
+  color: #999;
+  width: 20px;
+  height: 20px;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+:is(.list-filter, .list-editor) .search-icon i.material-symbols-outlined-search {
+  font-family: 'Material Symbols Outlined';
+  font-size: 19px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+:is(.list-filter, .list-editor) .filter-list {
+  max-height: 250px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+
+:is(.list-filter, .list-editor) .select-all-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #e0e0e0;
+  font-size: 13px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  color: #444;
+  gap: 8px;
+}
+
+:is(.list-filter, .list-editor) .select-all-row label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 6px 8px 6px 8px;
+  border-radius: 8px;
+  transition: background 0.15s;
+  width: 100%;
+}
+
+:is(.list-filter, .list-editor) .select-all-row label:hover { background: #f6f7fa; }
+
+:is(.list-filter, .list-editor) .select-all-checkbox {
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  border: 2px solid #bfc6d1;
+  accent-color: #5e6a75;
+  background: #fff;
+  transition: border-color 0.2s, background 0.2s;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+:is(.list-filter, .list-editor) .filter-item {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px 6px 8px;
+  font-size: 13px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  cursor: pointer;
+  gap: 8px;
+  border-radius: 8px;
+  transition: background 0.15s;
+  justify-content: flex-start;
+}
+
+
+:is(.list-filter, .list-editor) .filter-item input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  border: 2px solid #bfc6d1;
+  accent-color: #5e6a75;
+  background: #fff;
+  transition: border-color 0.2s, background 0.2s;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+:is(.list-filter, .list-editor) .filter-item input[type="checkbox"]:checked {
+  background: #5e6a75;
+  border-color: #5e6a75;
+}
+:is(.list-filter, .list-editor) .filter-item input[type="checkbox"]:focus { outline: none; }
+
+:is(.list-filter, .list-editor) .filter-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+  display: inline-block;
+  color: #444;
+  font-size: 13px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+}
+
+/* Specific styles for Deadline filter */
+.deadline-filter { max-width: none; max-height: none; overflow: visible; }
+
+.deadline-filter .field-search { padding-bottom: 12px; margin-bottom: 12px; border-bottom: 1px solid #ccc; }
+.deadline-filter .field-search .search-input { padding: 7px 36px 7px 13px; }
+.deadline-filter .filter-list { max-height: none; overflow: visible; }
+.deadline-filter .filter-item { width: 100%; padding: 12px 12px; margin-bottom: 8px; }
+
+.deadline-filter .filter-item.custom {
+  border-top: 1px solid #ccc;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.deadline-filter .filter-item.custom .arrow-icon {
+  margin-left: auto;
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #424242;
+  font-size: 20px !important;
+  cursor:pointer;
+  flex-shrink: 0;
+}
+
+.deadline-filter .custom-header { display: flex; align-items: center; margin-bottom: 8px; }
+.deadline-filter .custom-header .back-btn {
+
+  border-radius: 6px;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #424242;
+  font-size: 20px !important;
+  line-height: 1;
+  padding: 0;
+  margin-right: 6px;
+}
+.deadline-filter .custom-header .custom-title { margin-left: auto; font-size: 13px; }
+
+.deadline-filter .custom-select {
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 6px 10px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  background: #fff;
+  color: #444;
+  box-sizing: border-box;
+}
+
+.deadline-filter .custom-range { display: flex; align-items: center; gap: 4px; margin-bottom: 8px; }
+.deadline-filter .custom-range.between-mode { flex-direction: column; align-items: stretch; }
+
+.deadline-filter .custom-range input[type="date"] {
+  flex: 1;
+  padding: 6px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+  color: #444;
+  box-sizing: border-box;
+}
+
+/* Estilos para opções de usuário com avatar */
+:is(.list-filter, .list-editor) .user-option { display: flex; align-items: center; gap: 8px; }
+:is(.list-filter, .list-editor) .avatar-outer {
+  width: 24px; height: 24px; border-radius: 50%; border: 1px solid #FFFFFF;
+  display: flex; align-items: center; justify-content: center; background: #fff; flex-shrink: 0;
+  box-shadow: 0 0 0 1px var(--grid-view-dinamica-avatar-shadow, #3A4663);
+}
+:is(.list-filter, .list-editor) .avatar-middle {
+  width: 22px; height: 22px; border-radius: 50%; border: 2px solid #fff;
+  display: flex; align-items: center; justify-content: center; background: #fff;
+}
+:is(.list-filter, .list-editor) .user-avatar {
+  width: 18px; height: 18px; border-radius: 50%; background: var(--grid-view-dinamica-avatar-bg, #4B6CB7);
+  display: flex; align-items: center; justify-content: center; overflow: hidden;
+}
+:is(.list-filter, .list-editor) .user-avatar img { width: 100%; height: 100%; object-fit: cover; border-radius: 50%; }
+:is(.list-filter, .list-editor) .user-initial {
+  width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;
+  font-size: 12px; font-weight: 400; background: transparent; color: #fff; border-radius: 50%; letter-spacing: 0.5px;
+}
+
+:is(.list-filter, .list-editor) .editor-close {
+  position: absolute; top: 2px; right: 8px; font-size: 18px; color: #888; cursor: pointer; line-height: 1;
+}
+
+/* ---- DatePicker base ---- */
+.dp-wrapper { position: relative; display: inline-flex; align-items: center; gap: 6px; }
+.dp-input { width: 160px; padding: 8px 10px; border: 1px solid #d0d5dd; border-radius: 8px; background: #fff; font: 14px/1.2 var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif); cursor: pointer; }
+.dp-input[disabled] { background: #f2f4f7; color: #98a2b3; cursor: not-allowed; }
+.dp-icon { border: 0; background: transparent; cursor: pointer; padding: 4px; border-radius: 6px; }
+.dp-icon:hover { background: #f2f4f7; }
+
+.datepicker-pop { position: fixed; z-index: 9999; background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 10px 30px rgba(0,0,0,.08); width: 280px; padding: 8px; user-select: none; }
+.dp-header { display: flex; align-items: center; justify-content: space-between; padding: 4px 4px 8px; }
+.dp-title { font: 600 14px/1.2 Inter, system-ui, Arial; }
+.dp-nav {
+  border: 1px solid #ccc;
+  background: #f7f7f7;
+  border-radius: 6px;
+  min-width: 28px;
+  min-height: 28px;
+  padding: 2px 8px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+.dp-nav:active { transform: translateY(1px); }
+
+.dp-weekdays, .dp-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
+.dp-weekdays { padding: 4px 2px; color: #6b7280; font: 600 11px/1 Inter, sans-serif; text-transform: uppercase; letter-spacing: .02em; }
+.dp-weekday { text-align: center; }
+.dp-grid { padding: 6px 2px 4px; }
+.dp-cell {
+  border: 1px solid transparent;
+  height: 30px;
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  font: 500 13px/1 Inter, sans-serif;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.dp-cell:hover { background: #f3f4f6; }
+.dp-cell.is-muted { color: #9ca3af; }
+.dp-cell.is-selected { background: #e7f0ff; border-color: #84a9ff; }
+.dp-cell.is-today { outline: 1px dashed #aaa; }
+
+.dp-actions { display: flex; gap: 6px; justify-content: flex-end; padding: 8px; flex-wrap: wrap; }
+.dp-action {
+  flex: 1;
+  border: 1px solid #ccc;
+  background: #f7f7f7;
+  height: 32px;
+  border-radius: 6px;
+  cursor: pointer;
+  font: 600 12px/1 Inter;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.dp-action:hover { background: #f9fafb; }
+
+.list-filter.deadline-filter { min-width: 280px; }
+.field-search { position: relative; margin-bottom: 8px; }
+.field-search .search-input { width: 100%; padding: 8px 10px; border: 1px solid #e5e7eb; border-radius: 8px; }
+.filter-list { display: flex; flex-direction: column; gap: 4px; max-height: 320px; overflow: auto; }
+.filter-item { display: flex; align-items: center; justify-content: space-between; padding: 8px 10px; border-radius: 8px; cursor: pointer; }
+.filter-item:hover { background: #f3f4f6; }
+.filter-item.selected { background: #e0e7ff; }
+.filter-item.custom.selected,
+.filter-item.clear.selected {
+  background: transparent;
+}
+.custom-header { display: flex; align-items: center; gap: 6px; margin-bottom: 8px; }
+.custom-title { font-weight: 400; }
+.custom-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 8px; }
+.custom-select { flex: 1; height: 32px; border: 1px solid #e5e7eb; border-radius: 8px; padding: 0 8px; }
+.custom-range { display: flex; flex-direction: column; gap: 8px; margin: 8px 0; }
+.picker-row { display: grid; grid-template-columns: 60px 1fr; align-items: center; gap: 8px; }
+.picker-label { color: #6b7280; font: 600 12px/1 Inter; }
+.custom-actions { display: flex; gap: 6px; }
+.apply-btn, .cancel-btn {
+  height: 32px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #f7f7f7;
+  flex: 1;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 13px;
+  color: #424242;
+}
+.apply-btn:hover:not(:disabled),
+.cancel-btn:hover { background: #ececec; }
+.apply-btn:disabled {
+  opacity: .5;
+  cursor: not-allowed;
+}
+
+/* Garante que o popup não seja clipado por containers do menu (usa Teleport→body) */
+.dp-backdrop {
+  position: fixed !important;
+  inset: 0 !important;
+  z-index: 2147483646 !important; /* ↑ sobe o nível do backdrop */
+  background: transparent !important;
+}
+
+.datepicker-pop {
+  position: fixed !important;
+  z-index: 2147483647 !important; /* ↑ garante no topo */
+  width: 280px;
+  border-radius: 12px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 10px 30px rgba(0,0,0,.08);
+  padding: 8px;
+}
+
+/* Botões do calendário podem ser afetados por resets (ex.: button{all:unset}) */
+.dp-nav, .dp-cell, .dp-action, .dp-icon {
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.dp-nav {
+  min-width: 28px;
+  min-height: 28px;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+  background: #f7f7f7;
+  padding: 2px 8px;
+}
+.dp-cell {
+  height: 30px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  padding: 0 0.25rem;
+}
+.dp-action {
+  height: 32px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  padding: 0 .5rem;
+  background: #f7f7f7;
+}
+.dp-icon { padding: 4px; border-radius: 6px; }
+.dp-cell.is-selected { background: #e7f0ff; border-color: #84a9ff; }
+.dp-cell.is-today { outline: 1px dashed #aaa; }
+
+/* Garanta que a fonte de ícone exista (Material Symbols) */
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined', sans-serif !important;
+  font-weight: normal; font-style: normal; line-height: 1;
+  letter-spacing: normal; text-transform: none; display: inline-block;
+  white-space: nowrap; word-wrap: normal; direction: ltr;
+  -webkit-font-feature-settings: 'liga'; -webkit-font-smoothing: antialiased;
+}

--- a/Project/TicketGrid/src/translation.js
+++ b/Project/TicketGrid/src/translation.js
@@ -1,0 +1,58 @@
+export function translatePhrase(phrase) {
+  if (phrase == null) {
+    return "";
+  }
+
+  const lang = window?.wwLib?.wwVariable?.getValue("aa44dc4c-476b-45e9-a094-16687e063342"); // idioma atual (ex: "pt-BR")
+  const jsonArr = window?.wwLib?.wwVariable?.getValue("4bb37062-2a1b-4cb6-a115-ae6df0c557d2"); // array de traduções
+  const allLangs = window?.wwLib?.wwVariable?.getValue("5abe8801-7f12-4c9c-b356-900431ab4491"); // lista de idiomas
+
+  if (!Array.isArray(jsonArr) || !Array.isArray(allLangs)) {
+    return String(phrase);
+  }
+
+  const isoLangs = allLangs.map((l) => l.Lang); // ["en-US", "pt-BR", ...]
+
+  // Helper para encontrar índice de um termo existente
+  function findIndexByTerm(term) {
+    return jsonArr.findIndex(
+      (obj) => obj.term?.trim().toLowerCase() === term.trim().toLowerCase()
+    );
+  }
+
+  const part = String(phrase).trim();
+  if (!part) {
+    return "";
+  }
+
+  const idx = findIndexByTerm(part);
+
+  if (idx === -1) {
+    // 🔹 Não existe → cria novo registro completo
+    const newEntry = { term: part, source: "FrontEnd" };
+
+    // Preenche cada idioma com o próprio texto (ou tradução automática se quiser depois)
+    isoLangs.forEach((code) => {
+      // Inicialmente copia o termo original para todos os idiomas
+      newEntry[code] = part;
+    });
+
+    // Adiciona ao array principal
+    jsonArr.push(newEntry);
+
+    // Retorna o texto no idioma atual (ou o termo se não houver tradução)
+    return newEntry[lang] ?? part;
+  } else {
+    // 🔹 Já existe → retorna a tradução existente (ou o próprio termo se estiver vazio)
+    const entry = jsonArr[idx];
+
+    const value = entry[lang];
+
+    // Se for string vazia, null ou undefined → retorna phrase
+    if (value === "" || value == null) {
+      return String(phrase);
+    }
+
+    return value;
+  }
+}

--- a/Project/TicketGrid/src/utils/fontFamily.js
+++ b/Project/TicketGrid/src/utils/fontFamily.js
@@ -1,0 +1,60 @@
+const DEFAULT_FONT_FAMILY = "Roboto, Arial, sans-serif";
+
+const TYPOGRAPHY_VARIABLE_ID = "5e429bf8-2fe3-42e4-a41d-e3b4ac1b52fa";
+
+function sanitizeFontFamily(fontFamily) {
+  if (typeof fontFamily !== "string") {
+    return "";
+  }
+
+  const trimmed = fontFamily.trim();
+  return trimmed.length > 0 ? trimmed : "";
+}
+
+export function readTypographyVariable() {
+  try {
+    if (typeof window === "undefined") {
+      return "";
+    }
+
+    const getter = window?.wwLib?.wwVariable?.getValue;
+    if (typeof getter !== "function") {
+      return "";
+    }
+
+    const typographySettings = getter(TYPOGRAPHY_VARIABLE_ID);
+    return sanitizeFontFamily(typographySettings?.fontFamily);
+  } catch {
+    return "";
+  }
+}
+
+export function resolveTypographyFontFamily(customFallback) {
+  const typographyFontFamily = readTypographyVariable();
+  if (typographyFontFamily) {
+    return typographyFontFamily;
+  }
+
+  const fallback = sanitizeFontFamily(customFallback);
+  if (fallback) {
+    return fallback;
+  }
+
+  return DEFAULT_FONT_FAMILY;
+}
+
+export function applyGlobalGridFontFamily(fontFamily) {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const target = document.documentElement;
+  if (!fontFamily) {
+    target.style.removeProperty("--grid-view-dinamica-font-family");
+    return;
+  }
+
+  target.style.setProperty("--grid-view-dinamica-font-family", fontFamily);
+}
+
+export { DEFAULT_FONT_FAMILY, TYPOGRAPHY_VARIABLE_ID };

--- a/Project/TicketGrid/src/wwElement.vue
+++ b/Project/TicketGrid/src/wwElement.vue
@@ -1,0 +1,4994 @@
+<template>
+  <div class="ww-datagrid" :class="[{ editing: isEditing }, paginationPositionClass]" :style="cssVars">
+    <ag-grid-vue :key="componentKey" ref="agGridRef" :rowData="rowData" :columnDefs="finalColumnDefs"
+      :defaultColDef="defaultColDef" :domLayout="content.layout === 'auto' ? 'autoHeight' : 'normal'" :style="style"
+      :rowSelection="rowSelection" :suppressMovableColumns="!content.movableColumns" :alwaysShowHorizontalScroll="false"
+      :suppressColumnMoveAnimation="true" :suppressDragLeaveHidesColumns="true" :maintainColumnOrder="true"
+      :suppressPropertyNamesCheck="true" :isColumnMovable="isColumnMovable" :theme="theme" :getRowId="getRowId"
+      :pagination="content.pagination" :paginationPageSize="content.paginationPageSize || 10"
+      :paginationPageSizeSelector="false" :columnHoverHighlight="content.columnHoverHighlight" :locale-text="localeText"
+      :components="editorComponents" :singleClickEdit="true" @grid-ready="onGridReady" @row-selected="onRowSelected"
+      @selection-changed="onSelectionChanged" @cell-value-changed="onCellValueChanged" @filter-changed="onFilterChanged"
+      @sort-changed="onSortChanged" @column-moved="onColumnMoved" @row-clicked="onRowClicked"
+      @row-data-changed="onRowDataChanged" @row-data-updated="onRowDataUpdated"
+      @first-data-rendered="onFirstDataRendered" @cell-clicked="onCellClicked"
+      @cell-mouse-over="onCellMouseOver">
+    </ag-grid-vue>
+  </div>
+</template>
+
+<script>
+  import { shallowRef, computed, ref, onMounted, onUnmounted, watch, h, nextTick } from "vue";
+  import { AgGridVue } from "ag-grid-vue3";
+  import {
+  AllCommunityModule,
+  ModuleRegistry,
+  themeQuartz,
+  } from "ag-grid-community";
+  import {
+  AG_GRID_LOCALE_EN,
+  AG_GRID_LOCALE_FR,
+  AG_GRID_LOCALE_DE,
+  AG_GRID_LOCALE_ES,
+  AG_GRID_LOCALE_PT,
+  } from "@ag-grid-community/locale";
+  import ActionCellRenderer from "./components/ActionCellRenderer.vue";
+  import ImageCellRenderer from "./components/ImageCellRenderer.vue";
+  import WewebCellRenderer from "./components/WewebCellRenderer.vue";
+  import FormatterCellRenderer from "./components/FormatterCellRenderer.vue";
+  import UserCellRenderer from "./components/UserCellRenderer.vue";
+  import ListFilterRenderer from "./components/ListFilterRenderer.js";
+  import ResponsibleUserFilterRenderer from "./components/ResponsibleUserFilterRenderer.js";
+  import DeadlineFilterRenderer from "./components/DeadlineFilterRenderer.js";
+  import DateTimeCellEditor from "./components/DateTimeCellEditor.vue";
+  import FixedListCellEditor from "./components/FixedListCellEditor.js";
+  import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
+  import { translatePhrase } from "./translation";
+  import {
+  applyGlobalGridFontFamily,
+  readTypographyVariable,
+  DEFAULT_FONT_FAMILY,
+  TYPOGRAPHY_VARIABLE_ID,
+  } from "./utils/fontFamily.js";
+
+  const GRID_BASE_FONT_SIZE = 12;
+  const DEFAULT_GRID_FONT_SIZE = `${GRID_BASE_FONT_SIZE}px`;
+  const PINNED_HEADER_DATASET_FLAG = 'wwPinnedHeaderBlockApplied';
+  const noopConsole = () => {};
+  const stopPinnedHeaderMouseDown = event => {
+    event.stopPropagation();
+  };
+  const preventPinnedHeaderDragStart = event => {
+    event.preventDefault();
+  };
+  const sanitizeFontFamily = value => {
+    if (typeof value !== 'string') {
+      return '';
+    }
+
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : '';
+  };
+  const sanitizeFontSize = value => {
+    if (value == null) {
+      return '';
+    }
+
+    const size = typeof value === 'number' ? `${value}px` : String(value).trim();
+    return size.length > 0 ? size : '';
+  };
+  // Editor customizado inline para listas
+  class ListCellEditor {
+    init(params) {
+      this.params = params;
+      const colDef = params.colDef || {};
+      this.rendererParams =
+        typeof colDef.cellRendererParams === 'function'
+          ? colDef.cellRendererParams(params)
+          : colDef.cellRendererParams || {};
+      this.eGui = document.createElement('div');
+      this.eGui.className = 'list-editor';
+      this.eGui.innerHTML = `
+        <span class="editor-close">&times;</span>
+        <div class="field-search">
+          <input type="text" class="search-input" placeholder="${translatePhrase("Search...")}" />
+          <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
+        </div>
+        <div class="filter-list"></div>
+      `;
+      this.searchInput = this.eGui.querySelector('.search-input');
+      this.listEl = this.eGui.querySelector('.filter-list');
+      this.closeBtn = this.eGui.querySelector('.editor-close');
+
+      const tag = (params.colDef.TagControl || params.colDef.tagControl || params.colDef.tagcontrol || '').toString().toUpperCase();
+      const identifier = (params.colDef.FieldDB || '').toString().toUpperCase();
+      const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
+      this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+
+      // Build option array (supports promises)
+      const normalize = opt =>
+        typeof opt === 'object' ? opt : { value: opt, label: String(opt) };
+
+      const resolveOptions = arr => {
+        this.options = (arr || []).map(normalize);
+        this.filteredOptions = [...this.options];
+        this.renderOptions();
+      };
+
+      let optionsPromise;
+      if (params.options && typeof params.options.then === 'function') {
+        optionsPromise = params.options;
+      } else if (Array.isArray(params.options)) {
+        optionsPromise = Promise.resolve(params.options);
+      } else if (Array.isArray(params.colDef.options)) {
+        optionsPromise = Promise.resolve(params.colDef.options);
+      } else if (Array.isArray(params.colDef.listOptions)) {
+        optionsPromise = Promise.resolve(params.colDef.listOptions);
+      } else if (
+        typeof params.colDef.listOptions === 'string' &&
+        params.colDef.listOptions.trim() !== ''
+      ) {
+        optionsPromise = Promise.resolve(
+          params.colDef.listOptions.split(',').map(o => o.trim())
+        );
+      } else if (
+        params.colDef.dataSource &&
+        typeof params.colDef.dataSource.list_options === 'string' &&
+        params.colDef.dataSource.list_options.trim() !== ''
+      ) {
+        optionsPromise = Promise.resolve(
+          params.colDef.dataSource.list_options.split(',').map(o => o.trim())
+        );
+      } else {
+        optionsPromise = Promise.resolve([]);
+      }
+
+      optionsPromise.then(resolveOptions);
+
+      this.value = params.value;
+
+      this.searchInput.addEventListener('input', e => {
+        this.filterOptions(e.target.value);
+      });
+
+      if (this.closeBtn) {
+        this.closeBtn.addEventListener('click', () => {
+          if (this.params.api && this.params.api.stopEditing) {
+            this.params.api.stopEditing(true);
+          } else if (this.params.stopEditing) {
+            this.params.stopEditing(true);
+          }
+        });
+      }
+    }
+    filterOptions(text) {
+      const t = text.toLowerCase();
+      this.filteredOptions = this.options.filter(opt => {
+        const label = this.stripHtml(String(this.formatOption(opt)));
+        return label.toLowerCase().includes(t);
+      });
+      this.renderOptions();
+    }
+    stripHtml(html) {
+      const tmp = document.createElement('div');
+      tmp.innerHTML = html;
+      return tmp.textContent || tmp.innerText || '';
+    }
+    getRoundedSpanColor(value, colorArray, fieldName) {
+      if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+      const matchingStyle = colorArray.find(item => item.Valor === value);
+      if (!matchingStyle) return value;
+      const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+      const fontweight = 'font-weight:bold;';
+      return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+    }
+    dateFormatter(dateValue, lang) {
+      try {
+        if (!dateValue) return '';
+        const dateOptions = { day: '2-digit', month: '2-digit', year: 'numeric' };
+        const timeOptions = { hour: '2-digit', minute: '2-digit', hour12: false };
+        const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(
+          new Date(dateValue)
+        );
+        const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(
+          new Date(dateValue)
+        );
+        return `${datePart}`;
+      } catch (error) {
+        return dateValue;
+      }
+    }
+    formatOption(opt) {
+      const value = opt.label != null ? opt.label : opt.value;
+      if (this.isCategoryField) {
+        return `<span style="height:25px; color:#303030; background:#c9edf9; border:1px solid #c9edf9; border-radius:12px; font-weight:normal; display:inline-flex; align-items:center; padding:0 12px;">${value}</span>`;
+      }
+      const colDef = this.params.colDef || {};
+      const params = this.rendererParams || {};
+      try {
+        if (params.useCustomFormatter && typeof params.formatter === 'string') {
+          const fn = new Function(
+            'value',
+            'row',
+            'colDef',
+            'getRoundedSpanColor',
+            'dateFormatter',
+            params.formatter
+          );
+          return fn(
+            value,
+            {},
+            colDef,
+            this.getRoundedSpanColor.bind(this),
+            this.dateFormatter.bind(this)
+          );
+        } else if (params.useStyleArray && Array.isArray(params.styleArray)) {
+          const styled = this.getRoundedSpanColor(
+            value,
+            params.styleArray,
+            colDef.FieldDB
+          );
+          if (styled) return styled;
+        }
+      } catch (e) {
+        noopConsole('Format option error', e);
+      }
+      return value;
+    }
+    getColumnFieldKey() {
+      if (!this.params) return null;
+      const col = this.params.column;
+      if (col && typeof col.getColId === 'function') {
+        const id = col.getColId();
+        if (id) return id;
+      }
+      return this.params.colDef?.field || this.params.colDef?.colId || null;
+    }
+    extractOptionLabel(value) {
+      if (!this.options || !this.options.length) return undefined;
+      const match = this.options.find(opt => String(opt.value) === String(value));
+      if (!match) return undefined;
+      const label =
+        match.label ??
+        match.name ??
+        match.text ??
+        match.descricao ??
+        match.description ??
+        match.Valor ??
+        match.value;
+      return label != null ? label : undefined;
+    }
+    updateDisplayLabel(value, { refresh = true } = {}) {
+      const fieldKey = this.getColumnFieldKey();
+      const rowData = this.params?.node?.data;
+      if (!fieldKey || !rowData) return;
+      const labelField = `${fieldKey}__displayLabel`;
+      const label = this.extractOptionLabel(value);
+      if (label != null) {
+        rowData[labelField] = String(label);
+      } else if (value != null && value !== '') {
+        rowData[labelField] = String(value);
+      } else {
+        delete rowData[labelField];
+      }
+      if (refresh && this.params.api && this.params.node) {
+        this.params.api.refreshCells({
+          rowNodes: [this.params.node],
+          columns: [fieldKey],
+          force: true,
+        });
+      }
+    }
+    renderOptions() {
+      this.listEl.innerHTML = this.filteredOptions
+        .map(opt => {
+          const formatted = this.formatOption(opt);
+          const selected = opt.value == this.value ? ' selected' : '';
+          return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+        })
+        .join('');
+      this.listEl.querySelectorAll('.filter-item').forEach(el => {
+        el.addEventListener('click', () => {
+          const selectedValue = el.getAttribute('data-value');
+          this.value = selectedValue;
+          this.updateDisplayLabel(selectedValue, { refresh: false });
+          if (this.params.api && this.params.api.stopEditing) {
+            this.params.api.stopEditing();
+          } else if (this.params.stopEditing) {
+            this.params.stopEditing();
+          }
+        });
+      });
+    }
+    getGui() { return this.eGui; }
+    afterGuiAttached() { if (this.searchInput) this.searchInput.focus(); }
+    getValue() {
+      this.updateDisplayLabel(this.value);
+      return this.value;
+    }
+    destroy() {}
+    isPopup() { return true; }
+  }
+  import './components/list-filter.css';
+
+  // TODO: maybe register less modules
+  // TODO: maybe register modules per grid instead of globally
+  ModuleRegistry.registerModules([AllCommunityModule]);
+
+  const HIDE_SAVE_BUTTON_VARIABLE_ID = "09c5aacd-b697-4e04-9571-d5db1f671877";
+
+  export default {
+  components: {
+  AgGridVue,
+  ActionCellRenderer,
+  ImageCellRenderer,
+  WewebCellRenderer,
+  FormatterCellRenderer, // Add this line
+  UserCellRenderer,
+  ListCellEditor, // registrar editor customizado
+  FixedListCellEditor,
+  ResponsibleUserCellEditor,
+  DateTimeCellEditor,
+  },
+  props: {
+  content: {
+  type: Object,
+  required: true,
+  },
+  uid: {
+  type: String,
+  required: true,
+  },
+  /* wwEditor:start */
+  wwEditorState: { type: Object, required: true },
+  /* wwEditor:end */
+  },
+  emits: ["trigger-event", "update:content:effect"],
+  setup(props, ctx) {
+  const { resolveMappingFormula } = wwLib.wwFormula.useFormula();  
+  const gridApi = shallowRef(null);
+  const columnApi = shallowRef(null);
+  const displayedRowData = shallowRef([]);
+  const rowMetadata = shallowRef(new Map());
+  const pendingRowListRefreshes = new Map();
+  let pendingRowListRefreshPromise = null;
+  let hasHydratedInitialRows = false;
+
+  const getRowFingerprint = row => {
+    try {
+      return JSON.stringify(row ?? {});
+    } catch (error) {
+      return '';
+    }
+  };
+
+  const resolveRowId = (row, fallbackIndex = null) => {
+    if (!row || typeof row !== 'object') {
+      return fallbackIndex != null ? `__idx_${fallbackIndex}` : null;
+    }
+
+    let resolvedId = null;
+    try {
+      if (props.content?.idFormula) {
+        resolvedId = resolveMappingFormula(props.content.idFormula, row);
+      }
+    } catch (error) {
+      noopConsole('[GridViewDinamica] Failed to resolve row id using formula', error);
+    }
+
+    if (resolvedId == null || resolvedId === '') {
+      const fallbackKeys = ['Id', 'ID', 'id'];
+      for (const key of fallbackKeys) {
+        if (row[key] != null && row[key] !== '') {
+          resolvedId = row[key];
+          break;
+        }
+      }
+    }
+
+    if (resolvedId == null || resolvedId === '') {
+      if (fallbackIndex != null) {
+        resolvedId = `__idx_${fallbackIndex}`;
+      } else {
+        resolvedId = getRowFingerprint(row);
+      }
+    }
+
+    return typeof resolvedId === 'string' ? resolvedId : String(resolvedId);
+  };
+
+  const syncDisplayedRowData = () => {
+    const collectionData = wwLib.wwUtils.getDataFromCollection(props.content?.rowData);
+    const sourceRows = Array.isArray(collectionData) ? collectionData : [];
+
+    const previousMetadata = rowMetadata.value || new Map();
+    const nextMetadata = new Map();
+    const nextRows = [];
+
+    sourceRows.forEach((rawRow, index) => {
+      if (!rawRow || typeof rawRow !== 'object') return;
+
+      const rowId = resolveRowId(rawRow, index);
+      if (rowId == null) return;
+
+      const fingerprint = getRowFingerprint(rawRow);
+      const previousEntry = previousMetadata.get(rowId);
+
+      if (previousEntry && previousEntry.hash === fingerprint) {
+        primeLazyStatusDisplayLabels(previousEntry.data);
+        nextMetadata.set(rowId, previousEntry);
+        nextRows.push(previousEntry.data);
+      } else {
+        const clonedRow = { ...rawRow };
+        primeLazyStatusDisplayLabels(clonedRow);
+        const entry = { data: clonedRow, hash: fingerprint };
+        nextMetadata.set(rowId, entry);
+        nextRows.push(clonedRow);
+        if (hasHydratedInitialRows) {
+          scheduleRowListOptionsRefresh(rowId, clonedRow);
+        }
+      }
+    });
+
+    displayedRowData.value = nextRows;
+    rowMetadata.value = nextMetadata;
+    hasHydratedInitialRows = true;
+  };
+
+  const refreshRowFromSource = (rowData, rowNode = null) => {
+    if (!rowData) return;
+
+    const collectionData = wwLib.wwUtils.getDataFromCollection(props.content?.rowData);
+    const sourceRows = Array.isArray(collectionData) ? collectionData : [];
+    if (!sourceRows.length) return;
+
+    const inferredIndex = rowNode?.rowIndex != null ? rowNode.rowIndex : null;
+    const rowId = resolveRowId(rowData, inferredIndex);
+    if (!rowId) return;
+
+    let matchedRow = null;
+    let matchedIndex = inferredIndex != null ? inferredIndex : -1;
+
+    if (matchedIndex != null && matchedIndex >= 0 && matchedIndex < sourceRows.length) {
+      const candidate = sourceRows[matchedIndex];
+      if (candidate && resolveRowId(candidate, matchedIndex) === rowId) {
+        matchedRow = candidate;
+      }
+    }
+
+    if (!matchedRow) {
+      for (let idx = 0; idx < sourceRows.length; idx += 1) {
+        const candidate = sourceRows[idx];
+        if (!candidate) continue;
+        if (resolveRowId(candidate, idx) === rowId) {
+          matchedRow = candidate;
+          matchedIndex = idx;
+          break;
+        }
+      }
+    }
+
+    if (!matchedRow) return;
+
+    const fingerprint = getRowFingerprint(matchedRow);
+    const previousEntry = (rowMetadata.value && rowMetadata.value.get(rowId)) || null;
+    if (previousEntry && previousEntry.hash === fingerprint) {
+      return;
+    }
+    const clonedRow = { ...matchedRow };
+    primeLazyStatusDisplayLabels(clonedRow);
+
+    const nextMetadata = new Map(rowMetadata.value || []);
+    const entry = { data: clonedRow, hash: fingerprint };
+    nextMetadata.set(rowId, entry);
+    rowMetadata.value = nextMetadata;
+
+    const currentRows = Array.isArray(displayedRowData.value) ? [...displayedRowData.value] : [];
+    if (matchedIndex != null && matchedIndex >= 0 && matchedIndex < currentRows.length) {
+      currentRows[matchedIndex] = clonedRow;
+      displayedRowData.value = currentRows;
+    }
+
+    if (hasHydratedInitialRows) {
+      scheduleRowListOptionsRefresh(rowId, clonedRow);
+    }
+
+    if (gridApi.value && typeof gridApi.value.refreshCells === 'function') {
+      const refreshConfig = { force: true };
+      if (rowNode) {
+        refreshConfig.rowNodes = [rowNode];
+      }
+      gridApi.value.refreshCells(refreshConfig);
+    }
+  };
+
+  const getRowMetadataHash = rowId => {
+    if (!rowId) return null;
+    const metadata = rowMetadata.value;
+    if (!metadata || typeof metadata.get !== 'function') {
+      return null;
+    }
+    const entry = metadata.get(rowId);
+    return entry ? entry.hash : null;
+  };
+
+  const waitForRowHydration = async (rowId, previousHash, options = {}) => {
+    if (!rowId) return null;
+
+    const { timeout = 6000, interval = 150 } = options;
+    const start = Date.now();
+
+    while (isComponentActive) {
+      const collectionData = wwLib.wwUtils.getDataFromCollection(props.content?.rowData);
+      const sourceRows = Array.isArray(collectionData) ? collectionData : [];
+
+      for (let idx = 0; idx < sourceRows.length; idx += 1) {
+        const candidate = sourceRows[idx];
+        if (!candidate) continue;
+        if (resolveRowId(candidate, idx) !== rowId) continue;
+
+        const fingerprint = getRowFingerprint(candidate);
+        if (!previousHash || fingerprint !== previousHash) {
+          return { row: candidate, index: idx, fingerprint };
+        }
+        break;
+      }
+
+      if (timeout != null && timeout >= 0 && Date.now() - start >= timeout) {
+        break;
+      }
+
+      await sleep(interval);
+    }
+
+    return null;
+  };
+
+  const isListLikeColumn = col => {
+    if (!col) return false;
+    const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+    const identifier = (col.FieldDB || '').toUpperCase();
+    const listIndicators = new Set([
+      'STATUSID',
+      'RESPONSIBLEUSERID',
+      'CATEGORYID',
+      'SUBCATEGORYID',
+      'CATEGORYLEVEL3ID',
+    ]);
+
+    if (col.cellDataType === 'list') return true;
+    if (listIndicators.has(tag) || listIndicators.has(identifier)) return true;
+    if (Array.isArray(col.listOptions) || Array.isArray(col.list_options) || Array.isArray(col.options)) {
+      return true;
+    }
+    if (typeof col.listOptions === 'string' || typeof col.list_options === 'string') return true;
+    if (col.dataSource) return true;
+    if (col.useStyleArray) return true;
+    return false;
+  };
+
+  const shouldLazyLoadStatus = col => {
+    if (!col) return false;
+    const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+    const identifier = (col.FieldDB || '').toUpperCase();
+    return tag === 'STATUSID' || identifier === 'STATUSID';
+  };
+
+  const deriveStatusDisplayLabel = (row, col) => {
+    if (!row || typeof row !== 'object' || !col) return undefined;
+
+    const fieldKey = col.field || col.FieldDB || col.id;
+    if (!fieldKey) return undefined;
+
+    const labelField = `${fieldKey}__displayLabel`;
+    const existingLabel = row[labelField];
+    if (existingLabel != null && existingLabel !== '') {
+      return existingLabel;
+    }
+
+    const explicitKeys = [
+      col.DisplayField,
+      col.displayField,
+      col.display_field,
+      col.DisplayLabel,
+      col.displayLabel,
+      col.display_label,
+    ];
+
+    const baseVariants = [
+      `${fieldKey}Label`,
+      `${fieldKey}label`,
+      `${fieldKey}Name`,
+      `${fieldKey}name`,
+      `${fieldKey}Description`,
+      `${fieldKey}description`,
+      `${fieldKey}_Label`,
+      `${fieldKey}_label`,
+      `${fieldKey}_Name`,
+      `${fieldKey}_name`,
+      `${fieldKey}_Description`,
+      `${fieldKey}_description`,
+    ];
+
+    const statusFallbacks = [
+      'StatusName',
+      'statusName',
+      'Status',
+      'status',
+      'StatusDescription',
+      'statusDescription',
+      'StatusLabel',
+      'statusLabel',
+    ];
+
+    const candidateKeys = [...explicitKeys, ...baseVariants, ...statusFallbacks];
+    for (const key of candidateKeys) {
+      if (!key) continue;
+      const value = row[key];
+      if (value != null && value !== '') {
+        return value;
+      }
+    }
+
+    const nestedCandidates = [
+      row[fieldKey],
+      row.Status,
+      row.status,
+    ];
+
+    for (const candidate of nestedCandidates) {
+      if (!candidate || typeof candidate !== 'object') continue;
+      const nestedValue =
+        candidate.label ??
+        candidate.Label ??
+        candidate.name ??
+        candidate.Name ??
+        candidate.description ??
+        candidate.Description ??
+        candidate.value ??
+        candidate.Value ??
+        null;
+      if (nestedValue != null && nestedValue !== '') {
+        return nestedValue;
+      }
+    }
+
+    return undefined;
+  };
+
+  const primeLazyStatusDisplayLabels = row => {
+    if (!row || typeof row !== 'object') return;
+    if (!props.content || !Array.isArray(props.content.columns)) return;
+
+    props.content.columns.forEach(col => {
+      if (!shouldLazyLoadStatus(col)) return;
+      const fieldKey = col.field || col.FieldDB || col.id;
+      if (!fieldKey) return;
+
+      const labelField = `${fieldKey}__displayLabel`;
+      if (row[labelField] != null && row[labelField] !== '') return;
+
+      const label = deriveStatusDisplayLabel(row, col);
+      if (label != null && label !== '') {
+        row[labelField] = String(label);
+      }
+    });
+  };
+
+  const readStatusValueFromRow = (row, col) => {
+    if (!row || typeof row !== 'object' || !col) return undefined;
+    const fieldCandidates = [col.field, col.FieldDB, col.id];
+    for (const key of fieldCandidates) {
+      if (!key) continue;
+      const value = row[key];
+      if (value != null && value !== '') {
+        return value;
+      }
+    }
+    return undefined;
+  };
+
+  const buildLazyStatusFallbackOptions = col => {
+    if (!col) return [];
+
+    const fieldKey = col.field || col.FieldDB || col.id;
+    if (!fieldKey) return [];
+
+    const rows = Array.isArray(displayedRowData.value) ? displayedRowData.value : [];
+    const seen = new Map();
+
+    rows.forEach(row => {
+      if (!row || typeof row !== 'object') return;
+      const rawValue = readStatusValueFromRow(row, col);
+      if (rawValue == null || rawValue === '') return;
+
+      const labelField = `${fieldKey}__displayLabel`;
+      let label = row[labelField];
+      if (label == null || label === '') {
+        label = deriveStatusDisplayLabel(row, col);
+      }
+
+      const mapKey = String(rawValue);
+      if (seen.has(mapKey)) return;
+
+      const finalLabel = label != null && label !== '' ? label : rawValue;
+      seen.set(mapKey, {
+        value: rawValue,
+        label: String(finalLabel),
+      });
+    });
+
+    return Array.from(seen.values());
+  };
+
+  const refreshRowListOptions = async (rowData, rowNode = null, editedColumn = null) => {
+    if (!rowData || !props.content || !Array.isArray(props.content.columns)) return;
+
+    await nextTick();
+
+    const ticketId = rowData?.TicketID;
+    const promises = [];
+    const columnsToRefresh = [];
+
+    const editedFieldKey = (() => {
+      if (!editedColumn) return null;
+      if (typeof editedColumn.getColId === 'function') {
+        const id = editedColumn.getColId();
+        if (id) return id;
+      }
+      return editedColumn.colId || editedColumn.field || null;
+    })();
+
+    const orderedColumns = props.content.columns
+      .filter(col => isListLikeColumn(col))
+      .sort((a, b) => {
+        if (!editedFieldKey) return 0;
+        const aKey = a.id || a.field;
+        const bKey = b.id || b.field;
+        if (aKey === editedFieldKey) return -1;
+        if (bKey === editedFieldKey) return 1;
+        return 0;
+      });
+
+    orderedColumns.forEach(col => {
+      const fieldKey = col.id || col.field;
+      if (!fieldKey) return;
+
+      const shouldUseTicket = usesTicketId(col);
+      const cacheKey = getOptionsCacheKey(col, shouldUseTicket ? ticketId : undefined);
+
+      if (!columnOptions.value[fieldKey]) {
+        columnOptions.value[fieldKey] = {};
+      }
+
+      delete columnOptions.value[fieldKey][cacheKey];
+
+      if (shouldLazyLoadStatus(col)) {
+        return;
+      }
+
+      const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+      const identifier = (col.FieldDB || '').toUpperCase();
+      if (tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') {
+        responsibleUserCache = null;
+      }
+
+      const promise = getColumnOptions(col, shouldUseTicket ? ticketId : undefined)
+        .then(opts => {
+          if (!columnOptions.value[fieldKey]) {
+            columnOptions.value[fieldKey] = {};
+          }
+          columnOptions.value[fieldKey][cacheKey] = opts;
+        })
+        .catch(error => {
+          noopConsole('[GridViewDinamica] Failed to refresh list options for column', fieldKey, error);
+        });
+      promises.push(promise);
+      columnsToRefresh.push(fieldKey);
+    });
+
+    if (promises.length) {
+      try {
+        await Promise.all(promises);
+      } catch (error) {
+        noopConsole('[GridViewDinamica] Failed to resolve list option refresh promises', error);
+      }
+    }
+
+    if (gridApi.value && typeof gridApi.value.refreshCells === 'function') {
+      const refreshConfig = { force: true };
+      if (rowNode) {
+        refreshConfig.rowNodes = [rowNode];
+      }
+      if (columnsToRefresh.length) {
+        refreshConfig.columns = Array.from(new Set(columnsToRefresh));
+      }
+      gridApi.value.refreshCells(refreshConfig);
+    }
+  };
+
+  function scheduleRowListOptionsRefresh(rowId, rowData) {
+    if (!rowId || !rowData) return;
+
+    pendingRowListRefreshes.set(rowId, rowData);
+
+    if (pendingRowListRefreshPromise) return;
+
+    pendingRowListRefreshPromise = Promise.resolve()
+      .then(async () => {
+        pendingRowListRefreshPromise = null;
+
+        if (!pendingRowListRefreshes.size) return;
+
+        const entries = Array.from(pendingRowListRefreshes.entries());
+        pendingRowListRefreshes.clear();
+
+        for (const [id, data] of entries) {
+          try {
+            const node = gridApi.value?.getRowNode ? gridApi.value.getRowNode(id) : null;
+            await refreshRowListOptions(data, node, null);
+          } catch (error) {
+            noopConsole(
+              '[GridViewDinamica] Failed to refresh list options after dataset update',
+              error
+            );
+          }
+        }
+      })
+      .catch(error => {
+        pendingRowListRefreshPromise = null;
+        noopConsole('[GridViewDinamica] Failed to schedule list option refresh', error);
+      });
+  }
+
+  // Unified Column API accessor for AG Grid v31+ (no columnApi) and older versions
+  const getColApi = () => {
+    if (columnApi.value && (
+        typeof columnApi.value.applyColumnState === 'function' ||
+        typeof columnApi.value.getColumnState === 'function' ||
+        typeof columnApi.value.resetColumnState === 'function' ||
+        typeof columnApi.value.moveColumns === 'function' ||
+        typeof columnApi.value.getAllGridColumns === 'function'
+      )) {
+      return columnApi.value;
+    }
+    return gridApi.value || null;
+  };
+
+  const isGridApiActive = () => {
+    const api = gridApi.value;
+    if (!api) return false;
+    if (typeof api.isDestroyed === 'function') {
+      return !api.isDestroyed();
+    }
+    return true;
+  };
+
+  const agGridRef = ref(null);
+
+// Executa após o AG Grid consolidar sort/columnState
+function microtask(fn) {
+if (typeof queueMicrotask === 'function') queueMicrotask(fn);
+else Promise.resolve().then(fn);
+}
+
+  // Run after grid has applied header/column state updates
+  function deferAfterGridUpdate(fn) {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => setTimeout(fn, 0));
+    } else {
+      setTimeout(fn, 0);
+    }
+  }
+
+
+  const updateHideSaveButtonVisibility = (value) => {
+    try {
+      const wwVariable = window?.wwLib?.wwVariable;
+      if (!wwVariable) return;
+
+      if (typeof wwVariable.setValue === "function") {
+        wwVariable.setValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+        return;
+      }
+
+      if (typeof wwVariable.updateValue === "function") {
+        wwVariable.updateValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+        return;
+      }
+
+      if (typeof wwVariable.setComponentValue === "function") {
+        wwVariable.setComponentValue(HIDE_SAVE_BUTTON_VARIABLE_ID, value);
+      }
+    } catch (error) {
+      noopConsole(
+        "[GridViewDinamica] Failed to update escondeBotaoSalvarGrid variable",
+        error
+      );
+    }
+  };
+
+  let suppressRevealUntilCapture = false;
+  let pendingInitialGridState = null;
+  let userInteractedDuringCapture = false;
+
+  const PROGRAMMATIC_EVENT_SOURCES = new Set([
+    "api",
+    "columnEverythingChanged",
+    "gridInitializing",
+    "rowDataChanged",
+    "rowDataUpdated",
+  ]);
+
+  const isProgrammaticEvent = event => {
+    if (!event || !event.source) return false;
+    return PROGRAMMATIC_EVENT_SOURCES.has(event.source);
+  };
+
+  const shouldRevealSaveButton = (event) => {
+    const programmatic = isProgrammaticEvent(event);
+
+    if (suppressRevealUntilCapture && !event) {
+      return false;
+    }
+
+    if (suppressRevealUntilCapture && programmatic) {
+      return false;
+    }
+
+    if (!event) return true;
+
+    return !programmatic;
+  };
+
+  const initialGridState = ref({
+    filters: {},
+    sort: [],
+    columns: [],
+  });
+
+
+  const normalizeFilterModel = model => {
+    if (!model || typeof model !== 'object') return {};
+    const clone = JSON.parse(JSON.stringify(model));
+    return Object.keys(clone)
+      .sort()
+      .reduce((acc, key) => {
+        acc[key] = clone[key];
+        return acc;
+      }, {});
+  };
+
+  const normalizeSortModel = model => {
+    if (!Array.isArray(model)) return [];
+
+    // Preserve sort priority when AG Grid supplies explicit indexes (multi-column sorting).
+    const containsSortIndex = model.some(entry => entry && entry.sortIndex != null);
+
+    return model
+      .map((item, idx) => {
+        const colId = item?.colId != null ? String(item.colId) : null;
+        if (colId == null) return null;
+
+        const normalized = {
+          colId,
+          sort: item?.sort ?? null,
+        };
+
+        if (item?.sortIndex != null) {
+          const parsedIndex = Number(item.sortIndex);
+          if (Number.isFinite(parsedIndex)) {
+            normalized.sortIndex = parsedIndex;
+          }
+        } else if (containsSortIndex) {
+          normalized.sortIndex = idx;
+        }
+
+        return normalized;
+      })
+      .filter(item => item && item.colId != null);
+  };
+
+  const getCurrentColumnOrder = () => {
+    if (!isGridApiActive() || typeof gridApi.value.getAllGridColumns !== 'function') return [];
+    return gridApi.value
+      .getAllGridColumns()
+      .map(col => col?.getColId?.())
+      .filter(colId => colId != null);
+  };
+
+  const getNormalizedGridState = () => {
+    if (!isGridApiActive()) {
+      return {
+        filters: {},
+        sort: [],
+        columns: [],
+      };
+    }
+
+    const filters = normalizeFilterModel(gridApi.value.getFilterModel?.() || {});
+    let sort = normalizeSortModel(gridApi.value.getSortModel?.() || []);
+
+    // Some row-models do not expose the current sort model via the grid API,
+    // but the column state still reflects active sorts. Fall back to that state
+    // when the direct API call reports no sorting information.
+    if (sort.length === 0) {
+      const colApi = getColApi();
+      if (colApi && typeof colApi.getColumnState === "function") {
+        const columnStateSorts = colApi
+          .getColumnState()
+          .filter(col => col && col.sort)
+          .sort((a, b) => {
+            const aIndex = a?.sortIndex != null ? a.sortIndex : Number.MAX_SAFE_INTEGER;
+            const bIndex = b?.sortIndex != null ? b.sortIndex : Number.MAX_SAFE_INTEGER;
+            return aIndex - bIndex;
+          })
+          .map(col => ({
+            colId: col?.colId,
+            sort: col?.sort,
+            sortIndex: col?.sortIndex,
+          }));
+
+        sort = normalizeSortModel(columnStateSorts);
+      }
+    }
+
+    const columns = getCurrentColumnOrder();
+
+    return { filters, sort, columns };
+  };
+
+  let captureInitialStateTimeout = null;
+
+  const captureInitialGridState = () => {
+    if (!gridApi.value) return;
+    const snapshot = getNormalizedGridState();
+    initialGridState.value = snapshot;
+    pendingInitialGridState = snapshot;
+  };
+
+  const scheduleCaptureInitialGridState = (delay = 0) => {
+    if (captureInitialStateTimeout) {
+      clearTimeout(captureInitialStateTimeout);
+      captureInitialStateTimeout = null;
+    }
+
+    suppressRevealUntilCapture = true;
+    pendingInitialGridState = getNormalizedGridState();
+    userInteractedDuringCapture = false;
+
+    const finalizeCapture = () => {
+      captureInitialStateTimeout = null;
+
+      try {
+        const nextState = getNormalizedGridState();
+        if (userInteractedDuringCapture && pendingInitialGridState) {
+          initialGridState.value = pendingInitialGridState;
+        } else {
+          pendingInitialGridState = nextState;
+          initialGridState.value = nextState;
+        }
+      } finally {
+        suppressRevealUntilCapture = false;
+        userInteractedDuringCapture = false;
+
+        // Depois de recapturar o estado inicial, sincroniza imediatamente
+        // a visibilidade do botão para refletir o novo snapshot.
+        updateHideSaveButtonVisibility(isGridStatePristine());
+      }
+    };
+
+    const timeoutDelay = typeof delay === "number" && delay > 0 ? delay : 0;
+    captureInitialStateTimeout = setTimeout(finalizeCapture, timeoutDelay);
+  };
+
+// Executa após o ciclo do AG Grid consolidar o sort/columnState
+function defer(fn, delay = 0) {
+  if (typeof window?.requestAnimationFrame === 'function' && delay === 0) {
+    requestAnimationFrame(() => fn());
+  } else {
+    setTimeout(fn, delay);
+  }
+}
+
+
+  const runWithSuppressedReveal = (operation, { recaptureDelay = 50 } = {}) => {
+    suppressRevealUntilCapture = true;
+    const finalize = () => {
+      if (typeof recaptureDelay === "number") {
+        scheduleCaptureInitialGridState(recaptureDelay);
+      } else {
+        suppressRevealUntilCapture = false;
+      }
+    };
+
+
+
+  // Atualiza a variável de "esconder botão salvar" com base no snapshot atual vs inicial
+    try {
+      const result = operation?.();
+      if (result && typeof result.then === "function") {
+        return result.finally(finalize);
+      }
+      finalize();
+      return result;
+    } catch (error) {
+      finalize();
+      throw error;
+    }
+  };
+
+
+  const isGridStatePristine = () => {
+    if (!gridApi.value) return true;
+    const current = getNormalizedGridState();
+    const initial = initialGridState.value || { filters: {}, sort: [], columns: [] };
+
+    const filtersEqual = JSON.stringify(current.filters) === JSON.stringify(initial.filters);
+    const sortEqual = JSON.stringify(current.sort) === JSON.stringify(initial.sort);
+    const columnsEqual = JSON.stringify(current.columns) === JSON.stringify(initial.columns);
+
+    return filtersEqual && sortEqual && columnsEqual;
+  };
+
+  const syncHideSaveButtonVisibility = (event) => {
+  // Sort é tratado exclusivamente em onSortChanged
+  if (event?.type === "sortChanged") return;
+  
+  const isRowDataSourceChange =
+  event?.source === "rowDataChanged" || event?.source === "rowDataUpdated";
+  
+  if (captureInitialStateTimeout && event && !isProgrammaticEvent(event)) {
+  userInteractedDuringCapture = true;
+  }
+  
+  if (isRowDataSourceChange) {
+  updateHideSaveButtonVisibility(true);
+  scheduleCaptureInitialGridState(50);
+  return;
+  }
+  
+  const pristine = isGridStatePristine();
+  
+  if (!shouldRevealSaveButton(event)) {
+  if (suppressRevealUntilCapture) {
+  updateHideSaveButtonVisibility(true);
+  scheduleCaptureInitialGridState(50);
+  return;
+  }
+  if (isProgrammaticEvent(event) && !pristine) {
+  updateHideSaveButtonVisibility(false);
+  return;
+  }
+  updateHideSaveButtonVisibility(pristine);
+  scheduleCaptureInitialGridState(50);
+  return;
+  }
+  
+  updateHideSaveButtonVisibility(pristine);
+  };
+
+
+  const resetHideSaveButtonVisibility = () => {
+    updateHideSaveButtonVisibility(true);
+    scheduleCaptureInitialGridState(100);
+  };
+
+  const componentFontFamily = ref("");
+  const fallbackFontFamily = computed(() => {
+  const candidates = [
+  props.content?.cellFontFamily,
+  props.content?.headerFontFamily,
+  props.content?.actionFontFamily,
+  ];
+  const validCandidate = candidates.find(font =>
+  typeof font === "string" && font.trim().length > 0
+  );
+  return validCandidate || DEFAULT_FONT_FAMILY;
+  });
+  const resolvedFontFamily = computed(
+  () => {
+    const explicitFont = sanitizeFontFamily(props.content?.gridFontFamily);
+    if (explicitFont) {
+      return explicitFont;
+    }
+
+    return (
+      sanitizeFontFamily(componentFontFamily.value) ||
+      fallbackFontFamily.value ||
+      DEFAULT_FONT_FAMILY
+    );
+  }
+  );
+  const resolvedFontSize = computed(() => {
+  return (
+  sanitizeFontSize(props.content?.gridFontSize) ||
+  sanitizeFontSize(props.content?.cellFontSize) ||
+  DEFAULT_GRID_FONT_SIZE
+  );
+  });
+  const resolvedFontSizeNumber = computed(() => {
+  const parsed = parseFloat(resolvedFontSize.value);
+  return Number.isFinite(parsed) ? parsed : GRID_BASE_FONT_SIZE;
+  });
+
+  const updateComponentFontFamily = () => {
+  componentFontFamily.value = readTypographyVariable();
+  };
+
+  let typographyUnsubscribe = null;
+
+  watch(
+  resolvedFontFamily,
+  value => {
+  applyGlobalGridFontFamily(value);
+  },
+  { immediate: true }
+  );
+
+  onMounted(() => {
+  updateComponentFontFamily();
+
+  if (
+  typeof window !== "undefined" &&
+  typeof window?.wwLib?.wwVariable?.subscribe === "function"
+  ) {
+  try {
+  typographyUnsubscribe = window.wwLib.wwVariable.subscribe(
+  TYPOGRAPHY_VARIABLE_ID,
+  () => {
+  updateComponentFontFamily();
+  }
+  );
+  } catch (error) {
+  noopConsole(
+  "[GridViewDinamica] Failed to subscribe to typography variable",
+  error
+  );
+  typographyUnsubscribe = null;
+  }
+  }
+  });
+
+  onUnmounted(() => {
+  if (typeof typographyUnsubscribe === "function") {
+  try {
+  typographyUnsubscribe();
+  } catch (error) {
+  noopConsole(
+  "[GridViewDinamica] Failed to unsubscribe typography listener",
+  error
+  );
+  }
+  }
+  });
+
+
+  const { value: selectedRows, setValue: setSelectedRows } =
+  wwLib.wwVariable.useComponentVariable({
+  uid: props.uid,
+  name: "selectedRows",
+  type: "array",
+  defaultValue: [],
+  readonly: true,
+  });
+  const { value: filterValue, setValue: setFilters } =
+  wwLib.wwVariable.useComponentVariable({
+  uid: props.uid,
+  name: "filters",
+  type: "object",
+  defaultValue: {},
+  readonly: true,
+  });
+  const { value: sortValue, setValue: setSort } =
+  wwLib.wwVariable.useComponentVariable({
+  uid: props.uid,
+  name: "sort",
+  type: "object",
+  defaultValue: {},
+  readonly: true,
+  });
+  const { setValue: setTicketTagCounts } = wwLib.wwVariable.useComponentVariable({
+    uid: props.uid,
+    name: "ticketTagCounts",
+    type: "array",
+    defaultValue: [
+      { TagControl: null, TicketModelName: translatePhrase("All"), QuantityTickets: 0 },
+      { TagControl: "incident", TicketModelName: translatePhrase("Incidents"), QuantityTickets: 0 },
+      { TagControl: "problem", TicketModelName: translatePhrase("Problems"), QuantityTickets: 0 },
+      { TagControl: "request", TicketModelName: translatePhrase("Requests"), QuantityTickets: 0 },
+      { TagControl: "update", TicketModelName: translatePhrase("Updates"), QuantityTickets: 0 }
+    ],
+    readonly: true,
+  });
+  const getTicketTypeFilter = () => {
+    const raw = props?.content?.ticketTypeFilter;
+    if (raw == null || raw === "") return null;
+    const normalized = String(raw).toLowerCase();
+    const allowed = ["incident", "request", "problem", "update"];
+    return allowed.includes(normalized) ? normalized : null;
+  };
+  const { value: columnsPositionValue, setValue: setColumnsPosition } = wwLib.wwVariable.useComponentVariable({
+  uid: props.uid,
+  name: "columnsPosition",
+  type: "array",
+  defaultValue: [],
+  readonly: false,
+  });
+  const { setValue: setColumnsSort } = wwLib.wwVariable.useComponentVariable({
+  uid: props.uid,
+  name: "columnsSort",
+  type: "array",
+  defaultValue: [],
+  readonly: false,
+  });
+
+  const columnOptions = ref({});
+  const componentKey = ref(0);
+
+  const GLOBAL_OPTIONS_KEY = '__all__';
+  function usesTicketId(col) {
+    const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+    const identifier = (col.FieldDB || '').toUpperCase();
+    return tag === 'STATUSID' || identifier === 'STATUSID';
+  }
+  function getOptionsCacheKey(col, ticketId) {
+    return usesTicketId(col) && ticketId != null ? String(ticketId) : GLOBAL_OPTIONS_KEY;
+  }
+
+// Flag para aplicar sort externo (WW variable) no próximo mount
+const forceExternalSortNextMount = ref(false);
+
+const asArray = (v) => {
+if (Array.isArray(v)) return v;
+if (v && typeof v === 'object') return Object.values(v);
+return [];
+};
+const asObject = (v) => (v && typeof v === 'object' ? v : {});
+
+  // Normaliza o Sort vindo da variável WW para o formato do AG Grid
+    function getExternalSortFromWW() {
+  try {
+      const raw = window.wwLib?.wwVariable?.getValue('74a13796-f64f-47d6-8e5f-4fb4700fd94b');
+      const sortArr = Array.isArray(raw) ? raw?.[0]?.Sort : raw?.Sort ?? raw?.[0]?.Sort;
+      if (!Array.isArray(sortArr)) return [];
+      // sortArr esperado: [{ id: 'ColId', isASC: true/false }, ...]
+      return sortArr
+        .filter(s => s && s.id)
+        .map((s, idx) => ({
+          colId: String(s.id),
+          sort: s.isASC ? 'asc' : 'desc',
+          sortIndex: idx
+        }));
+    } catch {
+      return [];
+    }
+  }
+
+  const buildTicketTagCounts = rows => {
+    const counts = {
+      incident: 0,
+      problem: 0,
+      request: 0,
+      update: 0,
+    };
+
+    rows.forEach(row => {
+      if (!row || typeof row !== 'object') return;
+      const tag = String(row.TagTicketModel || '').toLowerCase();
+      if (Object.prototype.hasOwnProperty.call(counts, tag)) {
+        counts[tag] += 1;
+      }
+    });
+
+    const total = rows.length;
+    return [
+      { TagControl: null, TicketModelName: translatePhrase("All"), QuantityTickets: total },
+      { TagControl: "incident", TicketModelName: translatePhrase("Incidents"), QuantityTickets: counts.incident },
+      { TagControl: "problem", TicketModelName: translatePhrase("Problems"), QuantityTickets: counts.problem },
+      { TagControl: "request", TicketModelName: translatePhrase("Requests"), QuantityTickets: counts.request },
+      { TagControl: "update", TicketModelName: translatePhrase("Updates"), QuantityTickets: counts.update },
+    ];
+  };
+
+  const resolveFilterInstance = async (colId) => {
+    if (!gridApi.value) return null;
+
+    if (typeof gridApi.value.getFilterInstance === "function") {
+      return gridApi.value.getFilterInstance(colId);
+    }
+
+    if (typeof gridApi.value.getColumnFilterInstance === "function") {
+      try {
+        return await gridApi.value.getColumnFilterInstance(colId);
+      } catch (error) {
+        noopConsole("[GridViewDinamica] Failed to resolve column filter instance", error);
+        return null;
+      }
+    }
+
+    return null;
+  };
+
+  const applyColumnFiltersToRows = async (rows) => {
+    if (!isGridApiActive() || typeof gridApi.value.getFilterModel !== "function") return rows;
+
+    const filterModel = gridApi.value.getFilterModel() || {};
+    const filterIds = Object.keys(filterModel);
+    if (!filterIds.length) return rows;
+
+    const filterInstances = await Promise.all(filterIds.map(resolveFilterInstance));
+
+    return rows.filter(row => {
+      const fakeNode = { data: row };
+
+      return filterIds.every((colId, index) => {
+        const filterInstance = filterInstances[index];
+
+        if (filterInstance?.doesFilterPass) {
+          try {
+            return filterInstance.doesFilterPass({ node: fakeNode, data: row });
+          } catch (error) {
+            noopConsole("[GridViewDinamica] Failed to evaluate filter for counts", error);
+            return true;
+          }
+        }
+
+        return true;
+      });
+    });
+  };
+
+  const updateTicketTagCounts = () => {
+    const collectionData = wwLib.wwUtils.getDataFromCollection(props.content?.rowData);
+    const rows = Array.isArray(collectionData) ? collectionData : [];
+
+    applyColumnFiltersToRows(rows)
+      .then(rowsAfterColumnFilters => {
+        setTicketTagCounts(buildTicketTagCounts(rowsAfterColumnFilters));
+      })
+      .catch(error => {
+        noopConsole("[GridViewDinamica] Failed to refresh ticket tag counts", error);
+        setTicketTagCounts(buildTicketTagCounts(rows));
+      });
+  };
+
+  const emitGridLoadedEvent = () => {
+    deferAfterGridUpdate(() => {
+      nextTick(() => {
+        const rows = [];
+
+        if (gridApi.value && typeof gridApi.value.forEachNode === "function") {
+          gridApi.value.forEachNode(node => {
+            if (node?.data) {
+              rows.push(node.data);
+            }
+          });
+        } else {
+          const collectionData = wwLib.wwUtils.getDataFromCollection(props.content?.rowData);
+          if (Array.isArray(collectionData)) {
+            rows.push(...collectionData);
+          }
+        }
+
+        ctx.emit("trigger-event", {
+          name: "gridLoaded",
+          event: { rows, totalRows: rows.length },
+        });
+      });
+    });
+  };
+
+/**
+ * Aplica a ordenação externa (WW variable) na grid e sincroniza variável local `sort`.
+ * - Atualiza columnState (applyColumnState)
+ * - Atualiza sortModel (setSortModel) para refletir no header e eventos
+ * - Atualiza variável local `sort` (setSort) no formato do getState().sort.sortModel
+ * - Persiste no localStorage via saveGridState()
+ */
+function applyExternalSortAndSync() {
+  const colApi = getColApi();
+  if (!isGridApiActive() || !colApi) return;
+  const external = getExternalSortFromWW();
+  if (!external.length) return;
+
+  // 1) Aplicar columnState de sort (reseta sort nas demais colunas)
+  const sortModel = external.map(e => ({ colId: e.colId, sort: e.sort }));
+
+  runWithSuppressedReveal(() => {
+    colApi?.applyColumnState?.({
+      state: external.map(e => ({ colId: e.colId, sort: e.sort, sortIndex: e.sortIndex })),
+      defaultState: { sort: null },
+      applyOrder: false
+    });
+
+    // 2) Aplicar sortModel (garante sincronismo visual/eventos)
+    if (typeof gridApi.value?.setSortModel === "function") {
+      gridApi.value.setSortModel(sortModel);
+    } else {
+      // Garantir fallback para versões sem setSortModel
+      colApi?.applyColumnState?.({
+        state: external.map(e => ({ colId: e.colId, sort: e.sort, sortIndex: e.sortIndex })),
+        defaultState: { sort: null },
+        applyOrder: false
+      });
+      gridApi.value?.refreshClientSideRowModel?.("sort");
+    }
+  });
+
+  // 3) Atualizar variável local `sort`
+  setSort(sortModel);
+
+  // 4) Persistir
+  saveGridState();
+}
+
+
+  const remountComponent = () => {
+    gridApi.value = null;
+    columnApi.value = null;
+    // Força reaplicar a ordenação externa no próximo ciclo
+    forceExternalSortNextMount.value = true;
+
+    componentKey.value++;
+    // Não chame updateColumnsPosition/Sort aqui; eles dependem do grid já montado
+  };
+
+  // ===================== Persistência de estado =====================
+  const storageKey = `GridViewDinamicaState_${props.uid}`;
+
+  function getGridStateFromLocalStorage() {
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  function saveGridState() {
+    const colApi = getColApi();
+    if (!isGridApiActive() || !colApi) return;
+    try {
+      const state = {
+        filterModel: gridApi.value.getFilterModel(),
+        columnState: colApi?.getColumnState?.(),
+        sortModel:
+          typeof gridApi.value.getSortModel === "function"
+            ? gridApi.value.getSortModel()
+            : [],
+      };
+      localStorage.setItem(storageKey, JSON.stringify(state));
+    } catch (e) {
+      noopConsole('Failed to save grid state', e);
+    }
+  }
+
+  function restoreGridState() {
+    const colApi = getColApi();
+    if (!isGridApiActive() || !colApi) return;
+    try {
+      const state = getGridStateFromLocalStorage();
+      if (!state) return;
+
+      const hasColumnState = Array.isArray(state.columnState) && state.columnState.length;
+      const hasFilterModel = state.filterModel && typeof state.filterModel === 'object';
+      const hasSortModel = Array.isArray(state.sortModel) && state.sortModel.length;
+
+      if (!hasColumnState && !hasFilterModel && !hasSortModel) {
+        return;
+      }
+
+      runWithSuppressedReveal(() => {
+        if (hasColumnState) {
+          colApi?.applyColumnState?.({ state: state.columnState, applyOrder: true });
+        }
+        if (hasFilterModel) {
+          gridApi.value.setFilterModel(state.filterModel);
+        }
+        if (hasSortModel) {
+          if (typeof gridApi.value?.setSortModel === "function") {
+            gridApi.value.setSortModel(state.sortModel);
+          } else {
+            const sortState = state.sortModel.map((entry, idx) => ({
+              colId: entry.colId,
+              sort: entry.sort,
+              sortIndex: Number.isFinite(entry.sortIndex) ? entry.sortIndex : idx
+            }));
+
+            colApi?.applyColumnState?.({
+              state: sortState,
+              defaultState: { sort: null },
+              applyOrder: false
+            });
+            gridApi.value?.refreshClientSideRowModel?.("sort");
+          }
+        }
+      });
+    } catch (e) {
+      noopConsole('Failed to restore grid state', e);
+    }
+  }
+
+  function clearSavedGridState() {
+    try {
+      localStorage.removeItem(storageKey);
+    } catch {}
+    const colApi = getColApi();
+    colApi?.resetColumnState?.();
+    if (isGridApiActive()) gridApi.value.setFilterModel(null);
+  }
+  // ================================================================
+
+  const parseStaticOptions = (opts) => {
+    const normalize = (opt) => {
+      if (typeof opt === 'object') {
+        const findKey = key => Object.keys(opt).find(k => k.toLowerCase() === key);
+        const labelKey = findKey('label') || findKey('name');
+        const valueKey = findKey('value') || findKey('id');
+        return {
+          ...opt,
+          value: valueKey ? opt[valueKey] : opt.value,
+          label: labelKey ? opt[labelKey] : opt.label || opt.name,
+        };
+      }
+      const str = String(opt);
+      return { value: str, label: str };
+    };
+    if (Array.isArray(opts)) {
+      return opts.map(normalize);
+    }
+    if (typeof opts === 'string' && opts.trim() !== '') {
+      return opts.split(',').map(o => {
+        const trimmed = o.trim();
+        return { value: trimmed, label: trimmed };
+      });
+    }
+    return [];
+  };
+
+  const loadApiOptions = async (col, ticketId) => {
+    try {
+      const lang = window.wwLib?.wwVariable?.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+      const companyId = window.wwLib?.wwVariable?.getValue('5d099f04-cd42-41fd-94ad-22d4de368c3a');
+      const apiUrl = window.wwLib?.wwVariable?.getValue('1195995b-34c3-42a5-b436-693f0f4f8825');
+      const apiKey = window.wwLib?.wwVariable?.getValue('d180be98-8926-47a7-b7f1-6375fbb95fa3');
+      const apiAuth = window.wwLib?.wwVariable?.getValue('dfcde09f-42f3-4b5c-b2e8-4314650655db');
+ const isResponsible = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase() == "RESPONSIBLEUSERID";
+      const ds = col.dataSource?.dataSource || col.dataSource;
+      if (!apiUrl || !ds?.functionName) return [];
+
+      const fetchOptions = {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...(companyId ? { p_idcompany: companyId } : {}),
+          ...(lang ? { p_language: lang } : {}),
+          ...(ticketId ? { p_ticketid: ticketId } : {})
+        })
+      };
+      if (apiKey) fetchOptions.headers['apikey'] = apiKey;
+      if (apiAuth) fetchOptions.headers['Authorization'] = apiAuth;
+
+      const response = await fetch(apiUrl + ds.functionName, fetchOptions);
+      if (!response.ok) throw new Error(`HTTP error ${response.status}`);
+      const data = await response.json();
+      if (!Array.isArray(data)) return [];
+
+      if (ds.transform) {
+        return data
+          .map(item => {
+            let value = item[ds.transform?.value] ?? item.id;
+            let label = item[ds.transform?.label] ?? item.name;
+            if (value === undefined || label === undefined) return null;
+            return {
+              ...(item && typeof item === 'object' ? item : {}),
+              value,
+              label,
+            };
+          })
+          .filter(v => v);
+      }
+
+      return data
+        .map(item => {
+          const value = item[ds.valueField || 'id'];
+          const label = item[ds.labelField || 'name'];
+          if (value === undefined || label === undefined) return null;
+          return {
+            ...(item && typeof item === 'object' ? item : {}),
+            value,
+            label,
+          };
+        })
+        .filter(v => v);
+    } catch (e) {
+      noopConsole('Failed to load options', e);
+      return [];
+    }
+  };
+
+  const loadResponsibleUserOptions = async () => {
+    const normalizeOptions = source => {
+      const items = asArray(source);
+      return items.filter(item => item?.istecnical === true);
+    };
+
+    try {
+      const fallbackCollectionId = '0e41f029-e1c3-4302-82ca-16aceccdadb1';
+      const datasourceBinding = props.content?.userDatasource;
+
+      const candidates = [
+        datasourceBinding,
+        datasourceBinding?.id,
+        datasourceBinding?.collection,
+        datasourceBinding?._id,
+        fallbackCollectionId,
+      ].filter(Boolean);
+
+      for (const candidate of candidates) {
+        try {
+          const liveData = wwLib.wwUtils.getDataFromCollection(candidate);
+          const normalizedLiveData = normalizeOptions(liveData);
+          if (normalizedLiveData.length) return normalizedLiveData;
+
+          const collectionRef =
+            typeof candidate === 'string' ? wwLib.wwCollection.getCollection(candidate) : candidate;
+          const normalizedRefData = normalizeOptions(collectionRef?.data);
+          if (normalizedRefData.length) return normalizedRefData;
+        } catch (collectionError) {
+          noopConsole('[GridViewDinamica] Failed to resolve responsible users from collection candidate', candidate, collectionError);
+        }
+      }
+    } catch (e) {
+      noopConsole('[GridViewDinamica] Failed to load responsible users from collection', e);
+    }
+
+    // Fallback: inline datasource object/array
+    const ds = props.content?.userDatasource;
+    if (Array.isArray(ds)) return normalizeOptions(ds);
+    if (ds && typeof ds === 'object') return normalizeOptions(ds.data || ds.result || ds.results);
+
+    return [];
+  };
+
+  let responsibleUserCache = null;
+
+  async function getColumnOptions(col, ticketId, { force = false } = {}) {
+    const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+    const identifier = (col.FieldDB || '').toUpperCase();
+    const lazyStatus = shouldLazyLoadStatus(col);
+
+    if (lazyStatus && !force) {
+      return [];
+    }
+
+    if (tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') {
+      if (!responsibleUserCache) {
+        responsibleUserCache = await loadResponsibleUserOptions();
+      }
+      return responsibleUserCache;
+    }
+
+    let opts = [];
+    if (col.listOptions) {
+      opts = parseStaticOptions(col.listOptions);
+    } else if (col.list_options) {
+      opts = parseStaticOptions(col.list_options);
+    } else if (col.dataSource?.list_options) {
+      opts = parseStaticOptions(col.dataSource.list_options);
+    }
+
+    const hasFn = col.dataSource?.functionName || col.dataSource?.dataSource?.functionName;
+    if (!opts.length && hasFn) {
+      const useTicket = usesTicketId(col);
+      opts = await loadApiOptions(col, useTicket ? ticketId : undefined);
+    }
+
+    return opts;
+  }
+
+  const loadAllColumnOptions = async () => {
+    if (!props.content || !Array.isArray(props.content.columns)) return;
+    const rows = wwLib.wwUtils.getDataFromCollection(props.content.rowData) || [];
+    const result = {};
+    const promises = [];
+    for (const col of props.content.columns) {
+      const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+      const identifier = (col.FieldDB || '').toUpperCase();
+      const isResponsible = tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+      if (!isResponsible) continue;
+      const colId = col.id || col.field;
+      result[colId] = {};
+      for (const row of rows) {
+        const ticketId = row?.TicketID;
+        const cacheKey = getOptionsCacheKey(col, ticketId);
+        if (result[colId][cacheKey]) continue;
+        const p = getColumnOptions(col, usesTicketId(col) ? ticketId : undefined).then(opts => {
+          result[colId][cacheKey] = opts;
+        });
+        promises.push(p);
+      }
+    }
+    await Promise.all(promises);
+    columnOptions.value = result;
+  };
+
+  const refreshAllDropdownOptions = async () => {
+    if (!props.content || !Array.isArray(props.content.columns)) {
+      return { refreshedColumns: 0, refreshedKeys: 0 };
+    }
+
+    const rows = wwLib.wwUtils.getDataFromCollection(props.content.rowData) || [];
+    const columns = props.content.columns.filter(col => isListLikeColumn(col));
+    if (!columns.length) {
+      return { refreshedColumns: 0, refreshedKeys: 0 };
+    }
+
+    responsibleUserCache = null;
+    const nextOptions = { ...(columnOptions.value || {}) };
+    const refreshTasks = [];
+
+    for (const col of columns) {
+      const fieldKey = col.id || col.field;
+      if (!fieldKey) continue;
+
+      const hasDynamicSource = !!(col.dataSource?.functionName || col.dataSource?.dataSource?.functionName);
+      const tag = (col.TagControl || col.tagControl || col.tagcontrol || '').toUpperCase();
+      const identifier = (col.FieldDB || '').toUpperCase();
+      const isResponsibleUser = tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+      if (!hasDynamicSource && !isResponsibleUser) {
+        continue;
+      }
+
+      nextOptions[fieldKey] = {};
+
+      const shouldUseTicket = usesTicketId(col);
+      const ticketKeys = shouldUseTicket
+        ? Array.from(
+            new Set(
+              rows
+                .map(row => row?.TicketID)
+                .filter(ticketId => ticketId != null && ticketId !== '')
+            )
+          )
+        : [undefined];
+
+      if (!ticketKeys.length) {
+        ticketKeys.push(undefined);
+      }
+
+      for (const ticketKey of ticketKeys) {
+        const cacheKey = getOptionsCacheKey(col, shouldUseTicket ? ticketKey : undefined);
+        refreshTasks.push(
+          getColumnOptions(
+            col,
+            shouldUseTicket ? ticketKey : undefined,
+            { force: true }
+          )
+            .then(opts => {
+              if (!nextOptions[fieldKey]) {
+                nextOptions[fieldKey] = {};
+              }
+              nextOptions[fieldKey][cacheKey] = Array.isArray(opts) ? opts : [];
+            })
+            .catch(error => {
+              noopConsole('[GridViewDinamica] Failed to refresh dropdown options for column', fieldKey, error);
+              if (!nextOptions[fieldKey]) {
+                nextOptions[fieldKey] = {};
+              }
+              nextOptions[fieldKey][cacheKey] = [];
+            })
+        );
+      }
+    }
+
+    if (refreshTasks.length) {
+      await Promise.all(refreshTasks);
+    }
+
+    columnOptions.value = nextOptions;
+
+    if (gridApi.value) {
+      const previousFilterModel =
+        typeof gridApi.value.getFilterModel === 'function'
+          ? gridApi.value.getFilterModel()
+          : null;
+      const columnIds = columns
+        .map(col => col.id || col.field)
+        .filter(Boolean);
+
+      if (columnIds.length && typeof gridApi.value.refreshCells === 'function') {
+        gridApi.value.refreshCells({ force: true, columns: columnIds });
+      }
+
+      if (typeof gridApi.value.refreshHeader === 'function') {
+        gridApi.value.refreshHeader();
+      }
+
+      if (typeof gridApi.value.destroyFilter === 'function') {
+        columnIds.forEach(colId => {
+          try {
+            gridApi.value.destroyFilter(colId);
+          } catch (error) {
+            noopConsole('[GridViewDinamica] Failed to destroy filter for column', colId, error);
+          }
+        });
+      }
+
+      if (
+        previousFilterModel &&
+        typeof previousFilterModel === 'object' &&
+        typeof gridApi.value.setFilterModel === 'function'
+      ) {
+        gridApi.value.setFilterModel(previousFilterModel);
+      }
+
+      if (typeof gridApi.value.onFilterChanged === 'function') {
+        gridApi.value.onFilterChanged();
+      }
+    }
+
+    return { refreshedColumns: columns.length, refreshedKeys: refreshTasks.length };
+  };
+
+  // Reaplica a ordem das colunas baseada na propriedade PositionInGrid
+  const applyColumnOrderFromPosition = () => {
+    const colApi = getColApi();
+    if (!colApi || !props.content || !Array.isArray(props.content.columns)) return;
+
+    const includeSelectionColumn =
+      props.content?.rowSelection === 'multiple' && !props.content?.disableCheckboxes;
+
+    const ordered = [...props.content.columns].sort((a, b) => {
+      const aPos = a.PositionInGrid ?? a.positionInGrid ?? a.PositionField ?? 0;
+      const bPos = b.PositionInGrid ?? b.positionInGrid ?? b.PositionField ?? 0;
+      return aPos - bPos;
+    });
+
+    let state = ordered
+      .map((col, idx) => {
+        const colId = col.id || col.field;
+        if (!colId) return null;
+        const pinned = col.pinned === 'left' || col.pinned === 'right' ? col.pinned : undefined;
+        return {
+          colId,
+          order: includeSelectionColumn ? idx + 1 : idx,
+          ...(pinned ? { pinned } : {}),
+        };
+      })
+      .filter(Boolean);
+
+    if (includeSelectionColumn) {
+      state = [
+        {
+          colId: 'ag-Grid-SelectionColumn',
+          order: 0,
+          pinned: 'left',
+          suppressSizeToFit: true,
+          suppressAutoSize: true,
+        },
+        ...state,
+      ];
+    }
+
+    if (state.length) {
+      runWithSuppressedReveal(() => {
+        const columnStateConfig = {
+          state,
+          applyOrder: true,
+        };
+
+        if (includeSelectionColumn) {
+          columnStateConfig.defaultState = { pinned: null };
+        }
+
+        colApi?.applyColumnState?.(columnStateConfig);
+      });
+      // Atualiza variáveis e persiste nova ordem
+      updateColumnsPosition();
+
+      if (includeSelectionColumn) {
+        defer(() => forceSelectionColumnFirst());
+
+      }
+    }
+  };
+
+  // Listener de unload para salvar estado (opcional, robustez extra)
+  let beforeUnloadHandler = null;
+
+  const handleDocumentClick = (e) => {
+    const selectors = [
+      '.list-editor',
+      '.list-filter',
+      '.ag-popup',
+      '.datepicker-pop',
+      '[role="dialog"]',
+      '[data-grid-popup]'
+    ];
+    const anyPopup = selectors.some(sel => document.querySelector(sel));
+    if (!anyPopup) return;
+    const clickedInside = selectors.some(sel => e.target.closest(sel));
+    if (!clickedInside && gridApi.value) {
+      gridApi.value.stopEditing();
+      if (typeof gridApi.value.hidePopupMenu === 'function') {
+        gridApi.value.hidePopupMenu();
+      }
+    }
+  };
+
+  onMounted(() => {
+    loadAllColumnOptions();
+
+    beforeUnloadHandler = () => saveGridState();
+    window.addEventListener('beforeunload', beforeUnloadHandler);
+    document.addEventListener('click', handleDocumentClick, true);
+  });
+
+  watch(() => props.content?.columns, () => {
+    loadAllColumnOptions();
+    applyColumnOrderFromPosition();
+    updateColumnsPosition({ fallbackToContent: true });
+    // Se estamos num ciclo de remount que deve respeitar a WW variable, reaplique
+    setTimeout(() => {
+      if (forceExternalSortNextMount.value) {
+        applyExternalSortAndSync();
+      }
+    }, 0);
+    resetHideSaveButtonVisibility();
+  }, { deep: true });
+
+  watch(() => props.content?.rowData, () => {
+    loadAllColumnOptions();
+    applyColumnOrderFromPosition();
+    updateColumnsPosition({ fallbackToContent: true });
+    // Se estamos num ciclo de remount que deve respeitar a WW variable, reaplique
+    setTimeout(() => {
+      if (forceExternalSortNextMount.value) {
+        applyExternalSortAndSync();
+      }
+    }, 0);
+    resetHideSaveButtonVisibility();
+    updateTicketTagCounts();
+    emitGridLoadedEvent();
+  }, { deep: true });
+
+
+
+
+  // Interval para atualizar células DEADLINE
+  let deadlineTimer = null;
+  if (!window.gridDeadlineNow) window.gridDeadlineNow = new Date();
+  onUnmounted(() => {
+    if (deadlineTimer) {
+      clearInterval(deadlineTimer);
+      deadlineTimer = null;
+    }
+    // Salva estado ao desmontar (garante persistência ao navegar)
+    saveGridState();
+    if (beforeUnloadHandler) {
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+      beforeUnloadHandler = null;
+    }
+    document.removeEventListener('click', handleDocumentClick, true);
+    if (captureInitialStateTimeout) {
+      clearTimeout(captureInitialStateTimeout);
+      captureInitialStateTimeout = null;
+    }
+    pendingInitialGridState = null;
+    suppressRevealUntilCapture = false;
+
+  });
+  
+    const onGridReady = (params) => {
+      gridApi.value = params.api;
+      columnApi.value = params.columnApi;
+
+      resetHideSaveButtonVisibility();
+
+      // Restaura imediatamente e também em pequenos delays
+      restoreGridState();
+      setTimeout(restoreGridState, 0);
+      setTimeout(restoreGridState, 150);
+      setTimeout(() => scheduleCaptureInitialGridState(0), 220);
+
+
+
+      // LOG: Tenta mostrar as colunas disponíveis e seus renderers
+      if (typeof params.api.getAllColumns === 'function') {
+        const allCols = params.api.getAllColumns().map(col => ({
+          colId: col.getColId(),
+          field: col.getColDef().field,
+          headerName: col.getColDef().headerName,
+          cellRenderer: col.getColDef().cellRenderer
+        }));
+        
+      } else if (typeof params.api.getColumnDefs === 'function') {
+        const colDefs = params.api.getColumnDefs();
+        
+      } else if (typeof params.api.getColumnState === 'function') {
+        const colState = params.api.getColumnState();
+        
+      } 
+
+      updateColumnsPosition();
+      updateColumnsSort();
+
+      updateTicketTagCounts();
+
+      // Persistir estado em todos eventos relevantes
+      params.api.addEventListener('filterChanged', saveGridState);
+      params.api.addEventListener('sortChanged', saveGridState);
+      params.api.addEventListener('columnPinned', saveGridState);
+      params.api.addEventListener('columnVisible', saveGridState);
+      params.api.addEventListener('columnResized', saveGridState);
+      params.api.addEventListener('columnEverythingChanged', saveGridState);
+
+      const applyPinnedHeaderBlock = () => {
+        const gridElement = agGridRef.value?.$el;
+        if (!gridElement) return;
+
+        gridElement
+          .querySelectorAll('.ag-header-cell.ag-pinned-left, .ag-header-cell.ag-pinned-right')
+          .forEach(cell => {
+            if (!('dataset' in cell)) return;
+            if (cell.dataset[PINNED_HEADER_DATASET_FLAG]) return;
+            cell.dataset[PINNED_HEADER_DATASET_FLAG] = 'true';
+            cell.addEventListener('mousedown', stopPinnedHeaderMouseDown, true);
+            cell.addEventListener('dragstart', preventPinnedHeaderDragStart, true);
+          });
+      };
+
+    // Impedir mover colunas para posição de pinned
+
+    params.api.addEventListener('columnMoved', (event) => {
+      const api = (params.columnApi && typeof params.columnApi.getAllGridColumns === 'function')
+        ? params.columnApi
+        : (params.api && typeof params.api.getAllGridColumns === 'function')
+          ? params.api
+          : null;
+      if (!api) return;
+
+      const allColumns = api.getAllGridColumns();
+      const firstPinnedIdx = allColumns.findIndex(col => col.getPinned && col.getPinned() === 'left');
+      if (firstPinnedIdx > 0) {
+        const hasNonPinnedBefore = allColumns
+          .slice(0, firstPinnedIdx)
+          .some(col => (col.getPinned && col.getPinned() !== 'left'));
+        if (hasNonPinnedBefore) {
+          const pinnedCols = allColumns.filter(col => col.getPinned && col.getPinned() === 'left');
+          const nonPinnedCols = allColumns.filter(col => !col.getPinned || col.getPinned() !== 'left');
+          const newOrder = [...pinnedCols, ...nonPinnedCols].map(col => col.getColId && col.getColId());
+          if (typeof (params.columnApi?.moveColumns) === 'function') {
+            params.columnApi.moveColumns(newOrder, 0);
+          } else if (typeof (params.api?.moveColumns) === 'function') {
+            params.api.moveColumns(newOrder, 0);
+          }
+        }
+      }
+    });
+
+    
+    params.api.addEventListener('columnPinned', applyPinnedHeaderBlock);
+    params.api.addEventListener('columnMoved', applyPinnedHeaderBlock);
+    params.api.addEventListener('columnVisible', applyPinnedHeaderBlock);
+    params.api.addEventListener('columnEverythingChanged', applyPinnedHeaderBlock);
+    params.api.addEventListener('bodyScroll', applyPinnedHeaderBlock);
+    params.api.addEventListener('displayedColumnsChanged', applyPinnedHeaderBlock);
+    setTimeout(() => {
+      applyPinnedHeaderBlock();
+    }, 500);
+
+    // Configurar a coluna de seleção para ser sempre a primeira
+    if (props.content.rowSelection === 'multiple' && !props.content.disableCheckboxes) {
+      // Múltiplas tentativas para garantir que funcione
+      setTimeout(() => forceSelectionColumnFirst(), 50);
+      setTimeout(() => forceSelectionColumnFirst(), 200);
+      
+      // Observer para detectar mudanças no DOM e reposicionar automaticamente
+      setTimeout(() => {
+        const gridElement = agGridRef.value?.$el;
+        if (gridElement) {
+          const observer = new MutationObserver(() => {
+            // Debounce para evitar execuções excessivas
+            clearTimeout(observer.debounceTimer);
+            observer.debounceTimer = setTimeout(() => {
+              forceSelectionColumnFirstDOM();
+            }, 50);
+          });
+          
+          observer.observe(gridElement, {
+            childList: true,
+            subtree: true,
+            attributes: false
+          });
+          
+          // Store observer for cleanup if needed
+          gridApi.value._selectionColumnObserver = observer;
+        }
+      }, 600);
+    }
+
+    // Descobrir colunas DEADLINE
+    let deadlineColumns = [];
+    // Timer para atualizar células DEADLINE
+    if (props.content && props.content.columns && Array.isArray(props.content.columns)) {
+      deadlineColumns = props.content.columns
+        .filter(col => {
+          const tc = col.TagControl || col.tagControl || col.tagcontrol;
+          return tc && tc.toUpperCase() === 'DEADLINE';
+        })
+        .map(col => col.id || col.field)
+        .filter(Boolean);
+    }
+    // Timer para atualizar células DEADLINE
+    if (deadlineColumns.length) {
+      deadlineTimer = setInterval(() => {
+        window.gridDeadlineNow = new Date();
+        if (gridApi.value) {
+          gridApi.value.refreshCells({ columns: deadlineColumns, force: true });
+        }
+      }, 1000);
+    }
+  };
+  
+  function restorePinnedColumns() {
+    if (!isGridApiActive() || !getColApi()) return;
+    const state = getColApi()?.getColumnState?.();
+    // Restaurar pinned e ordem das colunas pinned
+    const pinnedLeft = [];
+    const pinnedRight = [];
+    const others = [];
+    state.forEach(col => {
+      const original = props.content && props.content.columns ? props.content.columns.find(c => c.id === col.colId || c.field === col.colId) : null;
+      if (original && original.pinned === 'left') {
+        pinnedLeft.push({ ...col, pinned: 'left' });
+      } else if (original && original.pinned === 'right') {
+        pinnedRight.push({ ...col, pinned: 'right' });
+      } else {
+        others.push({ ...col, pinned: null });
+      }
+    });
+    const newState = [...pinnedLeft, ...others, ...pinnedRight];
+    getColApi()?.applyColumnState?.({ state: newState, applyOrder: true });
+  }
+  
+  // Função para forçar a coluna de seleção a ser a primeira
+  function forceSelectionColumnFirst() {
+    if (!isGridApiActive()) return;
+
+    try {
+      // Tentar reposicionar usando API do AG-Grid
+      const columnState = getColApi()?.getColumnState?.() || [];
+      const selectionColumnIndex = columnState.findIndex(col => 
+        col.colId === 'ag-Grid-SelectionColumn'
+      );
+      
+      if (selectionColumnIndex !== -1) {
+        // Configurar a coluna de seleção como pinned left
+        columnState[selectionColumnIndex].pinned = 'left';
+        columnState[selectionColumnIndex].suppressSizeToFit = true;
+        columnState[selectionColumnIndex].suppressAutoSize = true;
+        
+        // Reposicionar para o início
+        const selectionColumn = columnState.splice(selectionColumnIndex, 1)[0];
+        columnState.unshift(selectionColumn);
+        
+        // Restaurar pinning das outras colunas
+        const originalColumns = props.content && props.content.columns ? props.content.columns : [];
+        columnState.forEach(colState => {
+          const originalCol = originalColumns.find(col => col.id === colState.colId);
+          if (originalCol && originalCol.pinned === 'left' && colState.colId !== 'ag-Grid-SelectionColumn') {
+            colState.pinned = 'left';
+          }
+        });
+        
+        // Aplicar o novo estado
+        runWithSuppressedReveal(() => {
+          gridApi.value.applyColumnState({
+            state: columnState,
+            applyOrder: true
+          });
+        });
+      }
+    } catch (error) {
+      noopConsole('Erro ao reposicionar coluna de seleção:', error);
+    }
+
+    // Fallback: reposicionamento direto no DOM
+    setTimeout(() => {
+      forceSelectionColumnFirstDOM();
+    }, 100);
+  }
+
+  // Função para reposicionar a coluna de seleção diretamente no DOM
+  function forceSelectionColumnFirstDOM() {
+    if (!isGridApiActive()) return;
+
+    try {
+      const gridElement = agGridRef.value?.$el;
+      if (!gridElement) return;
+      
+      // Reposicionar headers
+      const headerRows = gridElement.querySelectorAll('.ag-header-row');
+      headerRows.forEach(headerRow => {
+        const selectionHeader = headerRow.querySelector('.ag-header-cell[col-id="ag-Grid-SelectionColumn"]');
+        if (selectionHeader && selectionHeader.parentElement === headerRow) {
+          // Move para o primeiro position
+          headerRow.insertBefore(selectionHeader, headerRow.firstChild);
+        }
+      });
+      
+      // Reposicionar células nas linhas
+      const rows = gridElement.querySelectorAll('.ag-row');
+      rows.forEach(row => {
+        const selectionCell = row.querySelector('.ag-cell[col-id="ag-Grid-SelectionColumn"]');
+        if (selectionCell && selectionCell.parentElement === row) {
+          // Move para o primeiro position
+          row.insertBefore(selectionCell, row.firstChild);
+        }
+      });
+    } catch (error) {
+      noopConsole('Erro ao reposicionar coluna de seleção no DOM:', error);
+    }
+  }
+  
+  watch(
+    [() => props.content.initialFilters, () => gridApi.value],
+    ([filters]) => {
+      if (!isGridApiActive()) return;
+      runWithSuppressedReveal(() => {
+        gridApi.value.setFilterModel(filters || null);
+      }, { recaptureDelay: 50 });
+
+    },
+    { deep: true, immediate: true }
+  );
+
+  watch(
+    [() => props.content.initialSort, () => gridApi.value],
+    ([sort]) => {
+      if (!isGridApiActive()) return;
+      runWithSuppressedReveal(() => {
+        gridApi.value.applyColumnState({
+          state: sort || [],
+          defaultState: { sort: null },
+        });
+      }, { recaptureDelay: 50 });
+
+    },
+    { deep: true, immediate: true }
+  );
+  
+  const onRowSelected = (event) => {
+  const name = event.node.isSelected() ? "rowSelected" : "rowDeselected";
+  ctx.emit("trigger-event", {
+  name,
+  event: { row: event.data },
+  });
+  };
+  
+  const onSelectionChanged = (event) => {
+  if (!isGridApiActive()) return;
+  const selected = gridApi.value.getSelectedRows() || [];
+  setSelectedRows(selected);
+  };
+
+  const refreshGridStateChanges = (event) => {
+    syncHideSaveButtonVisibility(event);
+    deferAfterGridUpdate(() => {
+      updateTicketTagCounts();
+      emitGridLoadedEvent();
+    });
+  };
+
+  const onRowDataChanged = (event) => {
+    refreshGridStateChanges(event);
+  };
+
+  const onRowDataUpdated = (event) => {
+    refreshGridStateChanges(event);
+  };
+  
+  const onFilterChanged = (event) => {
+    if (!isGridApiActive()) return;
+    const filterModel = gridApi.value.getFilterModel();
+    if (
+      JSON.stringify(filterModel || {}) !==
+      JSON.stringify(filterValue.value || {})
+    ) {
+      setFilters(filterModel);
+      syncHideSaveButtonVisibility(event);
+
+      ctx.emit("trigger-event", {
+        name: "filterChanged",
+        event: filterModel,
+      });
+    }
+
+    deferAfterGridUpdate(() => {
+      updateTicketTagCounts();
+      emitGridLoadedEvent();
+    });
+    saveGridState();
+    (() => { try { const pristine = isGridStatePristine(); updateHideSaveButtonVisibility(pristine); } catch (e) {} })();
+  };
+  
+  const onSortChanged = (event) => {
+    if (!isGridApiActive()) return;
+
+    if (suppressRevealUntilCapture) {
+      updateHideSaveButtonVisibility(true);
+      return;
+    }
+
+    deferAfterGridUpdate(() => {
+      const { sort: normalizedSort } = getNormalizedGridState();
+      setSort(normalizedSort);
+      updateColumnsSort();
+      saveGridState();
+      const pristine = isGridStatePristine();
+      updateHideSaveButtonVisibility(pristine);
+      (() => { try { const pristine = isGridStatePristine(); updateHideSaveButtonVisibility(pristine); } catch (e) {} })();
+      ctx.emit("trigger-event", { name: "sortChanged", event: normalizedSort });
+      emitGridLoadedEvent();
+    });
+  };
+
+  const onColumnMoved = (event) => {
+  if (!isGridApiActive() || !event?.finished) return;
+  const prev = JSON.stringify(columnsPositionValue.value || []);
+  updateColumnsPosition();
+  const current = JSON.stringify(columnsPositionValue.value || []);
+  if (prev !== current) {
+  syncHideSaveButtonVisibility(event);
+
+  ctx.emit("trigger-event", {
+  name: "columnMoved",
+  event: columnsPositionValue.value,
+  });
+  }
+    (() => { try { const pristine = isGridStatePristine(); updateHideSaveButtonVisibility(pristine); } catch (e) {} })();
+};
+
+  /* wwEditor:start */
+  const { createElement } = wwLib.wwElement.useCreate();
+  /* wwEditor:end */
+  
+  function buildColumnsPositionFromContentColumns() {
+    if (!props.content || !Array.isArray(props.content.columns)) {
+      return [];
+    }
+
+    const orderedColumns = [...props.content.columns].sort((a, b) => {
+      const getPosition = column =>
+        column.PositionInGrid ??
+        column.positionInGrid ??
+        column.PositionField ??
+        column.positionField ??
+        0;
+
+      return getPosition(a) - getPosition(b);
+    });
+
+    let order = 1;
+    return orderedColumns
+      .map(column => {
+        const fieldId =
+          column.FieldID ??
+          column.FieldId ??
+          column.Field ??
+          column.id ??
+          column.field ??
+          column.FieldDB;
+
+        if (!fieldId) {
+          return null;
+        }
+
+        return {
+          FieldID: String(fieldId),
+          PositionField: order++,
+          IsDeleted: false,
+        };
+      })
+      .filter(Boolean);
+  }
+
+  function updateColumnsPosition(options = {}) {
+    const { fallbackToContent = false } = options;
+
+    if (gridApi.value && typeof gridApi.value.getAllGridColumns === "function") {
+      const allColumns = gridApi.value.getAllGridColumns();
+      const positions = allColumns
+        .map((column, idx) => {
+          const colDef = typeof column.getColDef === "function" ? column.getColDef() : column.colDef || {};
+          const fieldId =
+            colDef?.id ??
+            colDef?.colId ??
+            (typeof column.getColId === "function" ? column.getColId() : undefined) ??
+            colDef?.field;
+
+          if (!fieldId) {
+            return null;
+          }
+
+          return {
+            FieldID: String(fieldId),
+            PositionField: idx + 1,
+            IsDeleted: false,
+          };
+        })
+        .filter(Boolean);
+
+      setColumnsPosition(positions);
+      saveGridState();
+
+      if (positions.length || !fallbackToContent) {
+        return;
+      }
+    }
+
+    if (fallbackToContent) {
+      setColumnsPosition(buildColumnsPositionFromContentColumns());
+    }
+  }
+  
+  function updateColumnsSort() {
+  const api = (columnApi.value && typeof columnApi.value.getColumnState === 'function')
+    ? columnApi.value
+    : (gridApi.value && typeof gridApi.value.getColumnState === 'function')
+      ? gridApi.value
+      : null;
+  if (!isGridApiActive() || !api) return;
+  const sortArray = (api.getColumnState() || [])
+    .filter(col => col.sort)
+    .map(col => ({
+      id: col.colId,
+      isASC: col.sort === 'asc'
+    }));
+  setColumnsSort(sortArray);
+}
+  
+      const onFirstDataRendered = () => {
+      updateColumnsPosition();
+      updateColumnsSort();
+      
+      // Reaplica o estado salvo após o primeiro render (garante consistência)
+      setTimeout(() => {
+        restoreGridState();
+      }, 0);
+
+      // Garantia extra: se ainda não aplicou, faça aqui também
+setTimeout(() => {
+  if (forceExternalSortNextMount.value) {
+    applyExternalSortAndSync();
+    forceExternalSortNextMount.value = false;
+  }
+}, 0);
+
+
+      // Garantir que a coluna de seleção esteja na primeira posição
+      if (props.content.rowSelection === 'multiple' && !props.content.disableCheckboxes) {
+        // Múltiplas tentativas para garantir que funcione
+        setTimeout(() => forceSelectionColumnFirst(), 10);
+        setTimeout(() => forceSelectionColumnFirst(), 100);
+        setTimeout(() => forceSelectionColumnFirst(), 300);
+        // Força reposicionamento no DOM como backup
+        setTimeout(() => forceSelectionColumnFirstDOM(), 400);
+      }
+
+      updateTicketTagCounts();
+      emitGridLoadedEvent();
+    };
+  
+      onMounted(() => {
+      setTimeout(() => {
+        if (gridApi.value && typeof gridApi.value.getAllColumns === 'function') {
+          const allCols = gridApi.value.getAllColumns().map(col => ({
+            colId: col.getColId(),
+            field: col.getColDef().field,
+            headerName: col.getColDef().headerName,
+            cellRenderer: col.getColDef().cellRenderer
+          }));
+          
+        } 
+      }, 2000); // Espera 2 segundos para garantir que a grid montou
+    });
+  
+      return {
+      resolveMappingFormula,
+      resolveRowId,
+      componentFontFamily,
+      resolvedFontFamily,
+      resolvedFontSize,
+      resolvedFontSizeNumber,
+      onGridReady,
+      onRowSelected,
+      onSelectionChanged,
+      onRowDataChanged,
+      onRowDataUpdated,
+      gridApi,
+      onFilterChanged,
+      onSortChanged,
+      onColumnMoved,
+      forceSelectionColumnFirst,
+      forceSelectionColumnFirstDOM,
+      columnOptions,
+      refreshRowFromSource,
+      refreshRowListOptions,
+      shouldLazyLoadStatus,
+      buildLazyStatusFallbackOptions,
+      refreshAllDropdownOptions,
+      getRowMetadataHash,
+      waitForRowHydration,
+      getColumnOptions,
+      getOptionsCacheKey,
+      usesTicketId,
+      componentKey,
+      remountComponent,
+      setColumnsSortVariable: setColumnsSort,
+      setSortVariable: setSort,
+      updateColumnsSortFromApi: updateColumnsSort,
+      clearSavedGridState,
+      localeText: computed(() => {
+        let lang = 'en-US';
+        try {
+          if (window.wwLib && window.wwLib.wwVariable && typeof window.wwLib.wwVariable.getValue === 'function') {
+            const v = window.wwLib.wwVariable.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+            if (typeof v === 'string' && v.length > 0) lang = v;
+          }
+        } catch (e) {}
+        switch (lang) {
+          case 'pt-BR':
+          case 'pt':
+            return AG_GRID_LOCALE_PT;
+          case 'fr':
+          case 'fr-FR':
+            return AG_GRID_LOCALE_FR;
+          case 'de':
+          case 'de-DE':
+            return AG_GRID_LOCALE_DE;
+          case 'es':
+          case 'es-ES':
+            return AG_GRID_LOCALE_ES;
+          case 'en-US':
+          default:
+            return AG_GRID_LOCALE_EN;
+        }
+      }),
+      /* wwEditor:start */
+      createElement,
+      /* wwEditor:end */
+      onFirstDataRendered,
+      editorComponents: {
+        ListCellEditor,
+        FixedListCellEditor,
+        ResponsibleUserCellEditor,
+        DateTimeCellEditor,
+      },
+    };
+  },
+    computed: {
+    rowData() {
+      const data = wwLib.wwUtils.getDataFromCollection(this.content.rowData);
+      const rows = Array.isArray(data) ? data ?? [] : [];
+      const rawFilter = this.content?.ticketTypeFilter;
+      if (rawFilter == null || rawFilter === "") return rows;
+
+      const normalized = String(rawFilter).toLowerCase();
+      const allowed = ["incident", "request", "problem", "update"];
+      if (!allowed.includes(normalized)) return rows;
+
+      return rows.filter(row => {
+        const tag = String(row?.TagTicketModel || "").toLowerCase();
+        return tag === normalized;
+      });
+    },
+    paginationPositionClass() {
+      return this.content.paginationPosition === "top" ? "pagination-top" : "pagination-bottom";
+    },
+    defaultColDef() {
+      return {
+        editable: false,
+        resizable: this.content.resizableColumns,
+      };
+    },
+    finalColumnDefs() {
+      const columns = this.columnDefs;
+      // Se temos seleção múltipla, garantir que colunas originalmente pinned permaneçam fixas
+      if (this.content.rowSelection === 'multiple' && !this.content.disableCheckboxes) {
+        return columns.map(col => {
+          if (col._originalPinned) {
+            return { ...col, pinned: col._originalPinned };
+          }
+          return col;
+        });
+      }
+      return columns;
+    },
+    columnDefs() {
+      if (!this.content || !this.content.columns || !Array.isArray(this.content.columns)) {
+        return [];
+      }
+
+      const orderedColumns = [...this.content.columns].sort((a, b) => {
+        const aPos = a.PositionInGrid ?? a.positionInGrid ?? a.PositionField ?? 0;
+        const bPos = b.PositionInGrid ?? b.positionInGrid ?? b.PositionField ?? 0;
+        return aPos - bPos;
+      });
+
+
+
+      return orderedColumns.map((col) => {
+        const colCopy = { ...col };
+        const colId = colCopy.id || colCopy.field;
+        // Forçar configuração correta para a coluna Deadline        
+
+        if (colCopy.field === 'Deadline') {
+          colCopy.cellRenderer = FormatterCellRenderer;
+          delete colCopy.cellRendererFramework;
+          delete colCopy.formatter;
+          delete colCopy.valueFormatter;
+          delete colCopy.useCustomFormatter;
+          delete colCopy.useStyleArray;
+        }
+        if (colCopy.cellDataType === 'dateTime') {
+          delete colCopy.useCustomFormatter;
+          delete colCopy.formatter;
+          delete colCopy.valueFormatter;
+          delete colCopy.cellRendererFramework;
+        }
+        if (colCopy.FieldDB === 'StatusID') {
+          colCopy.filter = 'agListColumnFilter';
+        }
+        // Função utilitária para garantir valor numérico
+        function toNumber(val) {
+          if (val === null || val === undefined || val === '' || val === 'auto') return undefined;
+          if (typeof val === 'number') return val;
+          if (typeof val === 'string' && val.endsWith('px')) return Number(val.replace('px', ''));
+          if (!isNaN(Number(val))) return Number(val);
+          return undefined;
+        }
+        
+        const minWidth = toNumber(colCopy.minWidth) ?? toNumber(colCopy.MinWidth) ?? 80;
+        const isFlex = colCopy.widthAlgo === 'flex';
+        const explicitWidth = toNumber(colCopy.width) ?? toNumber(colCopy.Width);
+        const width = isFlex ? undefined : (explicitWidth ?? minWidth);
+        const flex = isFlex ? (colCopy.flex ?? 1) : undefined;
+        const maxWidth = toNumber(colCopy.maxWidth) ?? toNumber(colCopy.MaxWidth);
+        const commonProperties = {
+          minWidth,
+          ...(width !== undefined ? { width } : {}),
+          ...(isFlex ? { flex } : {}),
+          ...(maxWidth !== undefined ? { maxWidth } : {}),
+          pinned: colCopy.pinned === "none" ? false : colCopy.pinned,
+          hide: !!colCopy.hide,
+          editable: !!colCopy.editable, // <-- garantir editable
+          FieldDB: colCopy.FieldDB, // <-- garantir FieldDB no colDef
+          TagControl: colCopy.TagControl,
+          ...(colCopy.pinned === 'left' ? { lockPinned: true, lockPosition: true } : {}),
+        };
+
+        const tagControl = (colCopy.TagControl || colCopy.tagControl || colCopy.tagcontrol || '').toUpperCase();
+        const identifier = (colCopy.FieldDB || '').toUpperCase();
+
+        // Se o filtro for agListColumnFilter, usar o filtro customizado
+        if (colCopy.filter === 'agListColumnFilter') {
+          const isResponsible = tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+          const result = {
+            ...commonProperties,
+            id: colId,
+            colId,
+            headerName: colCopy.headerName,
+            field: colCopy.field,
+            sortable: colCopy.sortable,
+            filter: isResponsible ? ResponsibleUserFilterRenderer : ListFilterRenderer,
+            cellRenderer: isResponsible ? 'UserCellRenderer' : 'FormatterCellRenderer',
+            cellRendererParams: {
+              useCustomFormatter: colCopy.useCustomFormatter,
+              formatter: colCopy.formatter,
+              // options will be added below when available
+            }
+          };
+          const fieldKey = colCopy.id || colCopy.field;
+          const useTicket = this.usesTicketId(colCopy);
+          const lazyStatus = this.shouldLazyLoadStatus(colCopy);
+          const getDsOptionsSync = params => {
+            const ticketId = params.data?.TicketID;
+            const key = this.getOptionsCacheKey(colCopy, ticketId);
+            if (lazyStatus) {
+              return this.buildLazyStatusFallbackOptions(colCopy);
+            }
+            const colOpts = this.columnOptions[fieldKey] || {};
+            const cached = colOpts[key];
+            if (cached) return cached;
+            if (lazyStatus) {
+              return this.buildLazyStatusFallbackOptions(colCopy);
+            }
+            if (tagControl === 'RESPONSIBLEUSERID') {
+              this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
+                if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
+                this.columnOptions[fieldKey][key] = opts;
+                params.api?.refreshCells?.({ columns: [fieldKey], force: true });
+              });
+            }
+            return [];
+          };
+          const getDsOptionsAsync = params => {
+            const ticketId = params.data?.TicketID;
+            if (lazyStatus) {
+              return this.getColumnOptions(
+                colCopy,
+                useTicket ? ticketId : undefined,
+                { force: true }
+              ).catch(error => {
+                noopConsole('[GridViewDinamica] Failed to lazy load StatusID options', error);
+                return this.buildLazyStatusFallbackOptions(colCopy);
+              });
+            }
+            const key = this.getOptionsCacheKey(colCopy, ticketId);
+            const colOpts = this.columnOptions[fieldKey] || {};
+            const cached = colOpts[key];
+            if (cached) return Promise.resolve(cached);
+            return this.getColumnOptions(
+              colCopy,
+              useTicket ? ticketId : undefined
+            ).then(opts => {
+              if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
+              this.columnOptions[fieldKey][key] = opts;
+              params.api?.refreshCells?.({ columns: [fieldKey], force: true });
+              return opts;
+            });
+          };
+
+          if (
+            colCopy.cellDataType === 'list' ||
+            (tagControl && tagControl.toUpperCase() === 'LIST')
+          ) {
+            const optionsArr = Array.isArray(colCopy.options)
+              ? parseStaticOptions(colCopy.options)
+              : Array.isArray(colCopy.listOptions)
+              ? parseStaticOptions(colCopy.listOptions)
+              : (colCopy.useStyleArray && Array.isArray(this.content.cellStyleArray))
+              ? this.content.cellStyleArray.map(opt => ({ value: opt.Valor, label: opt.Valor }))
+              : null;
+            if (colCopy.editable) {
+              result.editable = true;
+              if (optionsArr && optionsArr.length) {
+                result.cellEditor = ListCellEditor;
+                result.cellEditorParams = { options: optionsArr };
+                const baseRendererParams = result.cellRendererParams;
+                result.cellRendererParams = params => ({
+                  ...(typeof baseRendererParams === 'function'
+                    ? baseRendererParams(params)
+                    : baseRendererParams),
+                  options: optionsArr,
+                });
+              } else {
+                result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor;
+                result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+                const baseRendererParams = result.cellRendererParams;
+                result.cellRendererParams = params => ({
+                  ...(typeof baseRendererParams === 'function'
+                    ? baseRendererParams(params)
+                    : baseRendererParams),
+                  options: getDsOptionsSync(params),
+                });
+              }
+            } else {
+              const baseRendererParams = result.cellRendererParams;
+              result.cellRendererParams = params => ({
+                ...(typeof baseRendererParams === 'function'
+                  ? baseRendererParams(params)
+                  : baseRendererParams),
+                options: optionsArr || getDsOptionsSync(params),
+              });
+            }
+          }
+          if (colCopy.dataSource && colCopy.editable) {
+            result.editable = true;
+            result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor;
+            result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+            const baseRendererParams = result.cellRendererParams;
+            result.cellRendererParams = params => ({
+              ...(typeof baseRendererParams === 'function'
+                ? baseRendererParams(params)
+                : baseRendererParams),
+              options: getDsOptionsSync(params),
+            });
+          }
+          return result;
+        }
+
+        switch (colCopy.cellDataType) {
+          case "action": {
+            return {
+              ...commonProperties,
+              id: colId,
+              colId,
+              headerName: colCopy.headerName,
+              cellRenderer: "ActionCellRenderer",
+              cellRendererParams: {
+                name: colCopy.actionName,
+                label: colCopy.actionLabel,
+                trigger: this.onActionTrigger,
+                withFont: !!this.content.actionFont,
+              },
+              sortable: false,
+              filter: false,
+            };
+          }
+          case "custom":
+            return {
+              ...commonProperties,
+              id: colId,
+              colId,
+              headerName: colCopy.headerName,
+              field: colCopy.field,
+              cellRenderer: "WewebCellRenderer",
+              cellRendererParams: {
+                containerId: colCopy.containerId,
+              },
+              sortable: colCopy.sortable,
+              filter: colCopy.filter,
+            };
+          case "image": {
+            return {
+              ...commonProperties,
+              id: colId,
+              colId,
+              headerName: colCopy.headerName,
+              field: colCopy.field,
+              cellRenderer: "ImageCellRenderer",
+              cellRendererParams: {
+                width: colCopy.imageWidth,
+                height: colCopy.imageHeight,
+              },
+            };
+          }
+          case "list":
+            {
+              const fieldKey = colCopy.id || colCopy.field;
+              const useTicket = this.usesTicketId(colCopy);
+              const lazyStatus = this.shouldLazyLoadStatus(colCopy);
+              const getDsOptionsSync = params => {
+                const ticketId = params.data?.TicketID;
+                const key = this.getOptionsCacheKey(colCopy, ticketId);
+                if (lazyStatus) {
+                  return this.buildLazyStatusFallbackOptions(colCopy);
+                }
+                const colOpts = this.columnOptions[fieldKey] || {};
+                const cached = colOpts[key];
+                if (cached) return cached;
+                if (lazyStatus) {
+                  return this.buildLazyStatusFallbackOptions(colCopy);
+                }
+                this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
+                  if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
+                  this.columnOptions[fieldKey][key] = opts;
+                  params.api?.refreshCells?.({ force: true });
+                });
+                return [];
+              };
+              const getDsOptionsAsync = params => {
+                const ticketId = params.data?.TicketID;
+                if (lazyStatus) {
+                  return this.getColumnOptions(
+                    colCopy,
+                    useTicket ? ticketId : undefined,
+                    { force: true }
+                  ).catch(error => {
+                    noopConsole('[GridViewDinamica] Failed to lazy load StatusID options', error);
+                    return this.buildLazyStatusFallbackOptions(colCopy);
+                  });
+                }
+                const key = this.getOptionsCacheKey(colCopy, ticketId);
+                const colOpts = this.columnOptions[fieldKey] || {};
+                const cached = colOpts[key];
+                if (cached) return Promise.resolve(cached);
+                return this.getColumnOptions(
+                  colCopy,
+                  useTicket ? ticketId : undefined
+                ).then(opts => {
+
+                  if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
+                  this.columnOptions[fieldKey][key] = opts;
+                  return opts;
+                });
+              };
+
+              const staticOptions = Array.isArray(colCopy.options)
+                ? colCopy.options
+                : Array.isArray(colCopy.listOptions)
+                ? colCopy.listOptions
+                : null;
+
+              const isResponsible = tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
+              const result = {
+                ...commonProperties,
+                id: colId,
+                colId,
+                headerName: colCopy.headerName,
+                field: colCopy.field,
+                sortable: colCopy.sortable,
+                filter: isResponsible ? ResponsibleUserFilterRenderer : ListFilterRenderer,
+                cellRenderer: isResponsible ? 'UserCellRenderer' : 'FormatterCellRenderer',
+                cellRendererParams: {
+                  useCustomFormatter: colCopy.useCustomFormatter,
+                  formatter: colCopy.formatter,
+                },
+                editable: false,
+                cellEditor: staticOptions && staticOptions.length ? ListCellEditor : (tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor),
+              };
+              if (staticOptions && staticOptions.length) {
+                result.options = staticOptions;
+                result.cellEditorParams = { options: staticOptions };
+                result.cellRendererParams = {
+                  ...result.cellRendererParams,
+                  options: staticOptions,
+                };
+              } else {
+                result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+                const baseRendererParams = result.cellRendererParams;
+                result.cellRendererParams = params => ({
+                  ...(typeof baseRendererParams === 'function'
+                    ? baseRendererParams(params)
+                    : baseRendererParams),
+                  options: getDsOptionsSync(params),
+                });
+              }
+              if (colCopy.editable) {
+                result.editable = true;
+              }
+              // Add cursor pointer style when column is editable
+              let baseCellStyle = undefined;
+              if (colCopy.textAlign) {
+                baseCellStyle = params => ({ textAlign: colCopy.textAlign });
+              }
+              if (colCopy.cursor) {
+                const prevCellStyle = baseCellStyle;
+                baseCellStyle = params => ({
+                  ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
+                  cursor: colCopy.cursor
+                });
+              } else if (result.editable) {
+                const prevCellStyle = baseCellStyle;
+                baseCellStyle = params => ({
+                  ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
+                  cursor: 'pointer'
+                });
+              } else if (colCopy.FieldDB === 'TicketNumber') {
+                const prevCellStyle = baseCellStyle;
+                baseCellStyle = params => ({
+                  ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
+                  cursor: 'pointer'
+                });
+              }
+              if (baseCellStyle) {
+                result.cellStyle = baseCellStyle;
+              }
+              return result;
+            }
+          default: {
+            const result = {
+              ...commonProperties,
+              id: colId,
+              colId,
+              headerName: colCopy.headerName,
+              field: colCopy.field,
+              sortable: colCopy.sortable,
+              filter: colCopy.filter,
+            };
+            // Filtro de lista dinâmico
+            if (colCopy.filter === 'agListColumnFilter') {
+              result.filter = (tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID')
+                ? ResponsibleUserFilterRenderer
+                : ListFilterRenderer;
+            }
+            // Apply custom formatter if enabled
+            if (colCopy.useCustomFormatter) {
+              result.cellRenderer = 'FormatterCellRenderer';
+              result.cellRendererParams = {
+                useCustomFormatter: true,
+                formatter: colCopy.formatter
+              };
+            }
+            // Apply style array if provided
+            else if (colCopy.useStyleArray) {
+              result.cellRenderer = 'FormatterCellRenderer';
+              result.cellRendererParams = {
+                useCustomFormatter: false,
+                useStyleArray: true,
+                styleArray: this.content.cellStyleArray
+              };
+            }
+            
+            // Add text alignment style for cells
+            let baseCellStyle = undefined;
+            if (colCopy.textAlign) {
+              baseCellStyle = params => ({ textAlign: colCopy.textAlign });
+            }
+            // Cursor pointer para colunas editáveis
+            if (colCopy.cursor) {
+              const prevCellStyle = baseCellStyle;
+              baseCellStyle = params => ({
+                ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
+                cursor: colCopy.cursor
+              });
+            } else if (result.editable) {
+              const prevCellStyle = baseCellStyle;
+              baseCellStyle = params => ({
+                ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
+                cursor: 'pointer'
+              });
+            } else if (colCopy.FieldDB === 'TicketNumber') {
+              const prevCellStyle = baseCellStyle;
+              baseCellStyle = params => ({
+                ...(typeof prevCellStyle === 'function' ? prevCellStyle(params) : {}),
+                cursor: 'pointer'
+              });
+            }
+            if (baseCellStyle) {
+              result.cellStyle = baseCellStyle;
+            }
+            // Use editor numérico para impedir caracteres não numéricos durante a edição
+            if ((colCopy.cellDataType === 'number' || colCopy.cellDataType === 'integer') && colCopy.editable) {
+              if (colCopy.cellDataType === 'integer') {
+                result.cellEditor = 'agTextCellEditor';
+                result.cellEditorParams = {
+                  ...(result.cellEditorParams || {}),
+                  allowedCharPattern: '\\d'
+                };
+              } else {
+                result.cellEditor = 'agNumberCellEditor';
+              }
+              result.valueParser = params => {
+                const raw = params.newValue;
+                if (raw === null || raw === undefined || raw === '') return null;
+                const parsed = Number(raw);
+                if (!Number.isFinite(parsed)) return null;
+                if (colCopy.cellDataType === 'integer' && !Number.isInteger(parsed)) return null;
+                return parsed;
+              };
+            }
+            // Add header alignment style that affects all content in the header
+            if (colCopy.headerAlign) {
+              result.headerClass = `ag-header-align-${colCopy.headerAlign}`;
+            }
+            // Use DateTimeCellEditor for date fields and deadlines
+
+            if (colCopy.cellDataType === 'dateString' || colCopy.cellDataType === 'dateTime' || tagControl === 'DEADLINE') {
+              result.filter = DeadlineFilterRenderer;
+
+              if (tagControl !== 'DEADLINE' && colCopy.cellDataType !== 'dateTime') {
+                result.cellDataType = 'dateString';
+              } else {
+                if (colCopy.cellDataType === 'dateTime') {
+                  result.TagControl = 'DATETIME';
+                  result.cellRenderer = 'FormatterCellRenderer';
+                }
+                delete result.cellDataType;
+              }
+
+              if (colCopy.editable) {
+                // Register Vue component by name so AG Grid can resolve it
+                result.cellEditor = 'DateTimeCellEditor';
+                delete result.valueParser;
+              }
+            }
+            if (tagControl === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') {
+              result.cellRenderer = 'UserCellRenderer';
+              const opts = Array.isArray(colCopy.options)
+                ? colCopy.options
+                : Array.isArray(colCopy.listOptions)
+                ? colCopy.listOptions
+                : dsOptions;
+              if (opts.length) {
+                result.cellRendererParams = {
+                  ...(result.cellRendererParams || {}),
+                  options: opts
+                };
+              }
+            }
+            if (tagControl === 'DEADLINE') {
+              result.cellRenderer = params => {
+                // Função utilitária para calcular diff e cor (idêntica ao FieldComponent.vue)
+                function normalizeDeadline(val) {
+                  if (!val) return '';
+                  let dateStr = val;
+                  // ISO sem segundos
+                  if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(val)) {
+                    return val;
+                  }
+                  // ISO com espaço ao invés de T e sem timezone
+                  if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?/.test(val) && !/[\+\-]\d{2}$/.test(val)) {
+                    dateStr = val.replace(' ', 'T');
+                    return dateStr;
+                  }
+                  // ISO com timezone no formato +HH
+                  if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[\+\-]\d{2}$/.test(val)) {
+                    return val.replace(' ', 'T').replace(/([\+\-]\d{2})$/, '$1:00');
+                  }
+                  return dateStr;
+                }
+                function escapeHtml(str) {
+                  if (str == null) return '';
+                  return String(str)
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#39;');
+                }
+                function getDeadlineDiff(val) {
+                  if (!val) return '';
+                  const dateStr = normalizeDeadline(val);
+                  const deadline = new Date(dateStr);
+                  if (isNaN(deadline.getTime())) return '';
+                  const now = window.gridDeadlineNow instanceof Date ? window.gridDeadlineNow : new Date();
+                  let diffMs = deadline - now;
+                  if (isNaN(diffMs)) return '';
+                  const abs = Math.abs(diffMs);
+                  const isPast = diffMs < 0;
+                  let str = '';
+                  if (abs < 60 * 1000) {
+                    const s = Math.floor(abs / 1000);
+                    str = `${isPast ? '-' : ''}${s}s`;
+                  } else if (abs < 60 * 60 * 1000) {
+                    const m = Math.floor(abs / (60 * 1000));
+                    str = `${isPast ? '-' : ''}${m}m`;
+                  } else if (abs < 24 * 60 * 60 * 1000) {
+                    const h = Math.floor(abs / (60 * 60 * 1000));
+                    const m = Math.floor((abs % (60 * 60 * 1000)) / (60 * 1000));
+                    str = `${isPast ? '-' : ''}${h}h`;
+                    if (m > 0) str += ` ${m}m`;
+                  } else {
+                    const d = Math.floor(abs / (24 * 60 * 60 * 1000));
+                    const h = Math.floor((abs % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+                    const m = Math.floor((abs % (60 * 60 * 1000)) / (60 * 1000));
+                    str = `${isPast ? '-' : ''}${d}d`;
+                    if (h > 0) str += ` ${h}h`;
+                    if (m > 0) str += ` ${m}m`;
+                  }
+                  return str;
+                }
+                function getDeadlineColorClass(val) {
+                  if (!val) return '';
+                  const dateStr = normalizeDeadline(val);
+                  const deadline = new Date(dateStr);
+                  if (isNaN(deadline.getTime())) return '';
+                  const now = window.gridDeadlineNow instanceof Date ? window.gridDeadlineNow : new Date();
+                  let diffMs = deadline - now;
+                  if (isNaN(diffMs)) return '';
+                  const diffDays = diffMs / (24 * 60 * 60 * 1000);
+                  if (diffDays > 5) return 'deadline-green';
+                  if (diffDays > 0) return 'deadline-yellow';
+                  return 'deadline-red';
+                }
+                function getDeadlineOriginalFormatted(val) {
+                  if (!val) return '';
+                  const dateStr = normalizeDeadline(val);
+                  const deadline = new Date(dateStr);
+                  if (isNaN(deadline.getTime())) return val;
+                  // Pega o idioma da variável global
+                  let lang = 'en-US';
+                  try {
+                    if (window.wwLib && window.wwLib.wwVariable && typeof window.wwLib.wwVariable.getValue === 'function') {
+                      const v = window.wwLib.wwVariable.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+                      if (typeof v === 'string' && v.length > 0) lang = v;
+                    }
+                  } catch (e) {}
+                  const opts = { day: '2-digit', month: '2-digit', year: 'numeric' };
+                  try {
+                    return deadline.toLocaleDateString(lang, opts);
+                  } catch (err) {
+                    return deadline.toLocaleDateString(lang);
+                  }
+                }
+                function getDeadlineTooltipFormatted(val) {
+                  if (!val) return '';
+                  const dateStr = normalizeDeadline(val);
+                  const deadline = new Date(dateStr);
+                  if (isNaN(deadline.getTime())) return val;
+                  let lang = 'en-US';
+                  try {
+                    if (window.wwLib && window.wwLib.wwVariable && typeof window.wwLib.wwVariable.getValue === 'function') {
+                      const v = window.wwLib.wwVariable.getValue('aa44dc4c-476b-45e9-a094-16687e063342');
+                      if (typeof v === 'string' && v.length > 0) lang = v;
+                    }
+                  } catch (e) {}
+                  const opts = {
+                    day: '2-digit',
+                    month: '2-digit',
+                    year: 'numeric',
+                    hour: '2-digit',
+                    minute: '2-digit'
+                  };
+                  try {
+                    return deadline.toLocaleString(lang, opts);
+                  } catch (err) {
+                    return deadline.toLocaleString(lang);
+                  }
+                }
+                const val = params.value;
+                if (!val) {
+                  return `<span class="deadline-visual deadline-empty"><span class="material-symbols-outlined deadline-empty-icon">calendar_month</span><span class="deadline-empty-text">${translatePhrase("Select")}</span></span>`;
+                }
+                const formattedDate = getDeadlineOriginalFormatted(val);
+                const formattedTooltip = getDeadlineTooltipFormatted(val);
+                const tooltip = formattedTooltip || formattedDate || val || '';
+                const safeTooltip = escapeHtml(tooltip);
+                const tooltipAttr = safeTooltip ? ` title="${safeTooltip}"` : '';
+                const isClosedRaw = params.data?.IsClosed;
+                const isClosed =
+                  typeof isClosedRaw === 'string'
+                    ? isClosedRaw.toLowerCase() === 'true'
+                    : Boolean(isClosedRaw);
+                if (isClosed) {
+                  const label = formattedDate || val || '';
+                  const safeLabel = escapeHtml(label);
+                  return `<span class="deadline-visual deadline-closed"${tooltipAttr}>${safeLabel}</span>`;
+                }
+                const diff = getDeadlineDiff(val);
+                const colorClass = getDeadlineColorClass(val);
+                if (!diff) {
+                  return `<span class="deadline-visual deadline-empty"${tooltipAttr}><span class="material-symbols-outlined deadline-empty-icon">calendar_month</span><span class="deadline-empty-text">${translatePhrase("Select")}</span></span>`;
+                }
+                return `<span class="deadline-visual ${colorClass}"${tooltipAttr}>${diff}</span>`;
+              };
+            }
+            const fieldKey = colCopy.id || colCopy.field;
+            const useTicket = this.usesTicketId(colCopy);
+            const lazyStatus = this.shouldLazyLoadStatus(colCopy);
+            const getDsOptionsSync = params => {
+              const ticketId = params.data?.TicketID;
+              const key = this.getOptionsCacheKey(colCopy, ticketId);
+              if (lazyStatus) {
+                return this.buildLazyStatusFallbackOptions(colCopy);
+              }
+              const colOpts = this.columnOptions[fieldKey] || {};
+              const cached = colOpts[key];
+              if (cached) return cached;
+              if (lazyStatus) {
+                return this.buildLazyStatusFallbackOptions(colCopy);
+              }
+              this.getColumnOptions(colCopy, useTicket ? ticketId : undefined).then(opts => {
+                if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
+                this.columnOptions[fieldKey][key] = opts;
+                params.api?.refreshCells?.({ force: true });
+              });
+              return [];
+            };
+            const getDsOptionsAsync = params => {
+              const ticketId = params.data?.TicketID;
+              if (lazyStatus) {
+                return this.getColumnOptions(
+                  colCopy,
+                  useTicket ? ticketId : undefined,
+                  { force: true }
+                ).catch(error => {
+                  noopConsole('[GridViewDinamica] Failed to lazy load StatusID options', error);
+                  return this.buildLazyStatusFallbackOptions(colCopy);
+                });
+              }
+              const key = this.getOptionsCacheKey(colCopy, ticketId);
+              const colOpts = this.columnOptions[fieldKey] || {};
+              const cached = colOpts[key];
+              if (cached) return Promise.resolve(cached);
+              return this.getColumnOptions(
+                colCopy,
+                useTicket ? ticketId : undefined
+              ).then(opts => {
+
+                if (!this.columnOptions[fieldKey]) this.columnOptions[fieldKey] = {};
+                this.columnOptions[fieldKey][key] = opts;
+                return opts;
+              });
+            };
+            if (
+              colCopy.cellDataType === 'list' ||
+              (tagControl && tagControl.toUpperCase() === 'LIST')
+            ) {
+              const optionsArr = Array.isArray(colCopy.options)
+                ? colCopy.options
+                : Array.isArray(colCopy.listOptions)
+                ? colCopy.listOptions
+                : null;
+              if (colCopy.editable) {
+                result.editable = true;
+                if (optionsArr && optionsArr.length) {
+                  result.cellEditor = ListCellEditor;
+                  result.cellEditorParams = { options: optionsArr };
+                  result.cellRendererParams = {
+                    ...result.cellRendererParams,
+                    options: optionsArr,
+                  };
+                } else {
+                  result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor :  FixedListCellEditor;
+                  result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+                  const baseRendererParams = result.cellRendererParams;
+                  result.cellRendererParams = params => ({
+                    ...(typeof baseRendererParams === 'function'
+                      ? baseRendererParams(params)
+                      : baseRendererParams),
+                    options: getDsOptionsSync(params),
+                  });
+                }
+              } else {
+                const baseRendererParams = result.cellRendererParams;
+                result.cellRendererParams = params => ({
+                  ...(typeof baseRendererParams === 'function'
+                    ? baseRendererParams(params)
+                    : baseRendererParams),
+                  options: optionsArr || getDsOptionsSync(params),
+                });
+              }
+              // O cellRenderer já aplica a formatação visual
+            }
+            if (colCopy.dataSource && colCopy.editable) {
+              result.editable = true;
+              result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor;
+              result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+              const baseRendererParams = result.cellRendererParams;
+              result.cellRendererParams = params => ({
+                ...(typeof baseRendererParams === 'function'
+                  ? baseRendererParams(params)
+                  : baseRendererParams),
+                options: getDsOptionsSync(params),
+              });
+            }
+            return result;
+          }
+        }
+      });
+    },
+      rowSelection() {
+      if (this.content.rowSelection === "multiple") {
+        return {
+          mode: "multiRow",
+          checkboxes: !this.content.disableCheckboxes,
+          headerCheckbox: !this.content.disableCheckboxes,
+          selectAll: this.content.selectAll || "all",
+          enableClickSelection: this.content.enableClickSelection,
+        };
+      } else if (this.content.rowSelection === "single") {
+        return {
+          mode: "singleRow",
+          checkboxes: !this.content.disableCheckboxes,
+          enableClickSelection: this.content.enableClickSelection,
+        };
+      } else {
+        return {
+          mode: "singleRow",
+          checkboxes: false,
+          isRowSelectable: () => false,
+          enableClickSelection: this.content.enableClickSelection,
+        };
+      }
+    },
+  style() {
+  if (this.content.layout === "auto") return {};
+  return {
+  height: this.content.height || "400px",
+  };
+  },
+  cssVars() {
+  const baseFontSize = this.resolvedFontSize;
+  return {
+  "--ww-data-grid_action-backgroundColor":
+  this.content.actionBackgroundColor,
+  "--ww-data-grid_action-color": this.content.actionColor,
+  "--ww-data-grid_action-padding": this.content.actionPadding,
+  "--ww-data-grid_action-border": this.content.actionBorder,
+  "--ww-data-grid_action-borderRadius": this.content.actionBorderRadius,
+  ...(this.content.borderColor
+  ? { "--ww-data-grid_row-border-color": this.content.borderColor }
+  : {}),
+  ...(this.content.actionFont
+  ? { "--ww-data-grid_action-font": this.content.actionFont }
+  : {}),
+  "--ww-data-grid_action-fontSize": baseFontSize,
+  "--ww-data-grid_action-fontFamily": this.resolvedFontFamily,
+  "--ww-data-grid_action-fontWeight": this.content.actionFontWeight,
+  "--ww-data-grid_action-fontStyle": this.content.actionFontStyle,
+  "--ww-data-grid_action-lineHeight": this.content.actionLineHeight,
+  "--grid-view-dinamica-font-family": this.resolvedFontFamily,
+  "--grid-view-dinamica-font-size": baseFontSize,
+  "--ag-font-family": this.resolvedFontFamily,
+  "--ag-font-size": baseFontSize,
+  "--ag-header-font-family": this.resolvedFontFamily,
+  "--ag-header-font-size": baseFontSize,
+  fontFamily: this.resolvedFontFamily,
+  fontSize: baseFontSize,
+  ...(this.content.paginationBackgroundColor
+    ? {
+      "--grid-view-dinamica-pagination-background-color":
+        this.content.paginationBackgroundColor,
+    }
+    : {}),
+  ...(this.content.paginationPadding
+    ? { "--grid-view-dinamica-pagination-padding": this.content.paginationPadding }
+    : {}),
+  ...(this.content.selectionCheckboxColor
+    ? {
+      '--grid-view-dinamica-selection-checkbox-color':
+        this.content.selectionCheckboxColor,
+      '--ag-checkbox-checked-color': this.content.selectionCheckboxColor,
+      '--ag-checkbox-checked-background-color':
+        this.content.selectionCheckboxColor,
+    }
+    : {}),
+  ...(this.content.checkboxUncheckedBorderColor
+    ? {
+      '--grid-view-dinamica-checkbox-unchecked-border-color':
+        this.content.checkboxUncheckedBorderColor,
+      '--ag-checkbox-unchecked-color':
+        this.content.checkboxUncheckedBorderColor,
+    }
+    : {}),
+  };
+  },
+  theme() {
+  return themeQuartz.withParams({
+  headerBackgroundColor: "#F5F6FA",
+  headerTextColor: this.content.headerTextColor,
+  headerFontSize: this.resolvedFontSizeNumber,
+  headerFontWeight: this.content.headerFontWeight,
+  fontFamily: this.resolvedFontFamily,
+  fontSize: this.resolvedFontSizeNumber,
+  borderColor: this.content.borderColor,
+  cellTextColor: this.content.cellColor,
+  cellFontFamily: this.resolvedFontFamily,
+  headerFontFamily: this.resolvedFontFamily,
+  dataFontSize: this.resolvedFontSizeNumber,
+  oddRowBackgroundColor: this.content.rowAlternateColor,
+  backgroundColor: this.content.rowBackgroundColor,
+  rowHoverColor: this.content.rowHoverColor,
+  selectedRowBackgroundColor: this.content.selectedRowBackgroundColor,
+  rowVerticalPaddingScale: this.content.rowVerticalPaddingScale || 1,
+  menuBackgroundColor: this.content.menuBackgroundColor,
+  menuTextColor: this.content.menuTextColor,
+  columnHoverColor: this.content.columnHoverColor,
+  foregroundColor: this.content.textColor,
+  checkboxCheckedBackgroundColor: this.content.selectionCheckboxColor,
+  rangeSelectionBorderColor: this.content.cellSelectionBorderColor,
+  checkboxUncheckedBorderColor: this.content.checkboxUncheckedBorderColor,
+  focusShadow: this.content.focusShadow?.length
+  ? this.content.focusShadow
+  : undefined,
+  });
+  },
+  isEditing() {
+  /* wwEditor:start */
+  return (
+  this.wwEditorState.editMode === wwLib.wwEditorHelper.EDIT_MODES.EDITION
+  );
+  /* wwEditor:end */
+  // eslint-disable-next-line no-unreachable
+  return false;
+  },
+  },
+  methods: {
+  deselectAllRows() {
+    if (this.gridApi) {
+      this.gridApi.deselectAll();
+    }
+  },
+  resetFilters() {
+    if (this.gridApi) {
+      this.gridApi.setFilterModel(null);
+    }
+  },
+  async refreshDropdownOptions() {
+    if (typeof this.refreshAllDropdownOptions === "function") {
+      await this.refreshAllDropdownOptions();
+    }
+  },
+  setSort(sortInput) {
+    if (!this.gridApi) return;
+
+    let payload = sortInput;
+
+    if (typeof payload === "string") {
+      try {
+        payload = JSON.parse(payload);
+      } catch (error) {
+        noopConsole("[GridViewDinamica] Failed to parse sort payload", error);
+        return;
+      }
+    }
+
+    if (payload && typeof payload === "object" && !Array.isArray(payload)) {
+      if (Array.isArray(payload.Sort)) {
+        payload = payload.Sort;
+      } else if (Array.isArray(payload.sort)) {
+        payload = payload.sort;
+      } else {
+        const hasSingleSortEntryFields =
+          payload?.id != null ||
+          payload?.colId != null ||
+          payload?.field != null ||
+          payload?.fieldId != null;
+
+        if (hasSingleSortEntryFields) {
+          payload = [payload];
+        }
+      }
+    }
+
+    if (!Array.isArray(payload)) {
+      noopConsole("[GridViewDinamica] Invalid sort payload", payload);
+      return;
+    }
+
+    const normalized = payload
+      .map((entry, idx) => {
+        const colId = entry?.colId ?? entry?.id ?? entry?.field ?? entry?.fieldId;
+        if (!colId) return null;
+
+        let direction = entry?.sort;
+        if (!direction) {
+          if (entry?.isASC === true) direction = "asc";
+          else if (entry?.isASC === false) direction = "desc";
+        }
+
+        if (!direction) return null;
+
+        const normalizedEntry = {
+          colId: String(colId),
+          sort: String(direction).toLowerCase() === "desc" ? "desc" : "asc",
+          sortIndex: Number.isFinite(entry?.sortIndex) ? Number(entry.sortIndex) : idx,
+        };
+
+        return normalizedEntry;
+      })
+      .filter(Boolean);
+
+    if (!normalized.length) return;
+
+    const sortModel = normalized.map(({ colId, sort }) => ({ colId, sort }));
+
+    const colApi = this.gridApi?.getColumnApi ? this.gridApi.getColumnApi() : null;
+
+    if (colApi?.applyColumnState) {
+      colApi.applyColumnState({
+        state: normalized,
+        defaultState: { sort: null },
+        applyOrder: false,
+      });
+    }
+
+    if (typeof this.gridApi?.setSortModel === "function") {
+      this.gridApi.setSortModel(sortModel);
+    } else {
+      // Fallback para ambientes sem setSortModel na API
+      colApi?.applyColumnState?.({
+        state: normalized,
+        defaultState: { sort: null },
+        applyOrder: false,
+      });
+      this.gridApi?.refreshClientSideRowModel?.("sort");
+    }
+
+    if (typeof this.saveGridState === "function") {
+      this.saveGridState();
+    }
+
+    // Atualiza variáveis WW para refletir a ordenação aplicada
+    if (typeof this.setSortVariable === "function") {
+      this.setSortVariable(sortModel);
+    }
+    if (typeof this.setColumnsSortVariable === "function") {
+      this.setColumnsSortVariable(
+        normalized.map(entry => ({ id: entry.colId, isASC: entry.sort === "asc" }))
+      );
+    }
+
+    // Sincroniza estado interno das colunas
+    if (typeof this.updateColumnsSortFromApi === "function") {
+      this.updateColumnsSortFromApi();
+    }
+  },
+  setFilters(filters) {
+    if (this.gridApi) {
+      this.gridApi.setFilterModel(filters || null);
+    }
+  },
+  exportGridToExcel(fileNameInput) {
+    if (!this.gridApi) return;
+
+    const sanitizeFileName = (name) => {
+      const normalized = typeof name === "string" ? name.trim() : "";
+      const safeName = normalized.replace(/[\\/:*?"<>|]+/g, "_");
+      if (!safeName) return "grid-export.xls";
+      return safeName.toLowerCase().endsWith(".xls") ? safeName : `${safeName}.xls`;
+    };
+
+    const escapeXml = (value) => String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&apos;");
+
+    const getDisplayedColumns = () => {
+      if (typeof this.gridApi?.getAllDisplayedColumns === "function") {
+        return this.gridApi.getAllDisplayedColumns();
+      }
+      const colApi = typeof this.gridApi?.getColumnApi === "function"
+        ? this.gridApi.getColumnApi()
+        : null;
+      if (typeof colApi?.getAllDisplayedColumns === "function") {
+        return colApi.getAllDisplayedColumns();
+      }
+      return [];
+    };
+
+    const formatCellValue = (rawValue, node, column) => {
+      const colDef = column?.getColDef ? column.getColDef() : {};
+      if (typeof colDef?.valueFormatter === "function") {
+        try {
+          const formatted = colDef.valueFormatter({
+            value: rawValue,
+            data: node?.data,
+            node,
+            colDef,
+            column,
+            api: this.gridApi,
+            context: this.gridApi?.context,
+          });
+          if (formatted != null) return formatted;
+        } catch (error) {
+          noopConsole("[GridViewDinamica] Failed to format cell for Excel export", error);
+        }
+      }
+
+      if (rawValue == null) return "";
+      if (typeof rawValue === "object") {
+        try {
+          return JSON.stringify(rawValue);
+        } catch (error) {
+          return String(rawValue);
+        }
+      }
+      return String(rawValue);
+    };
+
+    const isExportableColumn = (column) => {
+      const colId = column?.getColId ? column.getColId() : column?.colId;
+      const colDef = column?.getColDef ? column.getColDef() : {};
+      if (!colId) return false;
+      if (String(colId).startsWith("ag-Grid-")) return false;
+      if (colDef?.checkboxSelection || colDef?.headerCheckboxSelection) return false;
+      return true;
+    };
+
+    const columns = getDisplayedColumns().filter(isExportableColumn);
+    if (!columns.length) return;
+
+    const rows = [];
+    if (
+      typeof this.gridApi?.getDisplayedRowCount === "function" &&
+      typeof this.gridApi?.getDisplayedRowAtIndex === "function"
+    ) {
+      const displayedCount = this.gridApi.getDisplayedRowCount();
+      for (let rowIndex = 0; rowIndex < displayedCount; rowIndex += 1) {
+        const node = this.gridApi.getDisplayedRowAtIndex(rowIndex);
+        if (node) rows.push(node);
+      }
+    } else if (typeof this.gridApi?.forEachNodeAfterFilterAndSort === "function") {
+      this.gridApi.forEachNodeAfterFilterAndSort((node) => {
+        rows.push(node);
+      });
+    } else if (typeof this.gridApi?.forEachNode === "function") {
+      this.gridApi.forEachNode((node) => {
+        rows.push(node);
+      });
+    }
+
+    const headerXml = columns
+      .map((column) => {
+        const colDef = column?.getColDef ? column.getColDef() : {};
+        const headerLabel = colDef?.headerName || colDef?.field || column?.getColId?.() || "";
+        return `<Cell><Data ss:Type="String">${escapeXml(headerLabel)}</Data></Cell>`;
+      })
+      .join("");
+
+    let bodyXml = rows
+      .map((node) => {
+        const cellsXml = columns
+          .map((column) => {
+            const colId = column?.getColId ? column.getColId() : column?.colId;
+            const rawValue = typeof this.gridApi?.getValue === "function"
+              ? this.gridApi.getValue(colId, node)
+              : node?.data?.[colId];
+            const formattedValue = formatCellValue(rawValue, node, column);
+            return `<Cell><Data ss:Type="String">${escapeXml(formattedValue)}</Data></Cell>`;
+          })
+          .join("");
+        return `<Row>${cellsXml}</Row>`;
+      })
+      .join("");
+
+    if (!bodyXml) {
+      const sourceRowsRaw = wwLib.wwUtils.getDataFromCollection(this.content?.rowData);
+      const sourceRows = Array.isArray(sourceRowsRaw) ? sourceRowsRaw : [];
+
+      bodyXml = sourceRows
+        .map((rowData, rowIndex) => {
+          const pseudoNode = {
+            data: rowData,
+            rowIndex,
+            id: rowData?.Id ?? rowData?.ID ?? rowData?.id ?? rowIndex,
+          };
+          const cellsXml = columns
+            .map((column) => {
+              const colId = column?.getColId ? column.getColId() : column?.colId;
+              const colDef = column?.getColDef ? column.getColDef() : {};
+              const field = colDef?.field || colId;
+              const rawValue = rowData?.[field];
+              const formattedValue = formatCellValue(rawValue, pseudoNode, column);
+              return `<Cell><Data ss:Type="String">${escapeXml(formattedValue)}</Data></Cell>`;
+            })
+            .join("");
+          return cellsXml ? `<Row>${cellsXml}</Row>` : "";
+        })
+        .join("");
+    }
+
+    if (!bodyXml && typeof this.gridApi?.getDataAsCsv === "function") {
+      const csvValue = this.gridApi.getDataAsCsv({
+        columnKeys: columns.map((column) => (
+          column?.getColId ? column.getColId() : column?.colId
+        )),
+        skipColumnHeaders: true,
+        skipColumnGroupHeaders: true,
+        processCellCallback: (params) => {
+          if (params?.valueFormatted != null) return params.valueFormatted;
+          if (params?.value == null) return "";
+          return typeof params.value === "object"
+            ? JSON.stringify(params.value)
+            : String(params.value);
+        },
+      });
+
+      const parseCsvLine = (line) => {
+        const values = [];
+        let current = "";
+        let inQuotes = false;
+
+        for (let i = 0; i < line.length; i += 1) {
+          const char = line[i];
+          const next = line[i + 1];
+
+          if (char === '"' && inQuotes && next === '"') {
+            current += '"';
+            i += 1;
+            continue;
+          }
+
+          if (char === '"') {
+            inQuotes = !inQuotes;
+            continue;
+          }
+
+          if (char === "," && !inQuotes) {
+            values.push(current);
+            current = "";
+            continue;
+          }
+
+          current += char;
+        }
+
+        values.push(current);
+        return values;
+      };
+
+      bodyXml = String(csvValue || "")
+        .split(/\r?\n/)
+        .filter((line) => line.trim().length > 0)
+        .map((line) => {
+          const cellsXml = parseCsvLine(line)
+            .map((value) => `<Cell><Data ss:Type="String">${escapeXml(value)}</Data></Cell>`)
+            .join("");
+          return cellsXml ? `<Row>${cellsXml}</Row>` : "";
+        })
+        .join("");
+    }
+
+    if (!bodyXml) {
+      const gridRoot = this.$el?.querySelector?.(".ag-root");
+      const domRows = gridRoot
+        ? Array.from(gridRoot.querySelectorAll(".ag-center-cols-container .ag-row"))
+        : [];
+
+      bodyXml = domRows
+        .map((rowEl) => {
+          const cells = Array.from(rowEl.querySelectorAll(".ag-cell"));
+          const cellsXml = cells
+            .map((cellEl) => {
+              const value = (cellEl?.innerText || cellEl?.textContent || "").trim();
+              return `<Cell><Data ss:Type="String">${escapeXml(value)}</Data></Cell>`;
+            })
+            .join("");
+          return cellsXml ? `<Row>${cellsXml}</Row>` : "";
+        })
+        .join("");
+    }
+
+    const xmlWorkbook = `<?xml version="1.0"?>
+<Workbook xmlns="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:o="urn:schemas-microsoft-com:office:office"
+ xmlns:x="urn:schemas-microsoft-com:office:excel"
+ xmlns:ss="urn:schemas-microsoft-com:office:spreadsheet"
+ xmlns:html="http://www.w3.org/TR/REC-html40">
+ <Worksheet ss:Name="Grid">
+  <Table>
+   <Row>${headerXml}</Row>
+   ${bodyXml}
+  </Table>
+ </Worksheet>
+</Workbook>`;
+
+    const blob = new Blob([xmlWorkbook], {
+      type: "application/vnd.ms-excel;charset=utf-8;",
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = sanitizeFileName(fileNameInput);
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  },
+  getRowId(params) {
+  return this.resolveMappingFormula(this.content.idFormula, params.data);
+  },
+  updateRow(rowInput) {
+  if (rowInput == null) return;
+
+  let payload = rowInput;
+  if (typeof payload === "string") {
+    try {
+      payload = JSON.parse(payload);
+    } catch (error) {
+      noopConsole("[GridViewDinamica] Failed to parse row JSON payload", error);
+      return;
+    }
+  }
+
+  if (Array.isArray(payload)) {
+    if (!payload.length) {
+      noopConsole("[GridViewDinamica] Received empty array payload for updateRow action");
+      return;
+    }
+    payload = payload[0];
+  }
+
+  if (!payload || typeof payload !== "object") {
+    noopConsole("[GridViewDinamica] Invalid payload for updateRow action", payload);
+    return;
+  }
+
+  const normalizeId = (row, index = null) => {
+    if (!row || typeof row !== "object") return null;
+    if (typeof this.resolveRowId === "function") {
+      const resolved = this.resolveRowId(row, index);
+      if (resolved != null && resolved !== "") return String(resolved);
+    }
+    const fallbackKeys = ["Id", "ID", "id"];
+    for (const key of fallbackKeys) {
+      if (row[key] != null && row[key] !== "") {
+        return String(row[key]);
+      }
+    }
+    return null;
+  };
+
+  const sourceRowsRaw = wwLib.wwUtils.getDataFromCollection(this.content.rowData);
+  const sourceRows = Array.isArray(sourceRowsRaw) ? sourceRowsRaw : [];
+
+  if (!sourceRows.length) {
+    noopConsole("[GridViewDinamica] Cannot update row: grid has no data available");
+    return;
+  }
+
+  const payloadId = normalizeId(payload);
+  let matchedIndex = -1;
+
+  if (payloadId != null) {
+    matchedIndex = sourceRows.findIndex((row, idx) => normalizeId(row, idx) === payloadId);
+  }
+
+  if (matchedIndex === -1) {
+    matchedIndex = sourceRows.findIndex(row => {
+      if (!row || typeof row !== "object") return false;
+      const fallbackKeys = ["Id", "ID", "id"];
+      return fallbackKeys.some(key => (
+        row[key] != null && payload[key] != null && String(row[key]) === String(payload[key])
+      ));
+    });
+  }
+
+  if (matchedIndex === -1) {
+    noopConsole("[GridViewDinamica] Failed to locate row to update", payload);
+    return;
+  }
+
+  const matchedRow = sourceRows[matchedIndex];
+  if (!matchedRow || typeof matchedRow !== "object") {
+    noopConsole("[GridViewDinamica] Matched row is not an object", matchedRow);
+    return;
+  }
+
+  Object.keys(payload).forEach(key => {
+    matchedRow[key] = payload[key];
+  });
+
+  let rowNode = null;
+  const resolvedId = normalizeId(matchedRow, matchedIndex);
+  if (resolvedId != null && this.gridApi && typeof this.gridApi.getRowNode === "function") {
+    rowNode = this.gridApi.getRowNode(resolvedId);
+  }
+
+  if (!rowNode && this.gridApi && typeof this.gridApi.forEachNode === "function") {
+    const fallbackKeys = ["Id", "ID", "id"];
+    this.gridApi.forEachNode(node => {
+      if (rowNode) return;
+      if (resolvedId != null && String(node.id) === String(resolvedId)) {
+        rowNode = node;
+        return;
+      }
+      const nodeData = node.data || {};
+      if (resolvedId != null && normalizeId(nodeData, node.rowIndex) === resolvedId) {
+        rowNode = node;
+        return;
+      }
+      if (resolvedId == null) {
+        const found = fallbackKeys.some(key => (
+          nodeData[key] != null && payload[key] != null && String(nodeData[key]) === String(payload[key])
+        ));
+        if (found) {
+          rowNode = node;
+        }
+      }
+    });
+  }
+
+  if (rowNode) {
+    Object.keys(payload).forEach(key => {
+      const value = payload[key];
+      if (typeof rowNode.setDataValue === "function") {
+        rowNode.setDataValue(key, value);
+      } else if (rowNode.data) {
+        rowNode.data[key] = value;
+      }
+    });
+  }
+
+  if (typeof this.refreshRowFromSource === "function") {
+    try {
+      this.refreshRowFromSource(matchedRow, rowNode || null);
+    } catch (error) {
+      noopConsole("[GridViewDinamica] Failed to refresh row metadata after update", error);
+    }
+  }
+
+  if (typeof this.refreshRowListOptions === "function") {
+    try {
+      this.refreshRowListOptions(matchedRow, rowNode || null, null);
+    } catch (error) {
+      noopConsole("[GridViewDinamica] Failed to refresh list options after row update", error);
+    }
+  }
+
+  if (this.gridApi && typeof this.gridApi.refreshCells === "function") {
+    const refreshConfig = { force: true };
+    if (rowNode) {
+      refreshConfig.rowNodes = [rowNode];
+    }
+    this.gridApi.refreshCells(refreshConfig);
+  }
+  },
+  onActionTrigger(event) {
+  if (!event) return;
+  
+  this.$emit("trigger-event", {
+  name: "action",
+  event: {
+  actionName: event.actionName || '',
+  row: event.row || null,
+  id: event.id != null ? event.id : null,
+  index: event.index != null ? event.index : null,
+  displayIndex: event.displayIndex != null ? event.displayIndex : null,
+  },
+  });
+  },
+  onCellValueChanged(event) {
+  const colDef = event.column.getColDef ? event.column.getColDef() : {};
+  const tag = (colDef.TagControl || colDef.tagControl || colDef.tagcontrol || '').toUpperCase();
+  const identifier = (colDef.FieldDB || '').toUpperCase();
+  if (tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID') {
+    const fieldKey = colDef.colId || colDef.field;
+    const colOpts = this.columnOptions[fieldKey] || {};
+    const ticketId = event.data?.TicketID;
+    const opts = colOpts[this.getOptionsCacheKey(colDef, ticketId)] || [];
+    const match = opts.find(o => String(o.value) === String(event.newValue));
+    if (match) {
+      if (event.data) {
+        event.data.ResponsibleUser = match.label || event.data.ResponsibleUser;
+        if (match.photo || match.image || match.img) {
+          event.data.PhotoUrl = match.photo || match.image || match.img;
+        } else {
+          // When the selected user has no photo, clear any existing one so the
+          // avatar with the initial is displayed
+          event.data.PhotoUrl = '';
+        }
+      }
+      if (this.gridApi && event.node) {
+        this.gridApi.refreshCells({
+          rowNodes: [event.node],
+          columns: [fieldKey],
+          force: true
+        });
+      }
+    }
+  }
+  if (tag === 'DEADLINE') {
+    const fieldKey = colDef.colId || colDef.field;
+    if (event.node && fieldKey) {
+      // Accept the value returned by the editor without conversion
+      const v = event.newValue;
+      event.node.setDataValue(fieldKey, v);
+
+      if (this.gridApi) {
+        this.gridApi.refreshCells({
+          rowNodes: [event.node],
+          columns: [fieldKey],
+          force: true
+        });
+      }
+    }
+  }
+  this.$emit("trigger-event", {
+    name: "cellValueChanged",
+    event: {
+      oldValue: event.oldValue,
+      newValue: event.newValue,
+      columnId: event.column.getColId(),
+      row: event.data,
+    },
+  });
+  },
+  onRowClicked(event) {
+  // Add null checks to prevent accessing properties of undefined objects
+  if (!event || !event.data) return;
+
+  // Identifica a coluna clicada
+  const colId = event.column?.getColId?.();
+  let fieldDB = null;
+  if (colId) {
+    const colConfig = this.content.columns.find(col => col.id === colId || col.field === colId);
+    if (colConfig) {
+      fieldDB = colConfig.FieldDB;
+    }
+  }
+
+  this.$emit("trigger-event", {
+    name: "rowClicked",
+    event: {
+      row: event.data,
+      id: event.node?.id || null,
+      index: event.node?.sourceRowIndex || null,
+      displayIndex: event.rowIndex != null ? event.rowIndex : null,
+      fieldDB // <-- novo campo
+    },
+  });
+},
+  onCellMouseOver(event) {
+  if (!event) return;
+
+  const colId = event.column?.getColId?.();
+  let fieldDB = null;
+  let fieldID = null;
+
+  if (colId) {
+    const colConfig = this.content.columns.find(col =>
+      col.id == colId || col.field == colId || col.colId == colId
+    );
+    if (colConfig) {
+      fieldDB = colConfig.FieldDB;
+      fieldID = colConfig.id;
+    }
+  }
+
+  let rowKey = null;
+  if (typeof this.resolveRowId === "function" && event.data) {
+    rowKey = this.resolveRowId(event.data, event.rowIndex ?? event.node?.rowIndex ?? null);
+  }
+  if (!rowKey && event.node?.id != null) {
+    rowKey = event.node.id;
+  }
+
+  this.$emit("trigger-event", {
+    name: "cellHovered",
+    event: {
+      row: event.data,
+      id: event.node?.id || null,
+      index: event.node?.sourceRowIndex || null,
+      displayIndex: event.rowIndex != null ? event.rowIndex : null,
+      fieldDB,
+      fieldID,
+      colId,
+      rowKey
+    },
+  });
+},
+  onCellClicked(event) {
+  const colId = event.column?.getColId?.();
+
+  let fieldDB = null;
+  let fieldID = null;
+  if (colId) {
+    const colConfig = this.content.columns.find(col =>
+      col.id == colId || col.field == colId || col.colId == colId
+    );
+    if (colConfig) {
+      fieldDB = colConfig.FieldDB;
+      fieldID = colConfig.id;
+    }
+  }
+
+  // Always ensure editable cells enter edit mode when clicked
+  const editable =
+    typeof event.colDef?.editable === "function"
+      ? event.colDef.editable(event)
+      : !!event.colDef?.editable;
+  if (editable) {
+    event.api?.startEditingCell({
+      rowIndex: event.rowIndex,
+      colKey: colId,
+    });
+  }
+
+  this.$emit("trigger-event", {
+    name: "cellClicked",
+    event: {
+      row: event.data,
+      id: event.node?.id || null,
+      index: event.node?.sourceRowIndex || null,
+      displayIndex: event.rowIndex != null ? event.rowIndex : null,
+      fieldDB,
+      fieldID,
+      colId
+    },
+  });
+},
+  /* wwEditor:start */
+  generateColumns() {
+  this.$emit("update:content", {
+  columns: this.rowData?.[0]
+  ? Object.keys(this.rowData[0]).map((key) => ({
+  field: key,
+  sortable: true,
+  filter: true,
+  }))
+  : [],
+  });
+  },
+  getOnActionTestEvent() {
+  const data = this.rowData;
+  if (!data || !data[0]) throw new Error("No data found");
+  return {
+  actionName: "actionName",
+  row: data[0],
+  id: 0,
+  index: 0,
+  displayIndex: 0,
+  };
+  },
+  getOnCellValueChangedTestEvent() {
+  const data = this.rowData;
+  if (!data || !data[0]) throw new Error("No data found");
+  return {
+  oldValue: "oldValue",
+  newValue: "newValue",
+  columnId: "columnId",
+  row: data[0],
+  };
+  },
+  getSelectionTestEvent() {
+  const data = this.rowData;
+  if (!data || !data[0]) throw new Error("No data found");
+  return {
+  row: data[0],
+  };
+  },
+  getRowClickedTestEvent() {
+  const data = this.rowData;
+  if (!data || !data[0]) throw new Error("No data found");
+  return {
+  row: data[0],
+  id: 0,
+  index: 0,
+  displayIndex: 0,
+  
+  };
+  },
+  getCellClickedTestEvent() {
+  const data = this.rowData;
+  const col = this.content?.columns?.[0];
+  return {
+    row: data?.[0] || null,
+    id: 0,
+    index: 0,
+    displayIndex: 0,
+    fieldDB: col?.FieldDB || null,
+    fieldID: col?.id || null,
+    colId: col?.colId || col?.id || col?.field || null
+  };
+},
+  getCellHoveredTestEvent() {
+  const data = this.rowData;
+  const col = this.content?.columns?.[0];
+  const row = data?.[0] || null;
+
+  let rowKey = null;
+  if (row && typeof this.resolveRowId === "function") {
+    rowKey = this.resolveRowId(row, 0);
+  }
+
+  return {
+    row,
+    id: 0,
+    index: 0,
+    displayIndex: 0,
+    fieldDB: col?.FieldDB || null,
+    fieldID: col?.id || null,
+    colId: col?.colId || col?.id || col?.field || null,
+    rowKey
+  };
+},
+clearSelection() {
+  // Limpar seleção usando a API do AG-Grid
+  if (this.gridApi) {
+    this.gridApi.deselectAll();
+  }
+  // Limpar a variável selectedRows
+  this.setSelectedRows([]);
+  // Forçar atualização visual
+  this.$nextTick(() => {
+    if (this.gridApi) {
+      this.gridApi.deselectAll();
+    }
+  });
+},
+forceClearSelection() {
+  // Força limpeza visual dos checkboxes via DOM
+  const gridElement = this.$refs.agGridRef?.$el;
+  if (gridElement) {
+    // Desmarcar todos os checkboxes de seleção
+    const checkboxes = gridElement.querySelectorAll('input[type="checkbox"]');
+    checkboxes.forEach(checkbox => {
+      checkbox.checked = false;
+      checkbox.indeterminate = false;
+    });
+    
+    // Limpar variável
+    this.setSelectedRows([]);
+    
+    // Forçar AG-Grid a desmarcar
+    if (this.gridApi) {
+      this.gridApi.deselectAll();
+    }
+  }
+},
+  /* wwEditor:end */
+      isColumnMovable(params) {
+      // Sempre impedir o movimento da coluna de seleção
+      if (params.column.getColId() === 'ag-Grid-SelectionColumn') {
+        return false;
+      }
+      // Impedir mover colunas pinned
+      if (params.column.getPinned() === 'left' || params.column.getPinned() === 'right') {
+        return false;
+      }
+      // Impedir mover qualquer coluna para a área pinned
+      const colDef = params.column.getColDef();
+      if (colDef && (colDef.pinned === 'left' || colDef.pinned === 'right')) {
+        return false;
+      }
+      // Checar configuração de draggable
+      const field = colDef.field;
+      const columns = Array.isArray(this.content?.columns) ? this.content.columns : [];
+      const columnConfig = columns.find(col => col.field === field);
+      if (columnConfig && columnConfig.draggable === false) {
+        return false;
+      }
+      // Caso contrário, segue a configuração global
+      return this.content.movableColumns;
+    }
+  },
+    /* wwEditor:start */
+  watch: {
+    columnDefs: {
+      async handler() {
+        if (this.wwEditorState?.boundProps?.columns) return;
+        this.gridApi?.resetColumnState?.();
+
+        if (this.wwEditorState.isACopy) return;
+
+        const columns = Array.isArray(this.content?.columns) ? this.content.columns : [];
+        if (!columns.length) return;
+
+        // We assume there will only be one custom column each time
+        const columnIndex = columns.findIndex(
+          (col) => col.cellDataType === "custom" && !col.containerId
+        );
+        if (columnIndex === -1) return;
+        const newColumns = [...columns];
+        let column = { ...newColumns[columnIndex] };
+        column.containerId = await this.createElement("ww-flexbox", {
+          _state: { name: `Cell ${column.headerName || column.field}` },
+        });
+        newColumns[columnIndex] = column;
+        this.$emit("update:content:effect", { columns: newColumns });
+      },
+      deep: true,
+    },
+    // Watch for changes in rowSelection to reconfigure selection column
+    'content.rowSelection': {
+      handler(newValue, oldValue) {
+        if (newValue !== oldValue && this.gridApi) {
+          this.$nextTick(() => {
+            if (newValue === 'multiple' && !this.content.disableCheckboxes) {
+              setTimeout(() => {
+                this.forceSelectionColumnFirst();
+              }, 100);
+              setTimeout(() => {
+                this.forceSelectionColumnFirstDOM();
+              }, 300);
+            }
+          });
+        }
+      },
+      immediate: false,
+    },
+    // Watch selectedRows to sync visual state when cleared
+    selectedRows: {
+      handler(newValue) {
+        if (this.gridApi && Array.isArray(newValue) && newValue.length === 0) {
+          // Clear via AG-Grid API
+          setTimeout(() => {
+            if (this.gridApi) {
+              this.gridApi.deselectAll();
+            }
+          }, 100);
+
+          // Force clear custom checkboxes via DOM
+          setTimeout(() => {
+            const gridElement = this.$refs.agGridRef?.$el;
+            if (gridElement) {
+              // Desmarcar todos os checkboxes customizados
+              const checkboxes = gridElement.querySelectorAll('.ag-selection-checkbox input[type="checkbox"]');
+              checkboxes.forEach(checkbox => {
+                checkbox.checked = false;
+              });
+
+              // Desmarcar header checkbox se existir
+              const headerCheckbox = gridElement.querySelector('.ag-header-checkbox input[type="checkbox"]');
+              if (headerCheckbox) {
+                headerCheckbox.checked = false;
+                headerCheckbox.indeterminate = false;
+              }
+            }
+          }, 150);
+        }
+      },
+      deep: true
+    },
+    // Reaplica a ordenação atual quando o datasource muda
+    'content.rowData': {
+      handler() {
+        if (this.gridApi) {
+          // Reaplica o sortModel atual se existir
+          try {
+            const currentSort = this.gridApi.getSortModel?.() || [];
+            if (currentSort.length) {
+              if (typeof this.gridApi?.setSortModel === "function") {
+                this.gridApi.setSortModel(currentSort);
+              } else {
+                const colApi = this.gridApi.getColumnApi?.();
+                const state = currentSort.map((entry, idx) => ({
+                  colId: entry.colId,
+                  sort: entry.sort,
+                  sortIndex: Number.isFinite(entry.sortIndex) ? entry.sortIndex : idx
+                }));
+
+                colApi?.applyColumnState?.({
+                  state,
+                  defaultState: { sort: null },
+                  applyOrder: false
+                });
+                this.gridApi?.refreshClientSideRowModel?.("sort");
+              }
+            } else if (this.content.initialSort) {
+              this.gridApi.applyColumnState({
+                state: this.content.initialSort,
+                defaultState: { sort: null }
+              });
+            }
+          } catch (e) {
+            // Fallback para simplesmente atualizar o modelo de linhas
+            this.gridApi.refreshClientSideRowModel?.('sort');
+          }
+        }
+      },
+      deep: true
+    },
+    'content.selectAllRows'(newValue) {
+      if (newValue === null) return;
+      if (this.gridApi) {
+        if (newValue === 'S') {
+          this.gridApi.selectAll();
+        } else if (newValue === 'N') {
+          this.gridApi.deselectAll();
+        }
+      }
+    },
+  },
+  /* wwEditor:end */
+  };
+  
+  
+</script>
+
+<style scoped lang="scss">
+  .ww-datagrid {
+    position: relative;
+    font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif);
+    font-size: var(--grid-view-dinamica-font-size, 12px);
+
+    :deep(.ag-theme-quartz),
+    :deep(.ag-theme-quartz *),
+    :deep(.ag-theme-quartz .ag-cell),
+    :deep(.ag-theme-quartz .ag-header-cell),
+    :deep(.ag-theme-quartz .ag-floating-filter),
+    :deep(.ag-theme-quartz .ag-menu),
+    :deep(.ag-theme-quartz .ag-overlay),
+    :deep(.ag-theme-quartz .ag-status-bar),
+    :deep(.ag-theme-quartz .ag-paging-panel),
+    :deep(.ag-theme-quartz .ag-tooltip),
+    :deep(.ag-theme-quartz input),
+    :deep(.ag-theme-quartz select),
+    :deep(.ag-theme-quartz textarea),
+    :deep(.ag-theme-quartz button) {
+      font-family: var(--grid-view-dinamica-font-family,
+          Roboto,
+          Arial,
+          sans-serif) !important;
+      font-size: var(--grid-view-dinamica-font-size, 12px) !important;
+    }
+
+    :deep(.ag-theme-quartz .material-symbols-outlined) {
+      font-family: "Material Symbols Outlined", sans-serif !important;
+    }
+
+    /* wwEditor:start */
+    &.editing {
+      &::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        display: block;
+        pointer-events: initial;
+        z-index: 10;
+      }
+    }
+
+    /* wwEditor:end */
+
+    // Estilos específicos para a coluna de seleção do AG-Grid
+    :deep(.ag-header-cell[col-id="ag-Grid-SelectionColumn"]) {
+      background-color: inherit !important;
+      border-right: var(--ag-border-color, #ddd) 1px solid !important;
+      min-width: 50px !important;
+      max-width: 50px !important;
+      width: 50px !important;
+
+      .ag-header-cell-resize {
+        display: none !important;
+      }
+
+      .ag-header-cell-menu-button {
+        display: none !important;
+      }
+
+      .ag-header-cell-sortable {
+        cursor: default !important;
+      }
+
+      // Garantir que o header checkbox apareça e esteja centralizado
+      .ag-header-checkbox,
+      .ag-checkbox {
+        margin: 0 auto !important;
+        display: flex !important;
+        justify-content: center !important;
+        align-items: center !important;
+        width: auto !important;
+        height: auto !important;
+
+        .ag-checkbox-input-wrapper {
+          border-color: var(--grid-view-dinamica-checkbox-unchecked-border-color,
+              var(--ag-checkbox-unchecked-color)) !important;
+        }
+
+        .ag-checkbox-input-wrapper.ag-checked,
+        .ag-checkbox-input-wrapper.ag-indeterminate {
+          background-color: var(--grid-view-dinamica-selection-checkbox-color,
+              var(--ag-checkbox-checked-background-color)) !important;
+          border-color: var(--grid-view-dinamica-selection-checkbox-color,
+              var(--ag-checkbox-checked-color)) !important;
+        }
+      }
+
+      // Garantir que o conteúdo do header esteja centralizado
+      .ag-header-cell-label {
+        display: flex !important;
+        justify-content: center !important;
+        align-items: center !important;
+        width: 100% !important;
+      }
+    }
+
+    :deep(.ag-cell[col-id="ag-Grid-SelectionColumn"]) {
+      background-color: transparent !important;
+      border-right: var(--ag-border-color, #ddd) 1px solid !important;
+      min-width: 50px !important;
+      max-width: 50px !important;
+      width: 50px !important;
+      align-items: center !important;
+      justify-content: center !important;
+      /* Remover display: flex e align-items para não afetar colunas vizinhas */
+
+      .ag-selection-checkbox {
+        margin-top: 10px !important;
+        display: flex !important;
+        align-items: center !important;
+        justify-content: center !important;
+        width: 100% !important;
+        height: 100% !important;
+
+        .ag-checkbox-input-wrapper {
+          border-color: var(--grid-view-dinamica-checkbox-unchecked-border-color, var(--ag-checkbox-unchecked-color)) !important;
+        }
+
+        .ag-checkbox-input-wrapper.ag-checked,
+        .ag-checkbox-input-wrapper.ag-indeterminate {
+          background-color: var(--grid-view-dinamica-selection-checkbox-color, var(--ag-checkbox-checked-background-color)) !important;
+          border-color: var(--grid-view-dinamica-selection-checkbox-color, var(--ag-checkbox-checked-color)) !important;
+        }
+      }
+    }
+
+    // Aplica a mesma cor de hover à célula de seleção
+    :deep(.ag-row-hover .ag-cell[col-id="ag-Grid-SelectionColumn"]) {
+      background-color: var(--ag-row-hover-color) !important;
+    }
+
+    // Garantir que a coluna de seleção seja sempre fixa à esquerda quando pinned
+    :deep(.ag-pinned-left-cols-container) {
+
+      .ag-header-cell[col-id="ag-Grid-SelectionColumn"],
+      .ag-cell[col-id="ag-Grid-SelectionColumn"] {
+        position: sticky !important;
+        left: 0 !important;
+        z-index: 5 !important;
+      }
+    }
+
+    // Garantir que não exista hover effect ou outras interações na coluna de seleção
+    :deep(.ag-header-cell[col-id="ag-Grid-SelectionColumn"]:hover) {
+      background-color: inherit !important;
+    }
+
+    // Garantir que a coluna de seleção seja sempre a primeira visualmente
+    :deep(.ag-header-cell[col-id="ag-Grid-SelectionColumn"]) {
+      order: -999 !important;
+      position: relative !important;
+      z-index: 10 !important;
+    }
+
+    :deep(.ag-row .ag-cell[col-id="ag-Grid-SelectionColumn"]) {
+      order: -999 !important;
+      position: relative !important;
+      z-index: 10 !important;
+    }
+
+    // Garantir que outras colunas pinned left tenham ordem menor
+    :deep(.ag-header-cell.ag-pinned-left):not([col-id="ag-Grid-SelectionColumn"]) {
+      order: -1 !important;
+    }
+
+    :deep(.ag-row .ag-cell.ag-pinned-left):not([col-id="ag-Grid-SelectionColumn"]) {
+      order: -1 !important;
+    }
+
+    // Impede drag e seleção em headers pinned
+    :deep(.ag-header-cell.ag-pinned-left),
+    :deep(.ag-header-cell.ag-pinned-right) {
+      pointer-events: none !important;
+      user-select: none !important;
+      cursor: default !important;
+    }
+
+    :deep(.ag-header-cell) {
+      border: none !important;
+      border-bottom: 1px solid #888888 !important;
+    }
+
+    :deep(.ag-cell) {
+      border-top: none !important;
+      border-right: none !important;
+      border-left: none !important;
+      border-bottom: 1px solid #888888 !important;
+
+    }
+
+    :deep(.ag-row) {
+      border: none !important;
+    }
+
+    :deep(.ag-row.ag-row-even),
+    :deep(.ag-row.ag-row-odd) {
+      border-top: none !important;
+      border-bottom: none !important;
+    }
+
+    :deep(.ag-row.ag-row-last .ag-cell),
+    :deep(.ag-row:last-child .ag-cell) {
+      border-bottom: 1px solid #888888 !important;
+
+    }
+
+    // Inputs de edição compactos e centralizados (ajuste agressivo)
+    :deep(.ag-cell.ag-cell-editing) {
+      padding: 0 !important;
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      height: 100% !important;
+      min-height: 0 !important;
+      max-height: none !important;
+      box-sizing: border-box !important;
+    }
+
+    :deep(.ag-cell.ag-cell-inline-editing .ag-cell-edit-wrapper),
+    :deep(.ag-cell.ag-cell-inline-editing .ag-cell-editor),
+    :deep(.ag-cell.ag-cell-inline-editing .ag-input-wrapper),
+    :deep(.ag-cell.ag-cell-inline-editing .ag-input-field-input-wrapper) {
+      display: flex !important;
+      align-items: center !important;
+      justify-content: center !important;
+      height: 100% !important;
+      min-height: 0 !important;
+      max-height: none !important;
+      padding: 0 !important;
+      margin: 0 !important;
+      box-sizing: border-box !important;
+    }
+
+    :deep(.ag-cell.ag-cell-inline-editing input),
+    :deep(.ag-cell.ag-cell-inline-editing select),
+    :deep(.ag-cell.ag-cell-inline-editing textarea) {
+      height: 26px !important;
+      min-height: 26px !important;
+      max-height: 26px !important;
+      font-size: var(--grid-view-dinamica-font-size, 12px) !important;
+      font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif) !important;
+      padding: 0 8px !important;
+      border-radius: 8 !important;
+      /* Remove arredondamento */
+      box-shadow: none !important;
+      /* Remove sombra */
+      border: 1px solid #888 !important;
+      /* Remove borda */
+      box-sizing: border-box !important;
+      line-height: 1.2 !important;
+      margin: 0 !important;
+      align-self: center !important;
+      resize: none !important;
+      background: #fff !important;
+      vertical-align: middle !important;
+      outline: none !important;
+      /* Remove borda azul de foco */
+      transition: none !important;
+      /* Remove animação de foco */
+    }
+
+    // Remove borda arredondada e sombra da célula de edição AG-Grid
+    :deep(.ag-cell-value.ag-cell.ag-cell-normal-height.ag-cell-focus.ag-cell-inline-editing) {
+      border-radius: 0 !important;
+      box-shadow: none !important;
+      outline: none !important;
+      transition: none !important;
+    }
+  }
+
+  :deep(.ag-header-align-left .ag-header-cell-label) {
+    justify-content: flex-start !important;
+  }
+
+  :deep(.ag-header-align-center .ag-header-cell-label) {
+    justify-content: center !important;
+    display: flex !important;
+    align-items: center !important;
+    gap: 4px;
+    width: 100%;
+    text-align: center !important;
+    margin-left: 12px !important;
+  }
+
+  :deep(.ag-header-align-center .ag-header-cell-label .ag-header-cell-text) {
+    flex: none !important;
+    text-align: center !important;
+    margin-left: 12px !important;
+  }
+
+  :deep(.ag-header-align-center .ag-header-icon) {
+    position: static !important;
+    margin-left: 12px !important;
+  }
+
+  :deep(.ag-header-align-right .ag-header-cell-label) {
+    justify-content: flex-end !important;
+  }
+
+  :deep(.ag-header-cell .ag-header-cell-menu-button),
+  :deep(.ag-header-cell .ag-header-cell-menu-button-wrapper),
+  :deep(.ag-header-cell .ag-header-icon) {
+    opacity: 0 !important;
+    pointer-events: none !important;
+    transition: opacity 0.2s;
+  }
+
+  :deep(.ag-header-cell:hover .ag-header-cell-menu-button),
+  :deep(.ag-header-cell:hover .ag-header-cell-menu-button-wrapper),
+  :deep(.ag-header-cell:hover .ag-header-icon) {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+  }
+
+  :deep(.ag-header-cell .ag-header-icon) {
+    opacity: 0 !important;
+    pointer-events: none !important;
+    transition: opacity 0.2s;
+  }
+
+  :deep(.ag-header-cell:hover .ag-header-icon),
+  :deep(.ag-header-cell.ag-header-cell-filtered .ag-header-icon) {
+    opacity: 1 !important;
+    pointer-events: auto !important;
+  }
+
+  :deep(.ag-header-cell.ag-header-cell-filtered .ag-header-icon) {
+    color: rgb(105, 157, 140) !important;
+    filter: drop-shadow(0 0 2px rgb(105, 157, 140));
+  }
+
+  .pagination-top {
+    :deep(.ag-root-wrapper) {
+      display: flex;
+      flex-direction: column;
+    }
+
+    :deep(.ag-paging-panel) {
+      order: -1;
+    }
+  }
+
+  :deep(.ag-paging-panel) {
+    background-color: var(--grid-view-dinamica-pagination-background-color, transparent) !important;
+    padding: var(--grid-view-dinamica-pagination-padding, 0) !important;
+  }
+
+  :deep(.ag-paging-row-summary-panel) {
+    display: none !important;
+  }
+
+  // Fonte da paginação igual à das linhas da grid
+  :deep(.ag-paging-panel),
+  :deep(.ag-paging-panel *),
+  :deep(.ag-pager),
+  :deep(.ag-pager *),
+  :deep(.ag-pagination),
+  :deep(.ag-pagination *) {
+    font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif) !important;
+    font-size: var(--grid-view-dinamica-font-size, 12px) !important;
+  }
+
+  // Remover bordas externas da grid
+  :deep(.ag-root),
+  :deep(.ag-root-wrapper),
+  :deep(.ag-root-wrapper-body),
+  :deep(.ag-body-viewport),
+  :deep(.ag-center-cols-clipper),
+  :deep(.ag-center-cols-container),
+  :deep(.ag-header),
+  :deep(.ag-header-viewport),
+  :deep(.ag-header-row),
+  :deep(.ag-paging-panel) {
+    border: none !important;
+    box-shadow: none !important;
+  }
+
+  // Estilos DEADLINE
+  :deep(.deadline-visual) {
+    border-radius: 999px !important;
+    text-align: center;
+    font-size: var(--grid-view-dinamica-font-size, 12px) !important;
+    font-family: var(--grid-view-dinamica-font-family, Roboto, Arial, sans-serif) !important;
+    font-weight: bold !important;
+    padding: 0 12px !important;
+    height: 26px !important;
+    width: 100px !important;
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    margin-top: 8px !important;
+    border: none !important;
+    box-shadow: none !important;
+    box-sizing: border-box;
+    overflow: hidden !important;
+    text-overflow: ellipsis !important;
+    white-space: nowrap !important;
+  }
+
+  :deep(.ag-cell[col-id*="Deadline"]) {
+    display: flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+  }
+
+  :deep(.deadline-green) {
+    background: #9bbff6 !important;
+    color: #fff !important;
+  }
+
+  :deep(.deadline-yellow) {
+    background: #ffd54f !important;
+    color: #fff !important;
+  }
+
+  :deep(.deadline-red) {
+    background: #ff6f6f !important;
+    color: #fff !important;
+  }
+
+  :deep(.deadline-closed) {
+    background: #666666 !important;
+    color: #fff !important;
+  }
+
+  :deep(.deadline-empty) {
+    background: transparent !important;
+    border: 1px solid #c4c4c4 !important;
+    color: #6b7280 !important;
+    font-weight: 500 !important;
+    gap: 6px;
+  }
+
+  :deep(.deadline-empty .deadline-empty-icon) {
+    font-size: 18px !important;
+    line-height: 1;
+  }
+
+  :deep(.deadline-empty .deadline-empty-text) {
+    line-height: 1;
+  }
+</style>

--- a/Project/TicketGrid/ww-config.js
+++ b/Project/TicketGrid/ww-config.js
@@ -1,0 +1,1654 @@
+export default {
+  editor: {
+  label: {
+  en: "TicketGrid",
+  },
+  icon: "table",
+  customStylePropertiesOrder: [
+  ["layout", "height", "textColor", "borderColor"],
+  ["gridFontFamily", "gridFontSize"],
+  [
+  "headerTitle",
+  "headerBackgroundColor",
+  "headerTextColor",
+  "headerFontWeight",
+  "headerFontSize",
+  "headerFontFamily",
+  ],
+  [
+  "rowTitle",
+  "rowBackgroundColor",
+  "rowAlternateColor",
+  "rowHoverColor",
+  "rowVerticalPaddingScale",
+  ],
+  ["columnTitle", "columnHoverHighlight", "columnHoverColor"],
+  [
+  "cellTitle",
+  "cellColor",
+  "cellFontFamily",
+  "cellFontSize",
+  "cellSelectionBorderColor",
+  ],
+  ["menuTitle", "menuTextColor", "menuBackgroundColor"],
+  [
+  "selectionTitle",
+  "selectedRowBackgroundColor",
+  "selectionCheckboxColor",
+  "focusShadow",
+  "checkboxUncheckedBorderColor",
+  ],
+  [
+  "actionTitle",
+  "actionColor",
+  "actionBackgroundColor",
+  "actionPadding",
+  "actionBorder",
+  "actionBorderRadius",
+  "actionFont",
+  "actionFontSize",
+  "actionFontFamily",
+  "actionFontWeight",
+  "actionFontStyle",
+  "actionLineHeight",
+  ],
+  ],
+  customSettingsPropertiesOrder: [
+  "rowData",
+  "ticketTypeFilter",
+  "idFormula",
+  "generateColumns",
+  "columns",
+  ["pagination", "paginationPageSize", "paginationPosition", "paginationPadding", "paginationBackgroundColor"],
+  [
+  "rowSelection",
+  "enableClickSelection",
+  "disableCheckboxes",
+    "selectAll",
+    "selectAllRows",    
+  ],
+  "movableColumns",
+  "resizableColumns",
+  "initialFilters",
+  "initialSort",
+  ["lang", "localeText"],
+  ],
+  },
+  triggerEvents: [
+  {
+  name: "action",
+  label: { en: "On Action" },
+  event: { actionName: "", row: null, id: 0, index: 0, displayIndex: 0 },
+  getTestEvent: "getOnActionTestEvent",
+  default: true,
+  },
+  {
+  name: "cellValueChanged",
+  label: { en: "On Cell Value Changed" },
+  event: {
+  oldValue: null,
+  newValue: null,
+  columnId: "id",
+  row: null,
+  },
+  getTestEvent: "getOnCellValueChangedTestEvent",
+  },
+  {
+  name: "rowSelected",
+  label: { en: "On Row Selected" },
+  event: {
+  row: null,
+  },
+  getTestEvent: "getSelectionTestEvent",
+  },
+  {
+  name: "rowDeselected",
+  label: { en: "On Row Deselected" },
+  event: {
+  row: null,
+  },
+  getTestEvent: "getSelectionTestEvent",
+  },
+  {
+  name: "filterChanged",
+  label: { en: "On Filter Changed" },
+  },
+  {
+  name: "sortChanged",
+  label: { en: "On Sort Changed" },
+  },
+  {
+  name: "columnMoved",
+  label: { en: "On Column Moved" },
+  },
+  {
+  name: "rowClicked",
+  label: { en: "On Row Clicked" },
+  event: {
+  row: null,
+  id: 0,
+  index: 0,
+  displayIndex: 0,
+  },
+  getTestEvent: "getRowClickedTestEvent",
+  },
+  {
+  name: "cellClicked",
+  label: { en: "On Cell Clicked" },
+  event: {
+    row: null,
+    id: 0,
+    index: 0,
+    displayIndex: 0,
+    fieldDB: null,
+    fieldID: null,
+    colId: null
+  },
+  getTestEvent: "getCellClickedTestEvent"
+},
+  {
+    name: "cellHovered",
+    label: { en: "On Cell Hovered" },
+    event: {
+      row: null,
+      id: 0,
+      index: 0,
+      displayIndex: 0,
+      fieldDB: null,
+      fieldID: null,
+      colId: null,
+      rowKey: null
+    },
+    getTestEvent: "getCellHoveredTestEvent"
+  },
+  {
+    name: "gridLoaded",
+    label: { en: "On Grid Loaded" },
+    event: { rows: [], totalRows: 0 },
+  },
+  ],
+  actions: [
+  {
+    action: 'deselectAllRows',
+    label: { en: 'Deselect All Rows' },
+    args: []
+  },
+  {
+    action: 'resetFilters',
+    label: { en: 'Reset Filters' },
+    args: []
+  },
+  {
+    action: 'resetColumnPositions',
+    label: { en: 'Reset Column Positions' },
+    args: []
+  },
+  {
+    action: 'refreshDropdownOptions',
+    label: { en: 'Refresh Dropdown Options' },
+    args: []
+  },
+    {
+      action: 'setFilters',
+      label: { en: 'Set Filters' },
+      args: [
+        {
+          name: 'filters',
+          type: 'object',
+          label: { en: 'Filters JSON' }
+        }
+      ]
+    },
+    {
+      action: 'setSort',
+      label: { en: 'Set Sort' },
+      args: [
+        {
+          name: 'sort',
+          type: 'object',
+          label: { en: 'Sort JSON' }
+        }
+      ]
+    },
+    {
+      action: 'updateRow',
+      label: { en: 'Update Row' },
+      args: [
+        {
+          name: 'row',
+          type: 'object',
+          label: { en: 'Row JSON' }
+        }
+      ]
+    },
+  {
+    action: 'remountComponent',
+    label: { en: 'Remount Component' },
+    args: []
+  },
+  {
+    action: 'exportGridToExcel',
+    label: { en: 'Export Grid to Excel' },
+    args: [
+      {
+        name: 'fileName',
+        type: 'string',
+        label: { en: 'File name' }
+      }
+    ]
+  },
+  ],
+  properties: {
+  headerTitle: {
+  type: "Title",
+  label: "Header",
+  editorOnly: true,
+  },
+  rowTitle: {
+  type: "Title",
+  label: "Row",
+  editorOnly: true,
+  },
+  columnTitle: {
+  type: "Title",
+  label: "Column",
+  editorOnly: true,
+  },
+  cellTitle: {
+  type: "Title",
+  label: "Cell",
+  editorOnly: true,
+  },
+  menuTitle: {
+  type: "Title",
+  label: "Menu",
+  editorOnly: true,
+  },
+  actionTitle: {
+  type: "Title",
+  label: "Action",
+  editorOnly: true,
+  },
+  selectionTitle: {
+  type: "Title",
+  label: "Selection",
+  editorOnly: true,
+  },   
+  layout: {
+  type: "TextSelect",
+  label: "Height Mode",
+  options: {
+  options: [
+  { value: "fixed", label: "Fixed", default: true },
+  { value: "auto", label: "Auto" },
+  ],
+  },
+  bindable: true,
+  responsive: true,
+  propertyHelp: {
+  tooltip:
+  "Be cautious when using auto mode with a large number of rows, as it may slow down page rendering",
+  },
+  bindingValidation: {
+  type: "string",
+  tooltip: "fixed | auto",
+  },
+  },
+  height: {
+  label: { en: "Grid Height" },
+  type: "Length",
+  section: "style",
+  options: {
+  noRange: true,
+  },
+  bindable: true,
+  classes: true,
+  responsive: true,
+  states: true,
+  defaultValue: "400px",
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  tooltip: "Height of the grid (e.g., 400px)",
+  },
+  hidden: (content) => content.layout === "auto",
+  /* wwEditor:end */
+  },
+  headerBackgroundColor: {
+  type: "Color",
+  label: "Background Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  headerTextColor: {
+  type: "Color",
+  label: "Text Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  headerFontWeight: {
+  label: "Font weight",
+  type: "TextSelect",
+  category: "text",
+  options: {
+  options: [
+  { value: null, label: "Default", default: true },
+  { value: 100, label: "100 - Thin" },
+  { value: 200, label: "200 - Extra Light" },
+  { value: 300, label: "300 - Light" },
+  { value: 400, label: "400 - Normal" },
+  { value: 500, label: "500 - Medium" },
+  { value: 600, label: "600 - Semi Bold" },
+  { value: 700, label: "700 - Bold" },
+  { value: 800, label: "800 - Extra Bold" },
+  { value: 900, label: "900 - Black" },
+  ],
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  bindingValidation: {
+  markdown: "font-weight",
+  type: "string",
+  cssSupports: "font-weight",
+  },
+  },
+  headerFontSize: {
+  label: "Font Size",
+  type: "Length",
+  options: {
+  unitChoices: [
+  { value: "px", label: "px", min: 1, max: 100, default: true },
+  { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+  { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+  ],
+  noRange: true,
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  bindingValidation: {
+  markdown: "font-size",
+  type: "string",
+  cssSupports: "font-size",
+  },
+  },
+  cellStyleArray: {
+  label: { en: "Cell Style Array" },
+  type: "Array",
+  section: "settings",
+  bindable: true,
+  defaultValue: [],
+  options: {
+  expandable: true,
+  getItemLabel(_, index) {
+  return `Style ${index + 1}`;
+  },
+  item: {
+  type: "Object",
+  defaultValue: {
+  Valor: "valor1",
+  CorFonte: "FFFFFF",
+  CorFundo: "000000"
+  },
+  options: {
+  item: {
+  Valor: {
+  label: "Valor",
+  type: "Text",
+  options: { placeholder: "Valor a comparar" }
+  },
+  CorFonte: {
+  label: "Cor da Fonte",
+  type: "Text",
+  options: { placeholder: "Código hex sem #" }
+  },
+  CorFundo: {
+  label: "Cor de Fundo",
+  type: "Text",
+  options: { placeholder: "Código hex sem #" }
+  }
+  }
+  }
+  }
+  },
+  /* wwEditor:start */
+  bindingValidation: {
+  type: 'Array',
+  tooltip: 'Array de estilos para células: [{"Valor":"valor1", "CorFonte":"FFFFFF", "CorFundo":"000000"}]'
+  },
+  propertyHelp: {
+  tooltip: 'Define estilos personalizados para células baseados no valor. Cada item deve ter Valor, CorFonte e CorFundo.'
+  }
+  /* wwEditor:end */
+  },
+  textColor: {
+  label: "Text Color",
+  type: "Color",
+  category: "text",
+  options: { nullable: true },
+  bindable: true,
+  bindingValidation: {
+  markdown: "color",
+  type: "string",
+  cssSupports: "color",
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  },
+  gridFontFamily: {
+  label: "Grid Font Family",
+  type: "FontFamily",
+  category: "text",
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  bindingValidation: {
+  markdown: "font-family",
+  type: "string",
+  cssSupports: "font-family",
+  },
+  },
+  gridFontSize: {
+  label: "Grid Font Size",
+  type: "Length",
+  category: "text",
+  options: {
+  unitChoices: [
+  { value: "px", label: "px", min: 1, max: 100, default: true },
+  { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+  { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+  ],
+  noRange: true,
+  },
+  defaultValue: "12px",
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  bindingValidation: {
+  markdown: "font-size",
+  type: "string",
+  cssSupports: "font-size",
+  },
+  },
+  headerFontFamily: {
+  label: "Font family",
+  type: "FontFamily",
+  category: "text",
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  bindingValidation: {
+  markdown: "font-family",
+  type: "string",
+  cssSupports: "font-family",
+  },
+  },
+  borderColor: {
+  type: "Color",
+  label: "Border Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  cellColor: {
+  type: "Color",
+  label: "Text Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  cellFontFamily: {
+  label: "Font family",
+  type: "FontFamily",
+  category: "text",
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  bindingValidation: {
+  markdown: "font-family",
+  type: "string",
+  cssSupports: "font-family",
+  },
+  },
+  cellFontSize: {
+  type: "Length",
+  label: "Font Size",
+  options: {
+  unitChoices: [
+  { value: "px", label: "px", min: 1, max: 100, default: true },
+  { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+  { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+  ],
+  noRange: true,
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  bindingValidation: {
+  markdown: "font-size",
+  type: "string",
+  cssSupports: "font-size",
+  },
+  },
+  useStyleArray: {
+  label: "Usar Array de Estilos",
+  type: "OnOff",
+  hidden: (content, sidePanelContent, boundProperties, wwProps, array) =>
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom" ||
+  array?.item?.useCustomLabel ||
+  array?.item?.useCustomFormatter,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "Ativa o uso do array de estilos para esta coluna"
+  },
+  propertyHelp: {
+  tooltip: "Quando ativado, compara o valor da célula com o array de estilos e aplica o estilo correspondente"
+  }
+  /* wwEditor:end */
+  },
+  cellSelectionBorderColor: {
+  type: "Color",
+  label: "Selection Border Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  bindingValidation: {
+  markdown: "color",
+  type: "string",
+  cssSupports: "color",
+  },
+  },
+  columnHoverHighlight: {
+  type: "OnOff",
+  label: "Hover Highlight",
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  columnHoverColor: {
+  type: "Color",
+  label: "Hover Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  propertyHelp: {
+  tooltip: `Should be a semi-transparent color to allow the background color to show through.`,
+  },
+  hidden: (content) => !content.columnHoverHighlight,
+  },
+  rowBackgroundColor: {
+  type: "Color",
+  label: "Background Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  rowAlternateColor: {
+  type: "Color",
+  label: "Alternate Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  rowHoverColor: {
+  type: "Color",
+  label: "Hover Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  propertyHelp: {
+  tooltip: `Should be a semi-transparent color to allow the background color to show through.`,
+  },
+  },
+  selectedRowBackgroundColor: {
+  type: "Color",
+  label: "Selected Background Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  propertyHelp: {
+  tooltip: `Should be a semi-transparent color to allow the background color to show through.`,
+  },
+  },
+  selectionCheckboxColor: {
+  type: "Color",
+  label: "Selection Checkboxes Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  bindingValidation: {
+  markdown: "color",
+  type: "string",
+  cssSupports: "color",
+  },
+  },
+  checkboxUncheckedBorderColor: {
+  type: "Color",
+  label: "Checkbox Unchecked Border Color",
+  options: {
+  nullable: true,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  bindingValidation: {
+  markdown: "color",
+  type: "string",
+  cssSupports: "color",
+  },
+  },
+  focusShadow: {
+  type: "Shadows",
+  label: "Focus Shadow",
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  bindingValidation: {
+  markdown: "shadow",
+  type: "string",
+  cssSupports: "shadow",
+  },
+  },
+  rowVerticalPaddingScale: {
+  type: "Number",
+  label: "Vertical Padding Scale",
+  options: {
+  min: 0,
+  max: 5,
+  step: 0.1,
+  default: 1,
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  },
+  menuTextColor: {
+  label: "Text color",
+  type: "Color",
+  category: "text",
+  options: { nullable: true },
+  bindable: true,
+  bindingValidation: {
+  markdown: "color",
+  type: "string",
+  cssSupports: "color",
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  },
+  menuBackgroundColor: {
+  label: "Background color",
+  type: "Color",
+  category: "background",
+  options: { nullable: true },
+  bindable: true,
+  bindingValidation: {
+  markdown: "background-color",
+  type: "string",
+  cssSupports: "background-color",
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  },
+  actionColor: {
+  label: "Text color",
+  type: "Color",
+  category: "text",
+  options: { nullable: true },
+  bindable: true,
+  bindingValidation: {
+  markdown: "color",
+  type: "string",
+  cssSupports: "color",
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  },
+  actionBackgroundColor: {
+  label: "Background color",
+  type: "Color",
+  category: "background",
+  options: { nullable: true },
+  bindable: true,
+  bindingValidation: {
+  markdown: "background-color",
+  type: "string",
+  cssSupports: "background-color",
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  },
+  actionPadding: {
+  label: "Padding",
+  type: "Spacing",
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  bindingValidation: {
+  markdown: "padding",
+  type: "string",
+  cssSupports: "padding",
+  },
+  },
+  actionBorder: {
+  label: "Border",
+  type: "Border",
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  bindingValidation: {
+  markdown: "border",
+  type: "string",
+  cssSupports: "border",
+  },
+  },
+  actionBorderRadius: {
+  label: "Border radius",
+  type: "Spacing",
+  options: {
+  isCorner: true,
+  unitChoices: [
+  { value: "px", label: "px", min: 0, max: 50, default: true },
+  { value: "%", label: "%", min: 0, max: 100, digits: 2, step: 1 },
+  ],
+  },
+  responsive: true,
+  bindable: true,
+  states: true,
+  classes: true,
+  bindingValidation: {
+  markdown: "border-radius",
+  type: "string",
+  cssSupports: "border-radius",
+  },
+  },
+  actionFont: {
+  label: "Typography",
+  type: "Typography",
+  category: "text",
+  options: (content, sidepanelContent, boundProperties) => ({
+  initialValue: {
+  fontSize: content["actionFontSize"],
+  fontFamily: content["actionFontFamily"],
+  fontWeight: content["actionFontWeight"],
+  fontStyle: content["actionFontStyle"],
+  lineHeight: content["actionLineHeight"],
+  },
+  creationDisabled:
+  boundProperties["actionFontSize"] ||
+  boundProperties["actionFontFamily"] ||
+  boundProperties["actionFontWeight"] ||
+  boundProperties["actionFontStyle"] ||
+  boundProperties["actionFontLineHeight"],
+  creationDisabledMessage:
+  "Cannot create typography from bound properties",
+  }),
+  bindable: true,
+  responsive: true,
+  states: true,
+  classes: true,
+  },
+  actionFontSize: {
+  label: "Size",
+  type: "Length",
+  category: "text",
+  options: {
+  unitChoices: [
+  { value: "px", label: "px", min: 1, max: 100, default: true },
+  { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+  { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+  ],
+  noRange: true,
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  hidden: (content, _, boundProps) =>
+  content["actionFont"] || boundProps["actionFont"],
+  bindingValidation: {
+  markdown: "font-size",
+  type: "string",
+  cssSupports: "font-size",
+  },
+  },
+  actionFontFamily: {
+  label: "Font family",
+  type: "FontFamily",
+  category: "text",
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  hidden: (content, _, boundProps) =>
+  content["actionFont"] || boundProps["actionFont"],
+  bindingValidation: {
+  markdown: "font-family",
+  type: "string",
+  cssSupports: "font-family",
+  },
+  },
+  actionFontWeight: {
+  label: "Font weight",
+  type: "TextSelect",
+  category: "text",
+  options: {
+  options: [
+  { value: null, label: "Default", default: true },
+  { value: 100, label: "100 - Thin" },
+  { value: 200, label: "200 - Extra Light" },
+  { value: 300, label: "300 - Light" },
+  { value: 400, label: "400 - Normal" },
+  { value: 500, label: "500 - Medium" },
+  { value: 600, label: "600 - Semi Bold" },
+  { value: 700, label: "700 - Bold" },
+  { value: 800, label: "800 - Extra Bold" },
+  { value: 900, label: "900 - Black" },
+  ],
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  hidden: (content, _, boundProps) =>
+  content["actionFont"] || boundProps["actionFont"],
+  bindingValidation: {
+  markdown: "font-weight",
+  type: "string",
+  cssSupports: "font-weight",
+  },
+  },
+  actionFontStyle: {
+  label: "Font Style",
+  type: "TextRadioGroup",
+  category: "text",
+  options: {
+  choices: [
+  {
+  value: null,
+  title: "Default",
+  icon: "typo-default",
+  default: true,
+  },
+  { value: "italic", title: "Italic", icon: "typo-italic" },
+  ],
+  },
+  responsive: true,
+  states: true,
+  bindable: true,
+  classes: true,
+  hidden: (content, _, boundProps) =>
+  content["actionFont"] || boundProps["actionFont"],
+  bindingValidation: {
+  markdown: "font-style",
+  type: "string",
+  cssSupports: "font-style",
+  },
+  },
+  actionLineHeight: {
+  label: "Line height",
+  type: "Length",
+  category: "text",
+  options: {
+  unitChoices: [
+  { value: "normal", label: "auto", default: true },
+  { value: "px", label: "px", min: 0, max: 100 },
+  { value: "%", label: "%", min: 0, max: 100 },
+  { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+  { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+  { value: "unset", label: "none" },
+  ],
+  noRange: true,
+  },
+  responsive: true,
+  states: true,
+  classes: true,
+  bindable: true,
+  hidden: (content, _, boundProps) =>
+  content["actionFont"] || boundProps["actionFont"],
+  bindingValidation: {
+  markdown: "line-height",
+  type: "string",
+  cssSupports: "line-height",
+  },
+  },
+  rowData: {
+  label: { en: "Data" },
+  type: "ObjectList",
+  options: {
+  useSchema: true,
+  },
+  section: "settings",
+  bindable: true,
+  defaultValue: [],
+  /* wwEditor:start */
+  bindingValidation: {
+  validations: [
+  {
+  type: "array",
+  },
+  {
+  type: "object",
+  },
+  ],
+  tooltip:
+  "A collection or an array of data: \n\n`myCollection` or `[{}, {}, ...]`",
+  },
+  /* wwEditor:end */
+  },
+  ticketTypeFilter: {
+    label: { en: "Ticket type filter" },
+    type: "TextSelect",
+    options: {
+      choices: [
+        { value: "", label: "All", default: true },
+        { value: "incident", label: "Incident" },
+        { value: "request", label: "Request" },
+        { value: "problem", label: "Problem" },
+        { value: "update", label: "Update" },
+      ],
+    },
+    section: "settings",
+    bindable: true,
+    propertyHelp: {
+      tooltip: "Limit which ticket type is shown in the grid without affecting ticketTagCounts.",
+    },
+  },
+  idFormula: {
+  type: "Formula",
+  label: "Unique Row Id",
+  options: (content) => ({
+  template: wwLib.wwUtils.getDataFromCollection(content.rowData)?.[0],
+  }),
+  section: "settings",
+  propertyHelp: {
+  tooltip:
+  "A unique id per row. Very useful for performance optimization.",
+  },
+  },
+  generateColumns: {
+  type: "Button",
+  options: {
+  text: "Generate columns",
+  color: "blue",
+  action: "generateColumns",
+  },
+  section: "settings",
+  editorOnly: true,
+  },
+  columns: {
+  label: {
+  en: "Columns",
+  },
+  type: "Array",
+  options: {
+  item: {
+  type: "Object",
+  options: (
+  content,
+  sidePanelContent,
+  boundProperties,
+  wwProps,
+  array
+  ) => ({
+  item: {
+  headerName: {
+  label: "Header Name",
+  type: "Text",
+  bindable: true,
+  },
+  cellDataType: {
+  label: "Type",
+  type: "TextSelect",
+  options: {
+  options: [
+  { value: undefined, label: "Auto", default: true },
+  { value: "text", label: "Text" },
+  { value: "number", label: "Number" },
+  { value: "boolean", label: "Boolean" },
+  { value: "dateString", label: "Date" },
+  { value: "image", label: "Image" },
+  { value: "action", label: "Action" },
+  { value: "custom", label: "Custom" },
+  ],
+  },
+  },
+  useCustomLabel: {
+  label: "Custom display value",
+  type: "OnOff",
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom",
+  },
+  displayLabelFormula: {
+  label: "Display value",
+  type: "Formula",
+  options: {
+  template: _.get(
+  wwLib.wwUtils.getDataFromCollection(content.rowData)?.[0],
+  array?.item?.field
+  ),
+  },
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  !array?.item?.useCustomLabel ||
+  array?.item?.cellDataType === "custom",
+  },
+  useCustomFormatter: {
+  label: "Use Custom Formatter",
+  type: "OnOff",
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom" ||
+  array?.item?.useCustomLabel,
+  },
+  useStyleArray: {
+  label: "Usar Array de Estilos",
+  type: "OnOff",
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom" ||
+  array?.item?.useCustomLabel ||
+  array?.item?.useCustomFormatter,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "Ativa o uso do array de estilos para esta coluna"
+  },
+  propertyHelp: {
+  tooltip: "Quando ativado, compara o valor da célula com o array de estilos e aplica o estilo correspondente"
+  }
+  /* wwEditor:end */
+  },
+  formatter: {
+  label: "Custom Formatter",
+  type: "Script",
+  options: {
+  language: "javascript",
+  placeholder: "// Write code that formats the cell value\n// Parameters: value, row, colDef, getRoundedSpanColor\n// Example: return getRoundedSpanColor(value, colorArray);"
+  },
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom" ||
+  !array?.item?.useCustomFormatter,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  tooltip: "JavaScript code that formats the cell value. Receives value, row, colDef, and getRoundedSpanColor function parameters."
+  },
+  propertyHelp: {
+  tooltip: "Write JavaScript code that returns the formatted value. Available parameters: value (cell value), row (entire row data), colDef (column definition), and getRoundedSpanColor function to create styled spans."
+  },
+  /* wwEditor:end */
+  },
+  widthAlgo: {
+  type: "TextRadioGroup",
+  label: "Width",
+  options: {
+  choices: [
+  { value: "fixed", label: "Fixed", default: true },
+  { value: "flex", label: "Flex" },
+  ],
+  },
+  },
+  flex: {
+  label: "Flex",
+  type: "Number",
+  options: {
+  min: 1,
+  max: 10,
+  step: 1,
+  noRange: true,
+  defaultValue: 1,
+  },
+  hidden: array?.item?.widthAlgo !== "flex",
+  },
+  width: {
+  type: "Length",
+  options: {
+  noRange: true,
+  unitChoices: [
+  { value: "px", label: "px", min: 0, max: 1300 },
+  { value: "auto", label: "auto" },
+  ],
+  },
+  hidden: array?.item?.widthAlgo === "flex",
+  },
+  minWidth: {
+  label: "Min Width",
+  type: "Length",
+  options: {
+  noRange: true,
+  unitChoices: [
+  { value: "px", label: "px", min: 0, max: 1300 },
+  { value: "auto", label: "auto" },
+  ],
+  },
+  },
+  maxWidth: {
+  label: "Max Width",
+  type: "Length",
+  options: {
+  noRange: true,
+  unitChoices: [{value: "px", label: "px", min: 0, max: 1300 },
+  { value: "auto", label: "auto" },
+  ],
+  },
+  },
+  pinned: {
+  label: "Pinned",
+  type: "TextRadioGroup",
+  options: {
+  choices: [
+  { value: "none", label: "None", default: true },
+  { value: "left", label: "Left" },
+  { value: "right", label: "Right" },
+  ],
+  },
+  },
+  draggable: {
+  label: "Draggable",
+  type: "OnOff",
+  defaultValue: true,
+  bindable: true,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "Whether this column can be moved via drag and drop"
+  },
+  propertyHelp: {
+  tooltip: "When enabled, this column can be reordered by dragging. Columns with pinned=left will never be draggable regardless of this setting."
+  }
+  /* wwEditor:end */
+  },
+  hide: {
+  label: "Hidden",
+  type: "OnOff",
+  bindable: true,
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "True to hide the column",
+  },
+  },
+  editable: {
+  label: "Editable",
+  type: "OnOff",
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom",
+  },
+  filter: {
+  label: "Filter",
+  type: "OnOff",
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image",
+  },
+  sortable: {
+  label: "Sortable",
+  type: "OnOff",
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image",
+  },
+  textAlign: {
+  label: "Text Alignment",
+  type: "TextRadioGroup",
+  options: {
+  choices: [
+  { value: "left", label: "Left", default: true },
+  { value: "center", label: "Center" },
+  { value: "right", label: "Right" },
+  ],
+  },
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom",
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  enum: ["left", "center", "right"],
+  tooltip: "Alignment of text within the cell: left, center, or right"
+  },
+  propertyHelp: {
+  tooltip: "Controls how text is aligned within each cell of this column"
+  },
+  /* wwEditor:end */
+  },
+  headerAlign: {
+  label: "Header Alignment",
+  type: "TextRadioGroup",
+  options: {
+  choices: [
+  { value: "left", label: "Left", default: true },
+  { value: "center", label: "Center" },
+  { value: "right", label: "Right" },
+  ],
+  },
+  hidden:
+  array?.item?.cellDataType === "action" ||
+  array?.item?.cellDataType === "image" ||
+  array?.item?.cellDataType === "custom",
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  enum: ["left", "center", "right"],
+  tooltip: "Alignment of text within the header cell: left, center, or right"
+  },
+  propertyHelp: {
+  tooltip: "Controls how text is aligned within the header cell of this column"
+  },
+  /* wwEditor:end */
+  },
+  cursor: {
+    label: "Cursor",
+    type: "TextSelect",
+    options: {
+      choices: [
+        { value: "default", label: "Default", default: true },
+        { value: "pointer", label: "Pointer (mãozinha)" },
+        { value: "text", label: "Text (texto)" },
+        { value: "move", label: "Move (mover)" },
+        { value: "crosshair", label: "Crosshair (mira)" },
+        { value: "not-allowed", label: "Not Allowed (proibido)" },
+        { value: "help", label: "Help (ajuda)" },
+        { value: "wait", label: "Wait (aguarde)" },
+        { value: "progress", label: "Progress (progresso)" },
+        { value: "copy", label: "Copy (copiar)" },
+        { value: "grab", label: "Grab (pegar)" },
+        { value: "zoom-in", label: "Zoom In" },
+        { value: "zoom-out", label: "Zoom Out" }
+      ]
+    },
+    hidden:
+      array?.item?.cellDataType === "action" ||
+      array?.item?.cellDataType === "image" ||
+      array?.item?.cellDataType === "custom",
+    /* wwEditor:start */
+    bindingValidation: {
+      type: "string",
+      tooltip: "Tipo de cursor ao passar o mouse sobre as células desta coluna"
+    },
+    propertyHelp: {
+      tooltip: "Escolha o tipo de cursor do mouse para as células desta coluna."
+    }
+    /* wwEditor:end */
+  },
+  },
+  }),
+  },
+  defaultValue: {
+  filter: false,
+  sortable: false,
+  },
+  movable: true,
+  expandable: true,
+  getItemLabel(item, index) {
+  return item?.headerName?.length
+  ? item?.headerName
+  : item?.field?.length
+  ? item?.field
+  : `Column ${index + 1}`;
+  },
+  },
+  defaultValue: [],
+  section: "settings",
+  bindable: true,
+  },
+  pagination: {
+  label: { en: "Pagination" },
+  type: "OnOff",
+  section: "settings",
+  bindable: true,
+  defaultValue: false,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "Enable or disable pagination",
+  },
+  /* wwEditor:end */
+  },
+  paginationPageSize: {
+  label: { en: "Rows Per Page" },
+  type: "Number",
+  section: "settings",
+  bindable: true,
+  defaultValue: 10,
+  options: {
+  noRange: true,
+  },
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "number",
+  tooltip: "Number of rows to display per page",
+  },
+  hidden: (content) => !content.pagination,
+  /* wwEditor:end */
+  },
+  paginationPosition: {
+  label: { en: "Pagination Position" },
+  type: "TextSelect",
+  section: "settings",
+  bindable: true,
+  defaultValue: "bottom",
+  options: {
+  options: [
+  { value: "bottom", label: "Bottom", default: true },
+  { value: "top", label: "Top" },
+  ],
+  },
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  tooltip: "Choose whether pagination is displayed at the top or bottom",
+  },
+  hidden: (content) => !content.pagination,
+  /* wwEditor:end */
+  },
+  paginationPadding: {
+  label: { en: "Pagination Padding" },
+  type: "Text",
+  section: "settings",
+  bindable: true,
+  defaultValue: "",
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  tooltip: "Padding for the pagination area (e.g. 8px 16px)",
+  },
+  hidden: (content) => !content.pagination,
+  /* wwEditor:end */
+  },
+  paginationBackgroundColor: {
+  label: { en: "Pagination Background Color" },
+  type: "Color",
+  section: "settings",
+  bindable: true,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  tooltip: "Background color for the pagination area",
+  },
+  hidden: (content) => !content.pagination,
+  /* wwEditor:end */
+  },
+  rowSelection: {
+  label: { en: "Row Selection" },
+  type: "TextSelect",
+  section: "settings",
+  bindable: true,
+  options: {
+  options: [
+  { value: "none", label: "None", default: true },
+  { value: "single", label: "Single" },
+  { value: "multiple", label: "Multiple" },
+  ],
+  },
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  tooltip: "Type of row selection: none or single or multiple",
+  },
+  /* wwEditor:end */
+  },
+  enableClickSelection: {
+  label: { en: "Enable Click Selection" },
+  type: "OnOff",
+  section: "settings",
+  bindable: true,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "True to enable row selection on click",
+  },
+  hidden: (content) =>
+  content.rowSelection === "none" || content.rowSelection === undefined,
+  /* wwEditor:end */
+  },
+  disableCheckboxes: {
+  label: { en: "Disable Checkboxes" },
+  type: "OnOff",
+  section: "settings",
+  bindable: true,
+  defaultValue: false,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "True to disable checkboxes",
+  },
+  hidden: (content) =>
+  content.rowSelection === "none" || content.rowSelection === undefined,
+  /* wwEditor:end */
+  },
+  selectAll: {
+  label: { en: "Select All behavior" },
+  type: "TextSelect",
+  section: "settings",
+  bindable: true,
+  defaultValue: "all",
+  options: {
+  options: [
+  { value: "all", label: "All", default: true },
+  { value: "filtered", label: "Filtered" },
+  { value: "currentPage", label: "Current Page" },
+  ],
+    },
+    /* wwEditor:start */
+    bindingValidation: {
+      type: "string",
+      enum: ["all", "filtered", "currentPage"],
+      tooltip:
+        "Select all behavior: 'all' to select all rows, 'filtered' to select filtered rows, 'currentPage' to select current page rows",
+    },
+    hidden: (content) => content.rowSelection !== "multiple",
+    /* wwEditor:end */
+  },
+  selectAllRows: {
+    label: { en: "Select/Deselect All Rows" },
+    type: "TextSelect",
+    bindable: true,
+    section: "settings",
+    defaultValue: null,
+    options: {
+      options: [
+        { value: null, label: "No Action", default: true },
+        { value: "S", label: "Select All" },
+        { value: "N", label: "Deselect All" }
+      ]
+    },
+    propertyHelp: {
+      tooltip: "Set to 'S' to select all rows, 'N' to deselect all rows, or null to do nothing. Has o mesmo efeito do checkbox do header."
+    },
+    bindingValidation: {
+      type: ["string", "null"],
+      enum: ["S", "N", null],
+      tooltip: "'S' para selecionar todas, 'N' para desmarcar todas, null para não fazer nada"
+    }
+  },
+  movableColumns: {
+  label: { en: "Movable Columns" },
+  type: "OnOff",
+  section: "settings",
+  bindable: true,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "Enable or disable movable columns",
+  },
+  /* wwEditor:end */
+  },
+  resizableColumns: {
+  label: { en: "Resizable Columns" },
+  type: "OnOff",
+  section: "settings",
+  bindable: true,
+  defaultValue: true,
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "boolean",
+  tooltip: "Enable or disable resizable columns",
+  },
+  /* wwEditor:end */
+  },
+  initialFilters: {
+  label: { en: "Initial Filters" },
+  type: "RawObject",
+  section: "settings",
+  bindable: true,
+  defaultValue: null,
+  bindingValidation: {
+  type: "object",
+  tooltip: "An object representing the initial filter model",
+  },
+  },
+  initialSort: {
+  label: { en: "Initial Sort" },
+  type: "RawObject",
+  section: "settings",
+  bindable: true,
+  defaultValue: null,
+  bindingValidation: {
+  type: "array",
+  tooltip: "An array representing the initial sort model",
+  },
+  },
+  lang: {
+  label: { en: "Language" },
+  type: "TextSelect",
+  section: "settings",
+  bindable: true,
+  options: {
+  options: [
+  { value: "en", label: "English", default: true },
+  { value: "fr", label: "French" },
+  { value: "es", label: "Spanish" },
+  { value: "de", label: "German" },
+  { value: "pt", label: "Portuguese" },
+  { value: "custom", label: "Custom" },
+  ],
+  },
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "string",
+  tooltip:
+  "Localisation to use. Default is English. Possible values: en, fr, es, de, pt, custom. Use custom to set your own locale texts.",
+  },
+  /* wwEditor:end */
+  },
+  localeText: {
+  label: { en: "Locale texts" },
+  type: "RawObject",
+  section: "settings",
+  bindable: true,
+  defaultValue: {},
+  hidden: (content) => content.lang !== "custom",
+  /* wwEditor:start */
+  bindingValidation: {
+  type: "object",
+  tooltip:
+  'See <a href="https://github.com/ag-grid/ag-grid/blob/latest/community-modules/locale/src/en-US.ts" target="_blank">Aggrid website</a> for the list of texts to localise',
+  },
+  /* wwEditor:end */
+  },
+  },
+  };
+  
+  function getRoundedSpanColor(value, colorArray) {
+  if (!colorArray || !Array.isArray(colorArray) || !value) return null;
+  
+  const matchingStyle = colorArray.find(item => item.Valor === value);
+  if (!matchingStyle) return null;
+  
+  return `<span style="height:30px; color: #${matchingStyle.CorFonte}; background:#${matchingStyle.CorFundo}; border: 1px solid #${matchingStyle.CorFundo}; border-radius: 10px; display: inline-flex; align-items: center; padding: 0 8px;">${value}</span>`;
+  }
+  
+  function dateFormatter(dateValue, lang) {
+  try {
+  if (!dateValue) return '';
+  const formatter = new Intl.DateTimeFormat(lang || 'en', {
+  day: '2-digit', 
+  month: '2-digit', 
+  year: 'numeric', 
+  hour: '2-digit', 
+  minute: '2-digit'
+  }); 
+  return formatter.format(new Date(dateValue));
+  } catch (error) {
+  return dateValue;
+  }
+  }


### PR DESCRIPTION
### Motivation
- Provide an isolated copy of the existing `GridViewDinamica` component so `TicketGrid` can be refactored and optimized without affecting the original implementation.
- Preserve current runtime behavior (renderers, editors, filters, events and utilities) while enabling future cleanup and simplification.

### Description
- Added a new component tree at `Project/TicketGrid` containing a full functional copy of `GridViewDinamica` (main element, `ww-config.js`, `translation.js`, `utils/fontFamily.js`, CSS and all specialized `components/` such as renderers, editors and filters). 
- Updated the component label in `Project/TicketGrid/ww-config.js` to `TicketGrid` so it appears under the new name in the editor and tooling.
- Kept existing integration points (AG Grid component usage, locale handling, custom cell editors/renderers and helper utilities) intact so behavior remains equivalent to the original grid.
- Prepared the copied codebase as a separate module to allow iterative refactorings (dead code removal, helper extraction, watcher simplification) in follow-up changes.

### Testing
- Verified new files and locations using `rg` to confirm the expected symbols (`ListCellEditor`, pinned header helpers, etc.) were present in `Project/TicketGrid/src/wwElement.vue` and `components/` (succeeded). 
- Inspected key files with `sed -n` and `nl -ba` (`Project/TicketGrid/src/wwElement.vue`, `Project/TicketGrid/ww-config.js`, `Project/TicketGrid/src/components/ListCellEditor.js`) to confirm the copy contains the expected content (succeeded). 
- Created a pull request entry using the repo tooling to summarize the change (PR created successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb1643a79c8330a945323c14e11830)