### PR TITLE
Show lock icon for rows that are not selectable and centralize selection condition

### DIFF
--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -364,7 +364,7 @@ export default {
       };
     },
     columnDefs() {
-      return this.content.columns.map((col) => {
+      const mappedColumns = this.content.columns.map((col) => {
         
         // Forçar cellDataType para 'dateString' se for 'date' ou 'dateString'
         if (col.cellDataType === 'date') col.cellDataType = 'dateString';
@@ -551,6 +551,43 @@ export default {
           }
         }
       });
+
+      if (
+        this.content.showDisabledSelectionLockIcon !== false &&
+        this.content.rowSelection === "multiple" &&
+        !this.content.disableCheckboxes
+      ) {
+        mappedColumns.push({
+          colId: "__lock_selection__",
+          headerName: "",
+          width: 52,
+          minWidth: 52,
+          maxWidth: 52,
+          sortable: false,
+          filter: false,
+          resizable: false,
+          suppressNavigable: true,
+          lockPosition: true,
+          suppressHeaderContextMenu: true,
+          suppressHeaderMenuButton: true,
+          suppressCellFocus: true,
+          suppressColumnsToolPanel: true,
+          cellStyle: {
+            textAlign: "center",
+            paddingLeft: "0",
+            paddingRight: "0",
+            overflow: "hidden",
+          },
+          cellRenderer: (params) => {
+            const selectable = this.isRowSelectableByCondition(params?.data);
+            return selectable
+              ? ""
+              : '<span style="display:flex;align-items:center;justify-content:center;width:100%;height:100%;"><i class="fa fa-lock" style="font-size:16px;line-height:1;" aria-hidden="true" title="Row not selectable"></i></span>';
+          },
+        });
+      }
+
+      return mappedColumns;
     },
     rowSelection() {
       if (this.content.rowSelection === "multiple") {
@@ -560,28 +597,7 @@ export default {
           headerCheckbox: !this.content.disableCheckboxes,
           selectAll: this.content.selectAll || "all",
           enableClickSelection: this.content.enableClickSelection,
-          isRowSelectable: (rowNode) => {
-            const cond = this.content.disableRowSelectionCondition;
-            if (!cond) return true;
-            let expr = cond.replace(/@([a-zA-Z0-9_çÇãÃáÁéÉíÍóÓúÚêÊôÔâÂàÀèÈìÌòÒùÙüÜñÑ]+)/g, (match, p1) => {
-              const val = rowNode.data && rowNode.data[p1];
-              if (val === undefined || val === null) return 'null';
-              if (typeof val === 'string') return `"${val.replace(/"/g, '\\"')}"`;
-              if (typeof val === 'boolean' || typeof val === 'number') return val;
-              return 'null';
-            });
-            // Troca operadores lógicos
-            expr = expr.replace(/\bAND\b/gi, '&&').replace(/\bOR\b/gi, '||');
-            // Troca apenas = isolado por ===
-            expr = expr.replace(/([^=!<>])=([^=])/g, '$1===$2');
-            // Não faz mais conversão de datas, pois o JSON já está em ISO
-            try {
-              return !eval(expr);
-            } catch (e) {
-              
-              return true;
-            }
-          }
+          isRowSelectable: (rowNode) => this.isRowSelectableByCondition(rowNode?.data),
         };
       } else if (this.content.rowSelection === "single") {
         return {
@@ -732,6 +748,24 @@ export default {
         event.api.setFocusedCell(nextRowIndex, targetColumn);
         event.api.startEditingCell(startEditParams);
       });
+    },
+    isRowSelectableByCondition(rowData) {
+      const cond = this.content.disableRowSelectionCondition;
+      if (!cond) return true;
+      let expr = cond.replace(/@([a-zA-Z0-9_çÇãÃáÁéÉíÍóÓúÚêÊôÔâÂàÀèÈìÌòÒùÙüÜñÑ]+)/g, (match, p1) => {
+        const val = rowData && rowData[p1];
+        if (val === undefined || val === null) return 'null';
+        if (typeof val === 'string') return `"${val.replace(/"/g, '\\"')}"`;
+        if (typeof val === 'boolean' || typeof val === 'number') return val;
+        return 'null';
+      });
+      expr = expr.replace(/\bAND\b/gi, '&&').replace(/\bOR\b/gi, '||');
+      expr = expr.replace(/([^=!<>])=([^=])/g, '$1===$2');
+      try {
+        return !eval(expr);
+      } catch (e) {
+        return true;
+      }
     },
     onRowClicked(event) {
       const colId = event.column && event.column.getColId && event.column.getColId();

--- a/Project/GridViewSimples/ww-config.js
+++ b/Project/GridViewSimples/ww-config.js
@@ -65,6 +65,7 @@ export default {
         "rowSelection",
         "enableClickSelection",
         "disableCheckboxes",
+        "showDisabledSelectionLockIcon",
         "selectAll",
         "selectAllRows",
         "disableRowSelectionCondition",
@@ -191,6 +192,17 @@ export default {
       type: "Title",
       label: "Selection",
       editorOnly: true,
+    },
+    showDisabledSelectionLockIcon: {
+      label: { en: "Show lock on disabled selection" },
+      type: "OnOff",
+      section: "settings",
+      defaultValue: true,
+      bindable: true,
+      propertyHelp: {
+        tooltip:
+          "Display a lock icon in rows where selection checkbox is disabled.",
+      },
     },
     layout: {
       type: "TextSelect",


### PR DESCRIPTION
### Motivation
- Add a visual indicator for rows that cannot be selected when using multi-row selection with checkboxes, and make selection logic reusable and maintainable.
- Expose the new UI toggle to enable/disable the lock icon from the component configuration.

### Description
- Added a new column renderer to `wwElement.vue` that appends a fixed-width `__lock_selection__` column showing a lock icon for rows that are not selectable when `rowSelection` is `multiple` and `showDisabledSelectionLockIcon` is not `false`.
- Extracted the selection condition evaluation into a new method `isRowSelectableByCondition` and updated `rowSelection.isRowSelectable` to delegate to it, consolidating the condition parsing and `eval` logic.
- Renamed the local column mapping to `mappedColumns` and return it after injecting the lock column when applicable in `columnDefs` in `wwElement.vue`.
- Added a new configurable property `showDisabledSelectionLockIcon` to `ww-config.js` and included it in `customSettingsPropertiesOrder` so editors can toggle the lock icon display.

### Testing
- Ran the project's automated unit tests and linters against the modified files; all checks passed.
- Built the project to ensure the component compiles; the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2921bff4833086a8e7d6699d097f)