### PR TITLE
Show lock icon for non-selectable rows and make it configurable; extract selection condition logic

### DIFF
--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -364,7 +364,7 @@ export default {
       };
     },
     columnDefs() {
-      return this.content.columns.map((col) => {
+      const mappedColumns = this.content.columns.map((col) => {
         
         // Forçar cellDataType para 'dateString' se for 'date' ou 'dateString'
         if (col.cellDataType === 'date') col.cellDataType = 'dateString';
@@ -551,6 +551,45 @@ export default {
           }
         }
       });
+
+      if (
+        this.content.showDisabledSelectionLockIcon !== false &&
+        this.content.rowSelection === "multiple" &&
+        !this.content.disableCheckboxes
+      ) {
+        mappedColumns.push({
+          colId: "__lock_selection__",
+          headerName: "",
+          width: 52,
+          minWidth: 52,
+          maxWidth: 52,
+          sortable: false,
+          filter: false,
+          resizable: false,
+          suppressNavigable: true,
+          lockPosition: true,
+          suppressHeaderContextMenu: true,
+          suppressHeaderMenuButton: true,
+          suppressCellFocus: true,
+          suppressColumnsToolPanel: true,
+          cellStyle: {
+            right: "5px",
+            textAlign: "center",
+            paddingLeft: "0",
+            paddingRight: "0",
+            overflow: "hidden",
+          },
+          cellRenderer: (params) => {
+            const selectable = this.isRowSelectableByCondition(params?.data);
+            const lockTitle = translatePhrase("The record cannot be deleted");
+            return selectable
+              ? ""
+              : `<span><i class="fa fa-lock" style="font-size:15px;line-height:1;" aria-hidden="true" title="${lockTitle}"></i></span>`;
+          },
+        });
+      }
+
+      return mappedColumns;
     },
     rowSelection() {
       if (this.content.rowSelection === "multiple") {
@@ -560,28 +599,7 @@ export default {
           headerCheckbox: !this.content.disableCheckboxes,
           selectAll: this.content.selectAll || "all",
           enableClickSelection: this.content.enableClickSelection,
-          isRowSelectable: (rowNode) => {
-            const cond = this.content.disableRowSelectionCondition;
-            if (!cond) return true;
-            let expr = cond.replace(/@([a-zA-Z0-9_çÇãÃáÁéÉíÍóÓúÚêÊôÔâÂàÀèÈìÌòÒùÙüÜñÑ]+)/g, (match, p1) => {
-              const val = rowNode.data && rowNode.data[p1];
-              if (val === undefined || val === null) return 'null';
-              if (typeof val === 'string') return `"${val.replace(/"/g, '\\"')}"`;
-              if (typeof val === 'boolean' || typeof val === 'number') return val;
-              return 'null';
-            });
-            // Troca operadores lógicos
-            expr = expr.replace(/\bAND\b/gi, '&&').replace(/\bOR\b/gi, '||');
-            // Troca apenas = isolado por ===
-            expr = expr.replace(/([^=!<>])=([^=])/g, '$1===$2');
-            // Não faz mais conversão de datas, pois o JSON já está em ISO
-            try {
-              return !eval(expr);
-            } catch (e) {
-              
-              return true;
-            }
-          }
+          isRowSelectable: (rowNode) => this.isRowSelectableByCondition(rowNode?.data),
         };
       } else if (this.content.rowSelection === "single") {
         return {
@@ -732,6 +750,24 @@ export default {
         event.api.setFocusedCell(nextRowIndex, targetColumn);
         event.api.startEditingCell(startEditParams);
       });
+    },
+    isRowSelectableByCondition(rowData) {
+      const cond = this.content.disableRowSelectionCondition;
+      if (!cond) return true;
+      let expr = cond.replace(/@([a-zA-Z0-9_çÇãÃáÁéÉíÍóÓúÚêÊôÔâÂàÀèÈìÌòÒùÙüÜñÑ]+)/g, (match, p1) => {
+        const val = rowData && rowData[p1];
+        if (val === undefined || val === null) return 'null';
+        if (typeof val === 'string') return `"${val.replace(/"/g, '\\"')}"`;
+        if (typeof val === 'boolean' || typeof val === 'number') return val;
+        return 'null';
+      });
+      expr = expr.replace(/\bAND\b/gi, '&&').replace(/\bOR\b/gi, '||');
+      expr = expr.replace(/([^=!<>])=([^=])/g, '$1===$2');
+      try {
+        return !eval(expr);
+      } catch (e) {
+        return true;
+      }
     },
     onRowClicked(event) {
       const colId = event.column && event.column.getColId && event.column.getColId();

--- a/Project/GridViewSimples/ww-config.js
+++ b/Project/GridViewSimples/ww-config.js
@@ -65,6 +65,7 @@ export default {
         "rowSelection",
         "enableClickSelection",
         "disableCheckboxes",
+        "showDisabledSelectionLockIcon",
         "selectAll",
         "selectAllRows",
         "disableRowSelectionCondition",
@@ -191,6 +192,17 @@ export default {
       type: "Title",
       label: "Selection",
       editorOnly: true,
+    },
+    showDisabledSelectionLockIcon: {
+      label: { en: "Show lock on disabled selection" },
+      type: "OnOff",
+      section: "settings",
+      defaultValue: true,
+      bindable: true,
+      propertyHelp: {
+        tooltip:
+          "Display a lock icon in rows where selection checkbox is disabled.",
+      },
     },
     layout: {
       type: "TextSelect",


### PR DESCRIPTION
### Motivation
- Visually indicate rows that cannot be selected in multi-select grids by showing a lock icon and make this behavior configurable.
- Centralize the logic that evaluates the row selection condition for reuse and clarity.
- Surface the new configuration option in the component configuration ordering for editor UI consistency.

### Description
- In `wwElement.vue` renamed the local column mapping to `mappedColumns` and return it at the end of `columnDefs`.
- Added a special read-only column (`__lock_selection__`) appended to `mappedColumns` when `this.content.showDisabledSelectionLockIcon !== false`, `rowSelection === "multiple"`, and checkboxes are enabled; the column renders a lock icon for rows that are not selectable.
- Extracted the previous inline expression evaluation into a new method `isRowSelectableByCondition(rowData)` and updated `rowSelection.isRowSelectable` to delegate to this method.
- Added the `showDisabledSelectionLockIcon` property to `ww-config.js` and included it in `customSettingsPropertiesOrder` so the option appears in the editor settings.

### Testing
- Ran lint via `npm run lint` and it completed successfully.
- Performed a project build via `npm run build` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2921bff4833086a8e7d6699d097f)