### PR TITLE
feat: adicionar componente ImportSpreadsheet (importação de planilhas para JSON)

### DIFF
--- a/Project/ImportSpreadsheet/src/wwElement.vue
+++ b/Project/ImportSpreadsheet/src/wwElement.vue
@@ -1,0 +1,185 @@
+<template>
+    <component
+        :is="tag"
+        class="ww-button"
+        :class="{ button: tag, '-link': hasLink && !isEditing, active: isActive }"
+        :type="buttonType"
+        :style="buttonStyle"
+        :disabled="content.disabled"
+        v-bind="properties"
+        @focus="isReallyFocused = true"
+        @blur="onBlur"
+        @mousedown="onMouseActivate"
+        @mouseup="onMouseDeactivate"
+        @mouseleave="onMouseDeactivate"
+        @keydown="onKeyDown"
+        @keyup="onKeyUp"
+        @click="onClick"
+    >
+        <wwElement v-if="content.hasLeftIcon && content.leftIcon" v-bind="content.leftIcon"></wwElement>
+        <wwText tag="span" :text="text"></wwText>
+        <wwElement v-if="content.hasRightIcon && content.rightIcon" v-bind="content.rightIcon"></wwElement>
+        <input ref="fileInput" type="file" accept=".csv,.xlsx,.xls" class="ww-button__file-input" @change="onFileChange" />
+    </component>
+</template>
+
+<script>
+import { computed } from 'vue';
+
+const TEXT_ALIGN_TO_JUSTIFY = {
+    center: 'center',
+    right: 'flex-end',
+    left: 'flex-start',
+    justify: 'center',
+};
+
+export default {
+    props: {
+        content: { type: Object, required: true },
+        uid: { type: String, required: false },
+        wwFrontState: { type: Object, required: true },
+        wwElementState: { type: Object, required: true },
+        wwEditorState: { type: Object, required: true },
+    },
+    emits: ['update:content', 'update:content:effect', 'add-state', 'remove-state', 'trigger-event'],
+    setup(props) {
+        const { createElement } = wwLib.useCreateElement();
+        const { hasLink, tag: linkTag, properties } = wwLib.wwElement.useLink({
+            isDisabled: computed(() => props.content.disabled),
+        });
+
+        const variable = wwLib?.wwVariable?.useComponentVariable
+            ? wwLib.wwVariable.useComponentVariable({
+                  uid: props.uid || props.wwElementState?.uid,
+                  name: 'importedData',
+                  type: 'array',
+                  defaultValue: [],
+              })
+            : null;
+
+        return {
+            createElement,
+            hasLink,
+            linkTag,
+            properties,
+            importedData: variable?.value || [],
+            setImportedData: variable?.setValue,
+        };
+    },
+    data() {
+        return { isReallyFocused: false, isReallyActive: false };
+    },
+    computed: {
+        buttonStyle() {
+            return { justifyContent: TEXT_ALIGN_TO_JUSTIFY[this.content['_ww-text_textAlign']] || 'center' };
+        },
+        isEditing() {
+            return this.wwEditorState.editMode === wwLib.wwEditorHelper.EDIT_MODES.EDITION;
+        },
+        tag() {
+            if (this.isEditing) return 'div';
+            if (this.hasLink) return this.linkTag;
+            return 'button';
+        },
+        buttonType() {
+            return this.isEditing || this.hasLink ? '' : 'button';
+        },
+        text() {
+            return this.wwElementState.props.text;
+        },
+        isActive() {
+            return this.isReallyActive;
+        },
+    },
+    methods: {
+        async onFileChange(event) {
+            const [file] = event?.target?.files || [];
+            if (!file) return;
+
+            try {
+                const parsedRows = await this.parseSpreadsheet(file);
+                if (!parsedRows.length) {
+                    this.notify('A planilha está vazia.', 'warning');
+                    return;
+                }
+
+                const [rawHeader, ...rawRows] = parsedRows;
+                const headers = rawHeader.map(header => String(header ?? '').trim());
+                if (!headers.some(Boolean)) {
+                    this.notify('A primeira linha da planilha deve conter os nomes das colunas.', 'warning');
+                    return;
+                }
+
+                const jsonData = rawRows
+                    .filter(row => row.some(value => value !== null && value !== undefined && String(value).trim() !== ''))
+                    .map(row => {
+                        const item = {};
+                        headers.forEach((header, index) => {
+                            if (!header) return;
+                            item[header] = row[index] ?? '';
+                        });
+                        return item;
+                    });
+
+                this.importedData = jsonData;
+                if (typeof this.setImportedData === 'function') {
+                    this.setImportedData(jsonData);
+                }
+
+                this.$emit('trigger-event', { name: 'import-success', event: { data: jsonData } });
+            } catch (error) {
+                this.notify(error?.message || 'Erro ao processar a planilha.');
+                this.$emit('trigger-event', { name: 'import-error', event: { error } });
+            } finally {
+                this.resetFileInput();
+            }
+        },
+        onBlur() { this.isReallyFocused = false; },
+        onMouseActivate() { this.isReallyActive = true; },
+        onMouseDeactivate() { this.isReallyActive = false; },
+        onKeyDown(event) { this.$emit('trigger-event', { name: 'keydown', event }); },
+        onKeyUp(event) { this.$emit('trigger-event', { name: 'keyup', event }); },
+        onClick(event) {
+            if (this.isEditing || this.content.disabled) return;
+            this.$emit('trigger-event', { name: 'click', event });
+            this.$refs.fileInput?.click();
+        },
+        async parseSpreadsheet(file) {
+            const name = file.name.toLowerCase();
+            if (name.endsWith('.csv')) {
+                const content = await file.text();
+                return this.parseCsv(content);
+            }
+
+            if ((name.endsWith('.xlsx') || name.endsWith('.xls')) && typeof window !== 'undefined' && window.XLSX) {
+                const buffer = await file.arrayBuffer();
+                const workbook = window.XLSX.read(buffer, { type: 'array' });
+                const firstSheetName = workbook.SheetNames[0];
+                const worksheet = workbook.Sheets[firstSheetName];
+                return window.XLSX.utils.sheet_to_json(worksheet, { header: 1, defval: '' });
+            }
+
+            throw new Error('Formato não suportado. Use CSV ou disponibilize XLSX no contexto da aplicação.');
+        },
+        parseCsv(content) {
+            return content
+                .split(/\r?\n/)
+                .filter(line => line.trim() !== '')
+                .map(line => line.split(',').map(part => part.trim()));
+        },
+        resetFileInput() {
+            if (this.$refs.fileInput) this.$refs.fileInput.value = '';
+        },
+        notify(message, type = 'error') {
+            if (wwLib?.wwNotification?.open) {
+                wwLib.wwNotification.open({ text: message, type, duration: 4000 });
+            }
+        },
+    },
+};
+</script>
+
+<style lang="scss" scoped>
+.ww-button { justify-content: center; align-items: center; }
+.ww-button__file-input { position: absolute; opacity: 0; pointer-events: none; width: 0; height: 0; }
+</style>

--- a/Project/ImportSpreadsheet/ww-config.js
+++ b/Project/ImportSpreadsheet/ww-config.js
@@ -1,0 +1,33 @@
+export default {
+    inherit: 'ww-text',
+    options: {
+        autoByContent: true,
+        displayAllowedValues: ['flex', 'inline-flex'],
+        linkable: true,
+    },
+    editor: {
+        label: { en: 'Import Spreadsheet', pt: 'Importar Planilha' },
+        icon: 'upload',
+    },
+    states: ['focus', 'disabled', 'active'],
+    triggerEvents: [
+        { name: 'click', label: { en: 'On click' }, event: null },
+        { name: 'keydown', label: { en: 'On key down' }, event: null },
+        { name: 'keyup', label: { en: 'On key up' }, event: null },
+        { name: 'import-success', label: { en: 'On import success' }, event: null },
+        { name: 'import-error', label: { en: 'On import error' }, event: null },
+    ],
+    properties: {
+        disabled: {
+            label: { en: 'Disabled' },
+            type: 'OnOff',
+            section: 'settings',
+            defaultValue: false,
+            bindable: true,
+        },
+        hasLeftIcon: { label: { en: 'Left icon' }, section: 'settings', type: 'OnOff' },
+        leftIcon: { hidden: true, isArray: false },
+        hasRightIcon: { label: { en: 'Right icon' }, type: 'OnOff', section: 'settings' },
+        rightIcon: { hidden: true, isArray: false },
+    },
+};


### PR DESCRIPTION
### Motivation
- Adicionar um componente derivado de `Project/ExportImportTranslate` que faça apenas importação de planilhas sem funcionalidade de exportação.
- Ao importar, converter uma planilha cuja primeira linha é o header em um `Array<Object>` (JSON), usando cada header como chave de campo, e expor esse resultado como variável do componente. 

### Description
- Adiciona o novo componente em `Project/ImportSpreadsheet/src/wwElement.vue` que abre um seletor de arquivo e aceita `.csv`, `.xlsx` e `.xls` e converte a planilha em linhas/colunas. 
- Implementa parsing CSV simples e suporte a XLS/XLSX quando `window.XLSX` estiver disponível, tratando a primeira linha como cabeçalho e filtrando linhas vazias para gerar o `Array<Object>`. 
- Salva o JSON resultante na variável do componente `importedData` usando `useComponentVariable` (valor público/interno) e emite eventos `import-success` e `import-error` ao finalizar. 
- Remove qualquer comportamento de exportação e fornece `ww-config.js` focado apenas em importação e eventos relevantes. 

### Testing
- Verifiquei que a nova pasta `Project/ImportSpreadsheet` foi criada e contém `src/wwElement.vue` e `ww-config.js`, e que os arquivos têm o conteúdo esperado (inspeção de arquivos concluída com sucesso). 
- Realizei uma checagem de status do repositório para confirmar a presença do novo diretório (checagem concluída com sucesso). 
- Gerei o PR usando a ferramenta interna `make_pr` e a operação relatou criação bem-sucedida (PR gerado com sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4ad728b08330b578e028a18735a3)