### PR TITLE
feat(GridViewDinamica): agrupar opções do dropdown de `getStatus` por `class_name` com grupos expansíveis

### DIFF
--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -163,6 +163,40 @@
   justify-content: flex-start;
 }
 
+:is(.list-filter, .list-editor) .filter-group {
+  margin-bottom: 6px;
+}
+
+:is(.list-filter, .list-editor) .filter-group-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 8px;
+  color: #2f2f2f;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+}
+
+:is(.list-filter, .list-editor) .filter-group-header:hover {
+  background: #f6f7fa;
+}
+
+:is(.list-filter, .list-editor) .filter-group .group-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:is(.list-filter, .list-editor) .filter-group .filter-group-options {
+  padding-left: 18px;
+}
+
 
 :is(.list-filter, .list-editor) .filter-item input[type="checkbox"] {
   width: 16px;

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -104,6 +104,10 @@
       const identifier = (params.colDef.FieldDB || '').toString().toUpperCase();
       const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
       this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+      const dataSourceConfig = params.colDef?.dataSource?.dataSource || params.colDef?.dataSource || {};
+      this.enableGroupedStatusOptions =
+        String(dataSourceConfig?.functionName || '').trim().toLowerCase() === 'getstatus';
+      this.groupExpandedState = {};
 
       // Build option array (supports promises)
       const normalize = opt =>
@@ -112,6 +116,9 @@
       const resolveOptions = arr => {
         this.options = (arr || []).map(normalize);
         this.filteredOptions = [...this.options];
+        if (this.enableGroupedStatusOptions) {
+          this.initializeGroupExpandedState(this.options);
+        }
         this.renderOptions();
       };
 
@@ -167,6 +174,32 @@
         const label = this.stripHtml(String(this.formatOption(opt)));
         return label.toLowerCase().includes(t);
       });
+      if (this.enableGroupedStatusOptions) {
+        this.ensureKnownGroups(this.filteredOptions);
+      }
+      this.renderOptions();
+    }
+    getGroupName(opt) {
+      const groupName = opt?.class_name;
+      if (groupName == null || String(groupName).trim() === '') {
+        return translatePhrase('Ungrouped');
+      }
+      return String(groupName);
+    }
+    initializeGroupExpandedState(options) {
+      this.groupExpandedState = {};
+      this.ensureKnownGroups(options, true);
+    }
+    ensureKnownGroups(options, defaultExpanded = false) {
+      (options || []).forEach(opt => {
+        const groupName = this.getGroupName(opt);
+        if (this.groupExpandedState[groupName] === undefined) {
+          this.groupExpandedState[groupName] = defaultExpanded;
+        }
+      });
+    }
+    toggleGroup(groupName) {
+      this.groupExpandedState[groupName] = !this.groupExpandedState[groupName];
       this.renderOptions();
     }
     stripHtml(html) {
@@ -280,6 +313,45 @@
       }
     }
     renderOptions() {
+      if (this.enableGroupedStatusOptions) {
+        const groups = this.filteredOptions.reduce((acc, opt) => {
+          const groupName = this.getGroupName(opt);
+          if (!acc[groupName]) acc[groupName] = [];
+          acc[groupName].push(opt);
+          return acc;
+        }, {});
+
+        const html = Object.entries(groups)
+          .map(([groupName, options]) => {
+            const expanded = this.groupExpandedState[groupName] === true;
+            const caret = expanded ? 'expand_more' : 'chevron_right';
+            const childrenHtml = expanded
+              ? options
+                  .map(opt => {
+                    const formatted = this.formatOption(opt);
+                    const selected = opt.value == this.value ? ' selected' : '';
+                    return `<div class="filter-item grouped-option${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+                  })
+                  .join('')
+              : '';
+            return `<div class="filter-group">
+              <button type="button" class="filter-group-header" data-group="${groupName}">
+                <span class="material-symbols-outlined">${caret}</span>
+                <span class="group-title">${groupName}</span>
+              </button>
+              <div class="filter-group-options">${childrenHtml}</div>
+            </div>`;
+          })
+          .join('');
+
+        this.listEl.innerHTML = html;
+        this.listEl.querySelectorAll('.filter-group-header').forEach(el => {
+          el.addEventListener('click', () => {
+            const groupName = el.getAttribute('data-group');
+            this.toggleGroup(groupName);
+          });
+        });
+      } else {
       this.listEl.innerHTML = this.filteredOptions
         .map(opt => {
           const formatted = this.formatOption(opt);
@@ -287,6 +359,7 @@
           return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
         })
         .join('');
+      }
       this.listEl.querySelectorAll('.filter-item').forEach(el => {
         el.addEventListener('click', () => {
           const selectedValue = el.getAttribute('data-value');


### PR DESCRIPTION
### Motivation
- Permitir que dropdowns alimentados pela função `getStatus` exibam opções agrupadas pela propriedade `class_name` para facilitar a navegação visual das opções de status.
- Garantir que o nome do grupo (`class_name`) sirva apenas como cabeçalho não selecionável e que as opções permaneçam selecionáveis individualmente.
- Manter a busca e o filtro funcionando sobre as opções, mesmo quando agrupadas, e oferecer controle de expandir/recolher por grupo.

### Description
- Detecta quando a coluna usa `dataSource.functionName = getStatus` (incluindo caso aninhado em `dataSource.dataSource`) e ativa `enableGroupedStatusOptions` no `ListCellEditor` em `Project/GridViewDinamica/src/wwElement.vue`.
- Introduz estado e utilitários para agrupamento: `groupExpandedState`, `getGroupName`, `initializeGroupExpandedState`, `ensureKnownGroups` e `toggleGroup`, além de ajustar `filterOptions` para manter os grupos conhecidos.
- Substitui a renderização plana em `renderOptions()` por uma renderização por grupos que cria cabeçalhos (`.filter-group-header`) não selecionáveis e listas de opções filhas clicáveis, com handlers para expandir/recolher grupos.
- Adiciona estilos CSS para suportar os novos elementos (`.filter-group`, `.filter-group-header`, `.group-title`, `.filter-group-options`) em `Project/GridViewDinamica/src/components/list-filter.css`.

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7f93ab508330987462f027ee27d3)