### PR TITLE
Add grouped, collapsible status option lists to list editors

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -36,6 +36,9 @@ export default class FixedListCellEditor {
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
     const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
     this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+    this.isStatusField = tag === 'STATUSID' || identifier === 'STATUSID';
+    this.groupedByClassName = this.isStatusField;
+    this.groupExpandedState = {};
 
 
     // Fixed list options (supports promises)
@@ -47,6 +50,9 @@ export default class FixedListCellEditor {
 
       this.options = (arr || []).map(normalize);
       this.filteredOptions = [...this.options];
+      if (this.groupedByClassName) {
+        this.initializeGroupExpandedState(this.options);
+      }
       this.renderOptions();
     };
 
@@ -248,6 +254,36 @@ export default class FixedListCellEditor {
       const label = this.stripHtml(String(this.formatOption(opt)));
       return label.toLowerCase().includes(t);
     });
+    if (this.groupedByClassName) {
+      this.ensureKnownGroups(this.filteredOptions);
+    }
+    this.renderOptions();
+  }
+
+  getGroupName(opt) {
+    const groupName = opt?.class_name;
+    if (groupName == null || String(groupName).trim() === '') {
+      return translatePhrase('Ungrouped');
+    }
+    return String(groupName);
+  }
+
+  initializeGroupExpandedState(options) {
+    this.groupExpandedState = {};
+    this.ensureKnownGroups(options, true);
+  }
+
+  ensureKnownGroups(options, defaultExpanded = false) {
+    (options || []).forEach(opt => {
+      const groupName = this.getGroupName(opt);
+      if (this.groupExpandedState[groupName] === undefined) {
+        this.groupExpandedState[groupName] = defaultExpanded;
+      }
+    });
+  }
+
+  toggleGroup(groupName) {
+    this.groupExpandedState[groupName] = !this.groupExpandedState[groupName];
     this.renderOptions();
   }
 
@@ -322,6 +358,43 @@ export default class FixedListCellEditor {
   }
 
   renderOptions() {
+    if (this.groupedByClassName) {
+      const groups = this.filteredOptions.reduce((acc, opt) => {
+        const groupName = this.getGroupName(opt);
+        if (!acc[groupName]) acc[groupName] = [];
+        acc[groupName].push(opt);
+        return acc;
+      }, {});
+
+      this.listEl.innerHTML = Object.entries(groups)
+        .map(([groupName, groupOptions]) => {
+          const expanded = this.groupExpandedState[groupName] === true;
+          const caret = expanded ? 'expand_more' : 'chevron_right';
+          const optionsHtml = expanded
+            ? groupOptions
+                .map(opt => {
+                  const formatted = this.formatOption(opt);
+                  const selected = opt.value == this.value ? ' selected' : '';
+                  return `<div class="filter-item grouped-option${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+                })
+                .join('')
+            : '';
+          return `<div class="filter-group">
+              <button type="button" class="filter-group-header" data-group="${groupName}">
+                <span class="material-symbols-outlined">${caret}</span>
+                <span class="group-title">${groupName}</span>
+              </button>
+              <div class="filter-group-options">${optionsHtml}</div>
+            </div>`;
+        })
+        .join('');
+
+      this.listEl.querySelectorAll('.filter-group-header').forEach(el => {
+        el.addEventListener('click', () => {
+          this.toggleGroup(el.getAttribute('data-group'));
+        });
+      });
+    } else {
     this.listEl.innerHTML = this.filteredOptions
       .map(opt => {
         const formatted = this.formatOption(opt);
@@ -345,6 +418,7 @@ export default class FixedListCellEditor {
         return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
       })
       .join('');
+    }
     this.listEl.querySelectorAll('.filter-item').forEach(el => {
       el.addEventListener('click', () => {
         const selectedValue = el.getAttribute('data-value');

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -163,6 +163,40 @@
   justify-content: flex-start;
 }
 
+:is(.list-filter, .list-editor) .filter-group {
+  margin-bottom: 6px;
+}
+
+:is(.list-filter, .list-editor) .filter-group-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 8px;
+  color: #2f2f2f;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+}
+
+:is(.list-filter, .list-editor) .filter-group-header:hover {
+  background: #f6f7fa;
+}
+
+:is(.list-filter, .list-editor) .filter-group .group-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:is(.list-filter, .list-editor) .filter-group .filter-group-options {
+  padding-left: 18px;
+}
+
 
 :is(.list-filter, .list-editor) .filter-item input[type="checkbox"] {
   width: 16px;

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -104,6 +104,10 @@
       const identifier = (params.colDef.FieldDB || '').toString().toUpperCase();
       const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
       this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+      const dataSourceConfig = params.colDef?.dataSource?.dataSource || params.colDef?.dataSource || {};
+      this.enableGroupedStatusOptions =
+        String(dataSourceConfig?.functionName || '').trim().toLowerCase() === 'getstatus';
+      this.groupExpandedState = {};
 
       // Build option array (supports promises)
       const normalize = opt =>
@@ -112,6 +116,9 @@
       const resolveOptions = arr => {
         this.options = (arr || []).map(normalize);
         this.filteredOptions = [...this.options];
+        if (this.enableGroupedStatusOptions) {
+          this.initializeGroupExpandedState(this.options);
+        }
         this.renderOptions();
       };
 
@@ -167,6 +174,32 @@
         const label = this.stripHtml(String(this.formatOption(opt)));
         return label.toLowerCase().includes(t);
       });
+      if (this.enableGroupedStatusOptions) {
+        this.ensureKnownGroups(this.filteredOptions);
+      }
+      this.renderOptions();
+    }
+    getGroupName(opt) {
+      const groupName = opt?.class_name;
+      if (groupName == null || String(groupName).trim() === '') {
+        return translatePhrase('Ungrouped');
+      }
+      return String(groupName);
+    }
+    initializeGroupExpandedState(options) {
+      this.groupExpandedState = {};
+      this.ensureKnownGroups(options, true);
+    }
+    ensureKnownGroups(options, defaultExpanded = false) {
+      (options || []).forEach(opt => {
+        const groupName = this.getGroupName(opt);
+        if (this.groupExpandedState[groupName] === undefined) {
+          this.groupExpandedState[groupName] = defaultExpanded;
+        }
+      });
+    }
+    toggleGroup(groupName) {
+      this.groupExpandedState[groupName] = !this.groupExpandedState[groupName];
       this.renderOptions();
     }
     stripHtml(html) {
@@ -280,6 +313,45 @@
       }
     }
     renderOptions() {
+      if (this.enableGroupedStatusOptions) {
+        const groups = this.filteredOptions.reduce((acc, opt) => {
+          const groupName = this.getGroupName(opt);
+          if (!acc[groupName]) acc[groupName] = [];
+          acc[groupName].push(opt);
+          return acc;
+        }, {});
+
+        const html = Object.entries(groups)
+          .map(([groupName, options]) => {
+            const expanded = this.groupExpandedState[groupName] === true;
+            const caret = expanded ? 'expand_more' : 'chevron_right';
+            const childrenHtml = expanded
+              ? options
+                  .map(opt => {
+                    const formatted = this.formatOption(opt);
+                    const selected = opt.value == this.value ? ' selected' : '';
+                    return `<div class="filter-item grouped-option${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+                  })
+                  .join('')
+              : '';
+            return `<div class="filter-group">
+              <button type="button" class="filter-group-header" data-group="${groupName}">
+                <span class="material-symbols-outlined">${caret}</span>
+                <span class="group-title">${groupName}</span>
+              </button>
+              <div class="filter-group-options">${childrenHtml}</div>
+            </div>`;
+          })
+          .join('');
+
+        this.listEl.innerHTML = html;
+        this.listEl.querySelectorAll('.filter-group-header').forEach(el => {
+          el.addEventListener('click', () => {
+            const groupName = el.getAttribute('data-group');
+            this.toggleGroup(groupName);
+          });
+        });
+      } else {
       this.listEl.innerHTML = this.filteredOptions
         .map(opt => {
           const formatted = this.formatOption(opt);
@@ -287,6 +359,7 @@
           return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
         })
         .join('');
+      }
       this.listEl.querySelectorAll('.filter-item').forEach(el => {
         el.addEventListener('click', () => {
           const selectedValue = el.getAttribute('data-value');


### PR DESCRIPTION
### Motivation
- Enable grouped presentation for status-like option lists so status values can be shown under `class_name` groups.  
- Improve usability for long status lists by allowing expand/collapse per group in the inline list editor and cell editor components.  

### Description
- Added grouping support keyed by option `class_name` with helper methods `getGroupName`, `initializeGroupExpandedState`, `ensureKnownGroups`, and `toggleGroup` in `FixedListCellEditor.js` and `wwElement.vue`.  
- Detect when grouping should be enabled: in `FixedListCellEditor` when `TagControl`/`FieldDB` is `STATUSID`, and in `wwElement.vue` when `dataSource.functionName` equals `getStatus`; both components maintain `groupExpandedState` and initialize groups when options load.  
- Render grouped UI in `renderOptions` with group headers showing a caret icon and expandable group children, and wire header clicks to toggle expand/collapse; item click behavior remains unchanged.  
- Added CSS rules in `list-filter.css` for `.filter-group`, `.filter-group-header`, `.group-title`, and `.filter-group-options` to support the new grouped layout and hover states.  

### Testing
- Ran project build with `npm run build` and the build completed successfully.  
- Executed test suite with `npm test` and the automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7f93ab508330987462f027ee27d3)