### PR TITLE
Support grouped Status options in list editors and filters

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -36,6 +36,9 @@ export default class FixedListCellEditor {
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
     const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
     this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+    this.isStatusField = tag === 'STATUSID' || identifier === 'STATUSID';
+    this.groupedByClassName = this.isStatusField;
+    this.groupExpandedState = {};
 
 
     // Fixed list options (supports promises)
@@ -47,6 +50,9 @@ export default class FixedListCellEditor {
 
       this.options = (arr || []).map(normalize);
       this.filteredOptions = [...this.options];
+      if (this.groupedByClassName) {
+        this.initializeGroupExpandedState(this.options);
+      }
       this.renderOptions();
     };
 
@@ -248,6 +254,36 @@ export default class FixedListCellEditor {
       const label = this.stripHtml(String(this.formatOption(opt)));
       return label.toLowerCase().includes(t);
     });
+    if (this.groupedByClassName) {
+      this.ensureKnownGroups(this.filteredOptions);
+    }
+    this.renderOptions();
+  }
+
+  getGroupName(opt) {
+    const groupName = opt?.class_name;
+    if (groupName == null || String(groupName).trim() === '') {
+      return translatePhrase('Ungrouped');
+    }
+    return String(groupName);
+  }
+
+  initializeGroupExpandedState(options) {
+    this.groupExpandedState = {};
+    this.ensureKnownGroups(options, true);
+  }
+
+  ensureKnownGroups(options, defaultExpanded = false) {
+    (options || []).forEach(opt => {
+      const groupName = this.getGroupName(opt);
+      if (this.groupExpandedState[groupName] === undefined) {
+        this.groupExpandedState[groupName] = defaultExpanded;
+      }
+    });
+  }
+
+  toggleGroup(groupName) {
+    this.groupExpandedState[groupName] = !this.groupExpandedState[groupName];
     this.renderOptions();
   }
 
@@ -322,6 +358,43 @@ export default class FixedListCellEditor {
   }
 
   renderOptions() {
+    if (this.groupedByClassName) {
+      const groups = this.filteredOptions.reduce((acc, opt) => {
+        const groupName = this.getGroupName(opt);
+        if (!acc[groupName]) acc[groupName] = [];
+        acc[groupName].push(opt);
+        return acc;
+      }, {});
+
+      this.listEl.innerHTML = Object.entries(groups)
+        .map(([groupName, groupOptions]) => {
+          const expanded = this.groupExpandedState[groupName] === true;
+          const caret = expanded ? 'expand_more' : 'chevron_right';
+          const optionsHtml = expanded
+            ? groupOptions
+                .map(opt => {
+                  const formatted = this.formatOption(opt);
+                  const selected = opt.value == this.value ? ' selected' : '';
+                  return `<div class="filter-item grouped-option${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+                })
+                .join('')
+            : '';
+          return `<div class="filter-group">
+              <button type="button" class="filter-group-header" data-group="${groupName}">
+                <span class="material-symbols-outlined">${caret}</span>
+                <span class="group-title">${groupName}</span>
+              </button>
+              <div class="filter-group-options">${optionsHtml}</div>
+            </div>`;
+        })
+        .join('');
+
+      this.listEl.querySelectorAll('.filter-group-header').forEach(el => {
+        el.addEventListener('click', () => {
+          this.toggleGroup(el.getAttribute('data-group'));
+        });
+      });
+    } else {
     this.listEl.innerHTML = this.filteredOptions
       .map(opt => {
         const formatted = this.formatOption(opt);
@@ -345,6 +418,7 @@ export default class FixedListCellEditor {
         return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
       })
       .join('');
+    }
     this.listEl.querySelectorAll('.filter-item').forEach(el => {
       el.addEventListener('click', () => {
         const selectedValue = el.getAttribute('data-value');

--- a/Project/GridViewDinamica/src/components/ListFilterRenderer.js
+++ b/Project/GridViewDinamica/src/components/ListFilterRenderer.js
@@ -8,6 +8,8 @@ export default class ListFilterRenderer {
     this.filteredValues = [];
     this.selectAll = false;
     this.formattedValues = [];
+    this.groupByRawKey = new Map();
+    this.groupExpandedState = {};
     this.rendererConfig = {};
     this.statusLookupMap = null;
     this.isStatusField = false;
@@ -383,7 +385,7 @@ export default class ListFilterRenderer {
       const rawValue = opt.value;
       const display = opt.label != null ? opt.label : opt.value;
       const formatted = this.formatDisplayValue(this.ensureDisplayText(display), colDef);
-      return { raw: rawValue, formatted };
+      return { raw: rawValue, formatted, groupName: opt.class_name };
     });
 
     const uniqueMap = new Map();
@@ -399,6 +401,13 @@ export default class ListFilterRenderer {
 
     this.allValues = unique.map(item => item.raw);
     this.formattedValues = unique.map(item => item.formatted);
+    this.groupByRawKey = new Map(
+      unique.map(item => [this.buildRawKey(item.raw), item.groupName || translatePhrase('Ungrouped')])
+    );
+    this.groupExpandedState = {};
+    this.groupByRawKey.forEach(groupName => {
+      if (this.groupExpandedState[groupName] === undefined) this.groupExpandedState[groupName] = true;
+    });
     this.filteredValues = [...this.allValues];
     this.selectedValues = this.selectedValues.map(value => this.resolveRawValue(value));
     return true;
@@ -563,10 +572,11 @@ export default class ListFilterRenderer {
       return {
         value: normalizedValue,
         label: normalizedLabel,
+        class_name: opt.class_name ?? opt.className ?? opt.class ?? null,
       };
     }
 
-    return { value: opt, label: opt == null ? '' : String(opt) };
+    return { value: opt, label: opt == null ? '' : String(opt), class_name: null };
   }
 
   formatDisplayValue(display, colDef) {
@@ -714,11 +724,12 @@ export default class ListFilterRenderer {
       return {
         value: normalizedValue,
         label: normalizedLabel,
+        class_name: opt.class_name ?? opt.className ?? opt.class ?? null,
       };
     }
 
 
-    return { value: opt, label: opt == null ? '' : String(opt) };
+    return { value: opt, label: opt == null ? '' : String(opt), class_name: null };
   }
 
   formatDisplayValue(display, colDef) {
@@ -876,7 +887,7 @@ export default class ListFilterRenderer {
       this.filteredValues.length > 0 &&
       this.filteredValues.every(v => this.selectedValues.includes(v));
 
-    this.filterList.innerHTML = this.filteredValues.map((rawValue) => {
+    const renderItem = rawValue => {
       const idx = this.allValues.indexOf(rawValue);
       const formattedValue = this.formattedValues[idx] || rawValue;
       const checked = this.selectedValues.includes(rawValue) ? 'checked' : '';
@@ -888,7 +899,40 @@ export default class ListFilterRenderer {
           <span class="filter-label" title="${title}">${formattedValue}</span>
         </label>
       `;
-    }).join('');
+    };
+
+    const hasGroupedStatus = this.isStatusField && this.groupByRawKey && this.groupByRawKey.size > 0;
+    if (hasGroupedStatus) {
+      const grouped = this.filteredValues.reduce((acc, rawValue) => {
+        const groupName = this.groupByRawKey.get(this.buildRawKey(rawValue)) || translatePhrase('Ungrouped');
+        if (!acc[groupName]) acc[groupName] = [];
+        acc[groupName].push(rawValue);
+        return acc;
+      }, {});
+
+      this.filterList.innerHTML = Object.entries(grouped).map(([groupName, values]) => {
+        const expanded = this.groupExpandedState[groupName] !== false;
+        const caret = expanded ? 'expand_more' : 'chevron_right';
+        const content = expanded ? values.map(renderItem).join('') : '';
+        return `<div class="filter-group">
+          <button type="button" class="filter-group-header" data-group="${groupName}">
+            <span class="material-symbols-outlined">${caret}</span>
+            <span class="group-title">${groupName}</span>
+          </button>
+          <div class="filter-group-options">${content}</div>
+        </div>`;
+      }).join('');
+
+      this.filterList.querySelectorAll('.filter-group-header').forEach(header => {
+        header.addEventListener('click', () => {
+          const groupName = header.getAttribute('data-group');
+          this.groupExpandedState[groupName] = !this.groupExpandedState[groupName];
+          this.renderFilterList();
+        });
+      });
+    } else {
+      this.filterList.innerHTML = this.filteredValues.map(renderItem).join('');
+    }
 
     this.filterList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
       checkbox.addEventListener('change', (e) => {

--- a/Project/GridViewDinamica/src/components/list-filter.css
+++ b/Project/GridViewDinamica/src/components/list-filter.css
@@ -163,6 +163,40 @@
   justify-content: flex-start;
 }
 
+:is(.list-filter, .list-editor) .filter-group {
+  margin-bottom: 6px;
+}
+
+:is(.list-filter, .list-editor) .filter-group-header {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  padding: 6px 8px;
+  border-radius: 8px;
+  color: #2f2f2f;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+}
+
+:is(.list-filter, .list-editor) .filter-group-header:hover {
+  background: #f6f7fa;
+}
+
+:is(.list-filter, .list-editor) .filter-group .group-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+:is(.list-filter, .list-editor) .filter-group .filter-group-options {
+  padding-left: 18px;
+}
+
 
 :is(.list-filter, .list-editor) .filter-item input[type="checkbox"] {
   width: 16px;

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -104,6 +104,10 @@
       const identifier = (params.colDef.FieldDB || '').toString().toUpperCase();
       const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
       this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+      const dataSourceConfig = params.colDef?.dataSource?.dataSource || params.colDef?.dataSource || {};
+      this.enableGroupedStatusOptions =
+        String(dataSourceConfig?.functionName || '').trim().toLowerCase() === 'getstatus';
+      this.groupExpandedState = {};
 
       // Build option array (supports promises)
       const normalize = opt =>
@@ -112,6 +116,9 @@
       const resolveOptions = arr => {
         this.options = (arr || []).map(normalize);
         this.filteredOptions = [...this.options];
+        if (this.enableGroupedStatusOptions) {
+          this.initializeGroupExpandedState(this.options);
+        }
         this.renderOptions();
       };
 
@@ -167,6 +174,32 @@
         const label = this.stripHtml(String(this.formatOption(opt)));
         return label.toLowerCase().includes(t);
       });
+      if (this.enableGroupedStatusOptions) {
+        this.ensureKnownGroups(this.filteredOptions);
+      }
+      this.renderOptions();
+    }
+    getGroupName(opt) {
+      const groupName = opt?.class_name;
+      if (groupName == null || String(groupName).trim() === '') {
+        return translatePhrase('Ungrouped');
+      }
+      return String(groupName);
+    }
+    initializeGroupExpandedState(options) {
+      this.groupExpandedState = {};
+      this.ensureKnownGroups(options, true);
+    }
+    ensureKnownGroups(options, defaultExpanded = false) {
+      (options || []).forEach(opt => {
+        const groupName = this.getGroupName(opt);
+        if (this.groupExpandedState[groupName] === undefined) {
+          this.groupExpandedState[groupName] = defaultExpanded;
+        }
+      });
+    }
+    toggleGroup(groupName) {
+      this.groupExpandedState[groupName] = !this.groupExpandedState[groupName];
       this.renderOptions();
     }
     stripHtml(html) {
@@ -280,6 +313,45 @@
       }
     }
     renderOptions() {
+      if (this.enableGroupedStatusOptions) {
+        const groups = this.filteredOptions.reduce((acc, opt) => {
+          const groupName = this.getGroupName(opt);
+          if (!acc[groupName]) acc[groupName] = [];
+          acc[groupName].push(opt);
+          return acc;
+        }, {});
+
+        const html = Object.entries(groups)
+          .map(([groupName, options]) => {
+            const expanded = this.groupExpandedState[groupName] === true;
+            const caret = expanded ? 'expand_more' : 'chevron_right';
+            const childrenHtml = expanded
+              ? options
+                  .map(opt => {
+                    const formatted = this.formatOption(opt);
+                    const selected = opt.value == this.value ? ' selected' : '';
+                    return `<div class="filter-item grouped-option${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+                  })
+                  .join('')
+              : '';
+            return `<div class="filter-group">
+              <button type="button" class="filter-group-header" data-group="${groupName}">
+                <span class="material-symbols-outlined">${caret}</span>
+                <span class="group-title">${groupName}</span>
+              </button>
+              <div class="filter-group-options">${childrenHtml}</div>
+            </div>`;
+          })
+          .join('');
+
+        this.listEl.innerHTML = html;
+        this.listEl.querySelectorAll('.filter-group-header').forEach(el => {
+          el.addEventListener('click', () => {
+            const groupName = el.getAttribute('data-group');
+            this.toggleGroup(groupName);
+          });
+        });
+      } else {
       this.listEl.innerHTML = this.filteredOptions
         .map(opt => {
           const formatted = this.formatOption(opt);
@@ -287,6 +359,7 @@
           return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
         })
         .join('');
+      }
       this.listEl.querySelectorAll('.filter-item').forEach(el => {
         el.addEventListener('click', () => {
           const selectedValue = el.getAttribute('data-value');


### PR DESCRIPTION
### Motivation
- Provide grouped display and collapsing behavior for status-like option sets that include a `class_name` grouping, improving usability for long status lists.
- Reuse grouping across the fixed list cell editor, inline list editor (`wwElement`), and the list filter renderer so status options appear consistently in editors and filters.

### Description
- Added detection of status/list grouping and preserved a `groupExpandedState` across `FixedListCellEditor`, `ListFilterRenderer`, and `wwElement`, plus helper methods `getGroupName`, `ensureKnownGroups`, `initializeGroupExpandedState`, and `toggleGroup` to manage group expansion state and names.
- Extended option normalization to capture `class_name` (falling back to `className`/`class`) and wired a `groupByRawKey` map in `ListFilterRenderer` to map raw values to group names, defaulting to the translated `Ungrouped` label when absent.
- Updated rendering logic in `renderOptions`/`renderFilterList` to output grouped DOM structure with collapsible group headers and to attach click handlers that toggle expansion and re-render the list; preserved previous behavior for non-grouped fields.
- Added CSS rules in `list-filter.css` for `.filter-group`, `.filter-group-header`, `.group-title`, and `.filter-group-options` to style group headers and nested option areas.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc7f93ab508330987462f027ee27d3)