### PR TITLE
Expose changed field data in FormRender `fieldsUpdated` trigger

### DIFF
--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -311,7 +311,7 @@ export default {
         {
             name: 'fieldsUpdated',
             label: { en: 'On fields updated' },
-            event: { value: [] }
+            event: { value: [], changedField: null }
         },
         {
             name: 'formUpdated',

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -263,7 +263,7 @@ export default {
     };
 
     const updateFormState = (options) => {
-      const { forceRerender = true } = options || {};
+      const { forceRerender = true, changedField = null } = options || {};
       try {
         const formState = {
           sections: formSections.value.map(section => ({
@@ -287,7 +287,8 @@ export default {
         emit('trigger-event', {
           name: 'fieldsUpdated',
           event: {
-            value: formState.sections.flatMap(section => section.fields)
+            value: formState.sections.flatMap(section => section.fields),
+            changedField
           }
         });
 
@@ -364,7 +365,7 @@ export default {
         const field = section.fields.find(f => f.id === fieldId || f.field_id === fieldId || f.ID === fieldId);
         if (field) {
           field.value = value;
-          updateFormState({ forceRerender: false });
+          updateFormState({ forceRerender: false, changedField: { ...field } });
         }
       }
     };


### PR DESCRIPTION
### Motivation
- Permitir que consumidores do evento `fieldsUpdated` saibam qual campo específico disparou a atualização para habilitar automações e decisões condicionais mais precisas.
- Manter compatibilidade com a payload atual enquanto adiciona informação adicional útil (`changedField`) sem alterar o formato principal de `value`.

### Description
- Atualizei `Project/FormRender/Component/wwElement.vue` para que `updateFormState` aceite a opção `changedField` e inclua `changedField` no payload do trigger `fieldsUpdated` (`{ value, changedField }`).
- Modifiquei `onFieldValueChange` para passar um snapshot do campo alterado ao chamar `updateFormState` (`updateFormState({ forceRerender: false, changedField: { ...field } })`).
- Atualizei `Project/FormRender/Component/ww-config.js` para documentar o novo campo do evento adicionando `changedField: null` no objeto `triggerEvents` para `fieldsUpdated`.

### Testing
- Nenhum teste automatizado foi executado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc8cab8a8833086c030c1a1854c78)