### PR TITLE
feat(timeline): render SLAUpdated entries with old/new value transition

### DIFF
--- a/Project/TimeLine/src/wwElement.vue
+++ b/Project/TimeLine/src/wwElement.vue
@@ -66,6 +66,36 @@
               </div>
             </template>
 
+            <!-- SLAUpdated -->
+            <template v-else-if="(item.TagControl || item.tagControl) === 'SLAUpdated'">
+              <div class="activity-added-card">
+                <div class="activity-added-card__left">
+                  <div class="activity-added-card__title">{{ item.Title }}</div>
+                  <div class="activity-added-card__subtitle">
+                    {{ item.NameFieldModified }}
+                  </div>
+                  <dl class="activity-added-card__list">
+                    <div class="row value-change">
+                      <dt></dt>
+                      <dd class="value-change__values">
+                        <span class="value-chip old">
+                          {{ item.OldValueTitle }}
+                        </span>
+                        <i class="material-symbols-outlined arrow">arrow_forward</i>
+                        <span class="value-chip new">
+                          {{ item.NewValueTitle }}
+                        </span>
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+                <div class="activity-added-card__right">
+                  <div class="activity-added-card__created-by">{{ item.CreatedByName }}</div>
+                  <div class="activity-added-card__created-date">{{ formatDateDash(item.CreatedDate) }}</div>
+                </div>
+              </div>
+            </template>
+
             <!-- FieldUpdated -->
             <template v-else-if="(item.TagControl || item.tagControl) === 'FieldUpdated'">
               <!-- FORMATED_TEXT -->


### PR DESCRIPTION
### Motivation
- SLA change events need a dedicated presentation in the timeline to show the changed field label and a clear Old→New value transition as requested.
- The generic `FieldUpdated` rendering does not match the desired layout for `SLAUpdated` entries, so a specific branch is required.

### Description
- Added a new rendering branch for `SLAUpdated` in `Project/TimeLine/src/wwElement.vue` that triggers when `(item.TagControl || item.tagControl) === 'SLAUpdated'`.
- The block displays the event `Title`, the changed field (`NameFieldModified`) and a value row with `OldValueTitle`, an arrow icon, and `NewValueTitle` using the existing `value-chip` styling.
- The right side retains the metadata: `CreatedByName` and formatted `CreatedDate` via `formatDateDash` to match other timeline entries.
- The change is self-contained and preserves existing `FieldUpdated` behavior.

### Testing
- Repository checks with `git -C /workspace/NewCode status --short` completed successfully.
- The change file was staged and committed with `git -C /workspace/NewCode add Project/TimeLine/src/wwElement.vue` and `git -C /workspace/NewCode commit -m "feat(timeline): add SLAUpdated rendering block"` and the commit succeeded.
- No automated unit or integration test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcda86ab84833093edbe1be6076e29)