### PR TITLE
Add Clear links to FormBuilder dropdowns (header and form fields)

### DIFF
--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -179,6 +179,15 @@
                 autofocus
               />
             </div>
+            <button
+              type="button"
+              class="dropdown-clear-link"
+              @click.stop="clearDropdownSelection"
+              @mousedown.stop
+              @touchstart.stop
+            >
+              Clear
+            </button>
             <div
               v-if="filteredListOptions.length === 0"
               class="custom-dropdown-no-options"
@@ -846,6 +855,11 @@ export default {
       this.updateValue(option.value);
       this.dropdownOpen = false;
     },
+    clearDropdownSelection() {
+      this.localValue = '';
+      this.updateValue('');
+      this.dropdownOpen = false;
+    },
     getScrollParent(element) {
       let style = getComputedStyle(element);
       const excludeStaticParent = style.position === 'absolute';
@@ -1444,6 +1458,18 @@ export default {
   .list-search-input:hover {
     border-color: #bdbdbd !important;
     background: #fff;
+  }
+
+  .dropdown-clear-link {
+    border: none;
+    background: transparent;
+    color: #3b82f6;
+    cursor: pointer;
+    font-size: 0.8rem;
+    margin: 0 14px 8px;
+    padding: 0;
+    text-align: left;
+    text-decoration: underline;
   }
 
   .custom-dropdown-wrapper {

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -96,6 +96,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('priority')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('priority').length === 0"
                       class="custom-dropdown-no-options"
@@ -151,6 +152,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('category')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('category').length === 0"
                       class="custom-dropdown-no-options"
@@ -206,6 +208,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('subcategory')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('subcategory').length === 0"
                       class="custom-dropdown-no-options"
@@ -261,6 +264,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('thirdLevelCategory')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('thirdLevelCategory').length === 0"
                       class="custom-dropdown-no-options"
@@ -321,6 +325,7 @@
                           @touchstart.stop
                         />
                       </div>
+                      <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('assignee')">Clear</button>
                       <div
                         v-if="getFilteredHeaderOptions('assignee').length === 0"
                         class="custom-dropdown-no-options"
@@ -377,6 +382,7 @@
                           @touchstart.stop
                         />
                       </div>
+                      <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('status')">Clear</button>
                       <div
                         v-if="getFilteredHeaderOptions('status').length === 0"
                         class="custom-dropdown-no-options"
@@ -1116,6 +1122,14 @@ return;
 
       headerSelectedLabels[key] = label;
       model.value = newValue ?? '';
+      closeAllHeaderDropdowns();
+    };
+    const clearHeaderSelection = key => {
+      const model = headerFieldModels[key];
+      if (!model) return;
+
+      model.value = '';
+      headerSelectedLabels[key] = '';
       closeAllHeaderDropdowns();
     };
 
@@ -2714,6 +2728,7 @@ return;
       getHeaderSelectedLabel,
       isHeaderOptionSelected,
       selectHeaderOption,
+      clearHeaderSelection,
       computeSelectWidthStyle,
       translateText,
       showTranslatedMessage,
@@ -3223,6 +3238,18 @@ i.material-symbols-outlined-search {
 .list-search-input:hover {
   border-color: #bdbdbd !important;
   background: #fff;
+}
+
+.dropdown-clear-link {
+  border: none;
+  background: transparent;
+  color: #3b82f6;
+  cursor: pointer;
+  font-size: 0.8rem;
+  margin: 0 14px 8px;
+  padding: 0;
+  text-align: left;
+  text-decoration: underline;
 }
 
 .tag-select-wrapper {


### PR DESCRIPTION
### Motivation
- Provide a quick way to clear selections for dropdown/list fields in the Project/FormBuilder UI by adding a visible `Clear` action under the options search input for both header filters and form fields.

### Description
- Added a `Clear` button under the search input in the list/dropdown template and implemented `clearDropdownSelection` in `Project/FormBuilder/Component/components/FieldComponent.vue` to reset the field and close the dropdown.
- Added `Clear` buttons for all header dropdowns (priority, category, subcategory, third-level category, assignee, status) in `Project/FormBuilder/Component/wwElement.vue` and implemented `clearHeaderSelection` to reset header model values and labels.
- Added shared styling for the clear control (`.dropdown-clear-link`) in both components to keep a consistent visual appearance.

### Testing
- Verified repository state with `git -C /workspace/NewCode status --short` which completed successfully.
- Staged and committed the changes with `git -C /workspace/NewCode commit -m "Add Clear action to list dropdown filters in FormBuilder"` which completed successfully.
- Created the PR metadata (`make_pr`) which produced the PR title and description successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdc778c2483309de6cdf0f5886c8b)