### PR TITLE
Add Clear action to custom dropdowns and header filters with handlers and styles

### DIFF
--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -179,6 +179,15 @@
                 autofocus
               />
             </div>
+            <button
+              type="button"
+              class="dropdown-clear-link"
+              @click.stop="clearDropdownSelection"
+              @mousedown.stop
+              @touchstart.stop
+            >
+              Clear
+            </button>
             <div
               v-if="filteredListOptions.length === 0"
               class="custom-dropdown-no-options"
@@ -846,6 +855,11 @@ export default {
       this.updateValue(option.value);
       this.dropdownOpen = false;
     },
+    clearDropdownSelection() {
+      this.localValue = '';
+      this.updateValue('');
+      this.dropdownOpen = false;
+    },
     getScrollParent(element) {
       let style = getComputedStyle(element);
       const excludeStaticParent = style.position === 'absolute';
@@ -1444,6 +1458,19 @@ export default {
   .list-search-input:hover {
     border-color: #bdbdbd !important;
     background: #fff;
+  }
+
+  .dropdown-clear-link {
+    border: none;
+    background: transparent;
+    color: #3b82f6;
+    cursor: pointer;
+    font-size: 0.8rem;
+    margin: 0 14px 8px auto;
+    padding: 0;
+    text-align: right;
+    text-decoration: underline;
+    display: block;
   }
 
   .custom-dropdown-wrapper {

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -96,6 +96,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('priority')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('priority').length === 0"
                       class="custom-dropdown-no-options"
@@ -151,6 +152,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('category')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('category').length === 0"
                       class="custom-dropdown-no-options"
@@ -206,6 +208,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('subcategory')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('subcategory').length === 0"
                       class="custom-dropdown-no-options"
@@ -261,6 +264,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('thirdLevelCategory')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('thirdLevelCategory').length === 0"
                       class="custom-dropdown-no-options"
@@ -321,6 +325,7 @@
                           @touchstart.stop
                         />
                       </div>
+                      <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('assignee')">Clear</button>
                       <div
                         v-if="getFilteredHeaderOptions('assignee').length === 0"
                         class="custom-dropdown-no-options"
@@ -377,6 +382,7 @@
                           @touchstart.stop
                         />
                       </div>
+                      <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('status')">Clear</button>
                       <div
                         v-if="getFilteredHeaderOptions('status').length === 0"
                         class="custom-dropdown-no-options"
@@ -1116,6 +1122,24 @@ return;
 
       headerSelectedLabels[key] = label;
       model.value = newValue ?? '';
+      closeAllHeaderDropdowns();
+    };
+    const resetHeaderFieldValue = key => {
+      const model = headerFieldModels[key];
+      if (!model) return;
+      model.value = '';
+      headerSelectedLabels[key] = '';
+    };
+    const clearHeaderSelection = key => {
+      resetHeaderFieldValue(key);
+
+      if (key === 'category') {
+        resetHeaderFieldValue('subcategory');
+        resetHeaderFieldValue('thirdLevelCategory');
+      } else if (key === 'subcategory') {
+        resetHeaderFieldValue('thirdLevelCategory');
+      }
+
       closeAllHeaderDropdowns();
     };
 
@@ -2714,6 +2738,7 @@ return;
       getHeaderSelectedLabel,
       isHeaderOptionSelected,
       selectHeaderOption,
+      clearHeaderSelection,
       computeSelectWidthStyle,
       translateText,
       showTranslatedMessage,
@@ -3223,6 +3248,19 @@ i.material-symbols-outlined-search {
 .list-search-input:hover {
   border-color: #bdbdbd !important;
   background: #fff;
+}
+
+.dropdown-clear-link {
+  border: none;
+  background: transparent;
+  color: #3b82f6;
+  cursor: pointer;
+  font-size: 0.8rem;
+  margin: 0 14px 8px auto;
+  padding: 0;
+  text-align: right;
+  text-decoration: underline;
+  display: block;
 }
 
 .tag-select-wrapper {


### PR DESCRIPTION
### Motivation

- Provide a quick way for users to clear selected values in custom dropdowns and header filter dropdowns to improve UX when resetting filters or fields.

### Description

- Add a `Clear` button to the dropdown list UI in `FieldComponent.vue` and multiple header dropdowns in `wwElement.vue` and style it via a new `.dropdown-clear-link` CSS rule.
- Implement `clearDropdownSelection` in `FieldComponent.vue` to reset `localValue`, call `updateValue('')`, and close the dropdown.
- Add `resetHeaderFieldValue` and `clearHeaderSelection` helper functions in `wwElement.vue` to reset header models and labels, cascade resets for dependent fields (`category` -> `subcategory` and `thirdLevelCategory`, `subcategory` -> `thirdLevelCategory`), and close dropdowns.
- Expose `clearHeaderSelection` from the header composition return so parent logic can call it where needed.

### Testing

- Ran the existing unit test suite and linting checks; all tests and linters completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcdc778c2483309de6cdf0f5886c8b)