### PR TITLE
Harden FORMATED_TEXT handling to prevent layout distortion in FormRender

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -530,7 +530,7 @@ export default {
     async updateValue(event) {
       const eventValue = event?.target?.value ?? event?.value;
       const rawValue = this.field.fieldType === 'FORMATED_TEXT'
-        ? this.localValue
+        ? this.sanitizeFormattedHtml(this.localValue)
         : (eventValue !== undefined ? eventValue : this.localValue);
 
       let value = rawValue;
@@ -712,7 +712,32 @@ export default {
       this.updateValue({ target: { value } });
     },
     onContentEditableInput(event) {
-      this.localValue = event.target.innerHTML;
+      this.localValue = this.sanitizeFormattedHtml(event.target.innerHTML);
+    },
+    sanitizeFormattedHtml(html) {
+      if (typeof document === 'undefined') return String(html ?? '');
+      const container = document.createElement('div');
+      container.innerHTML = String(html ?? '');
+      container.querySelectorAll('script,style,link,meta,iframe,object,embed,form').forEach((node) => node.remove());
+
+      Array.from(container.querySelectorAll('*')).forEach((node) => {
+        [...node.attributes].forEach((attr) => {
+          const name = attr.name.toLowerCase();
+          const value = String(attr.value || '').trim();
+          if (name.startsWith('on') || name === 'style' || name === 'class' || name === 'id') {
+            node.removeAttribute(attr.name);
+            return;
+          }
+          if (name === 'href' && !/^https?:\/\//i.test(value) && !/^mailto:/i.test(value)) {
+            node.removeAttribute(attr.name);
+            return;
+          }
+          if (name === 'src' && !/^https?:\/\//i.test(value) && !/^data:image\//i.test(value)) {
+            node.removeAttribute(attr.name);
+          }
+        });
+      });
+      return container.innerHTML;
     },
     format(cmd) {
       this.$refs.rte && this.$refs.rte.focus();
@@ -807,7 +832,7 @@ export default {
     async renderFormattedTextContent(htmlContent) {
       if (!this.$refs.rte) return;
       const formattedHtml = this.convertFormattedTextToHtml(htmlContent);
-      const processed = await this.processInboundTicketImages(formattedHtml);
+      const processed = await this.processInboundTicketImages(this.sanitizeFormattedHtml(formattedHtml));
       if (this.$refs.rte.innerHTML !== processed) {
         this.$refs.rte.innerHTML = processed;
       }


### PR DESCRIPTION
### Motivation
- The formatted text field (`FORMATED_TEXT`) could contain HTML or attributes that leak layout or execute unwanted behavior and thus distort the entire screen.
- The goal is to ensure that arbitrary or pasted HTML cannot affect page layout or inject unsafe attributes while keeping basic formatting and images working.

### Description
- Added a `sanitizeFormattedHtml` helper that strips dangerous tags (`script`, `style`, `iframe`, `object`, `embed`, `form`, etc.) and removes inline/event/style/class/id attributes from elements, and normalizes `href`/`src` values to safe patterns in `FieldComponent.vue`.
- Applied sanitization in the `contenteditable` input flow so pasted/typed HTML is cleaned on input (`onContentEditableInput`).
- Sanitized values before saving in `updateValue` when `field.fieldType === 'FORMATED_TEXT'` so persisted values are safe.
- Sanitized rendered content before inbound-image processing in `renderFormattedTextContent` so injected elements/attributes cannot break layout when shown.

### Testing
- Verified the repository diff to confirm the intended changes to `Project/FormRender/Component/components/FieldComponent.vue` were applied and inspected the modified lines locally.
- Executed the PR creation helper (`make_pr`) to publish the change; the tool completed successfully.
- No automated unit tests or CI were executed as part of this local change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcab5f6e08330b04636b58a66bf41)