### PR TITLE
fix: keep AnexosGenerico value as file array

### DIFF
--- a/Project/AnexosGenerico/src/wwElement.vue
+++ b/Project/AnexosGenerico/src/wwElement.vue
@@ -425,27 +425,7 @@ export default {
 
         const localData = ref({
             fileUpload: {
-                value: computed(() => {
-                    return fileList.value.map(file => {
-                        const plainObject = {};
-                        for (const key in file) {
-                            if (Object.prototype.hasOwnProperty.call(file, key)) {
-                                plainObject[key] = file[key];
-                            }
-                        }
-                        plainObject.name = file.name;
-                        plainObject.size = file.size;
-                        plainObject.type = file.type;
-                        plainObject.lastModified = file.lastModified;
-                        plainObject.mimeType = file.mimeType;
-                        plainObject.id = file.id;
-
-                        if (file.base64) plainObject.base64 = file.base64;
-                        if (file.binary) plainObject.binary = file.binary;
-
-                        return plainObject;
-                    });
-                }),
+                value: computed(() => fileList.value),
                 status: status,
                 deletedFile: deletedFile,
                 deletedFilesCount: deletedFilesCount,


### PR DESCRIPTION
### Motivation
- Restore previous behavior so the `value` provided by the `AnexosGenerico` element contains the actual array of File objects (not plain metadata objects) to maintain compatibility with consumers that expect real files.

### Description
- Replaced the transformation that mapped `fileList` items into plain metadata objects with a direct reference `computed(() => fileList.value)` so `localData.fileUpload.value` now exposes the original files; change in `Project/AnexosGenerico/src/wwElement.vue`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2b3eed8083308dd9f1865864cf9d)