### PR TITLE
GridViewSimples: ocultar resumo de registros na paginação

### DIFF
--- a/Project/GridViewSimples/src/wwElement.vue
+++ b/Project/GridViewSimples/src/wwElement.vue
@@ -1071,6 +1071,12 @@ export default {
     }
   }
 
+
+
+  :deep(.ag-paging-row-summary-panel) {
+    display: none !important;
+  }
+
   /* CSS para o filtro customizado ListFilterRenderer */
   .list-filter {
     padding: 10px;


### PR DESCRIPTION
### Motivation
- Remover a exibição do resumo de registros (ex.: `1 to 4 of 4`) no componente de paginação, mantendo apenas os controles de navegação e o resumo de páginas (ex.: `1 of 12`).

### Description
- Adicionada regra CSS em `Project/GridViewSimples/src/wwElement.vue` para ocultar o painel `.ag-paging-row-summary-panel` (`display: none !important;`).

### Testing
- Nenhum teste automatizado foi executado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe44b159448330aacd8effcb7c0216)