### PR TITLE
Add user-field menu icon and click trigger in FormRender

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -5,7 +5,16 @@
     :style="componentStyleVars">
     <!-- Label do campo -->
     <label v-if="!field.is_hide_legend" class="field-label">
-      {{ field.name }}
+      <span class="field-label-text">{{ field.name }}</span>
+      <button
+        v-if="field.is_field_user"
+        type="button"
+        class="field-user-menu-button material-symbols-outlined"
+        :aria-label="t('Field options')"
+        @click="onFieldUserMenuClick"
+      >
+        more_horiz
+      </button>
       <span v-if="field.is_mandatory" class="required-indicator">*</span>
     </label>
 
@@ -994,6 +1003,12 @@ export default {
         this.toggleDropdown();
       }
     },
+    onFieldUserMenuClick() {
+      this.$emit('field-user-menu-click', {
+        fieldId: this.field.field_id || this.field.id,
+        field: this.field
+      });
+    }
   },
   mounted() {
     if (this.field.fieldType === 'FORMATED_TEXT' && this.$refs.rte) {
@@ -1032,6 +1047,30 @@ export default {
     margin-bottom: 4px;
     color: #787878;
     padding-left: 8px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .field-label-text {
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .field-user-menu-button {
+    border: none;
+    background: transparent;
+    color: #787878;
+    cursor: pointer;
+    padding: 0;
+    font-size: 16px;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .field-user-menu-button:hover {
+    color: #4b5563;
   }
 
   .required-indicator {

--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -24,6 +24,7 @@ class="action-icon-section"
             :auto-save="autoSave"
             :ticket-closed="ticketClosed"
             @update:value="value => updateFieldValue(field.id, value)"
+            @field-user-menu-click="payload => onFieldUserMenuClick(payload)"
           />
         </div>
       </div>
@@ -91,7 +92,7 @@ export default {
       default: false
     }
   },
-  emits: ['update:value'],
+  emits: ['update:value', 'field-user-menu-click'],
   setup(props, { emit }) {
     
     const isExpanded = ref(true);
@@ -309,6 +310,13 @@ export default {
       emit('update:value', { fieldId, value });
     };
 
+    const onFieldUserMenuClick = (payload) => {
+      emit('field-user-menu-click', {
+        sectionId: props.section.id,
+        ...payload
+      });
+    };
+
     onMounted(() => {
       // Load options for all LIST fields
       sectionFields.value.forEach(field => {
@@ -334,6 +342,7 @@ export default {
       loadingOptions,
       fieldOptions,
       updateFieldValue,
+      onFieldUserMenuClick,
       options,
       loading,
       fieldValues,

--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -337,6 +337,11 @@ export default {
             name: 'importFormRequested',
             label: { en: 'On import form requested' },
             event: { value: true }
+        },
+        {
+            name: 'fieldUserMenuClick',
+            label: { en: 'On field user menu click' },
+            event: { sectionId: '', fieldId: '', field: {} }
         }
     ],
     actions: [

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -39,6 +39,7 @@
               @select-field="selectFieldForProperties"
               @remove-section="handleRemoveSection"
               @update:value="payload => onFieldValueChange(section.id, payload)"
+              @field-user-menu-click="onFieldUserMenuClick"
             />
           </div>
         </template>
@@ -370,6 +371,17 @@ export default {
       }
     };
 
+    const onFieldUserMenuClick = ({ sectionId, fieldId, field }) => {
+      emit('trigger-event', {
+        name: 'fieldUserMenuClick',
+        event: {
+          sectionId,
+          fieldId,
+          field
+        }
+      });
+    };
+
     // Watch for changes in formJson
     watch(() => props.content.formJson, (newValue) => {
       loadFormData();
@@ -474,6 +486,7 @@ export default {
       isLoading,
       renderKey,
       onFieldValueChange,
+      onFieldUserMenuClick,
       autoSave,
       ticketIsClosed,
       sectionComponents,


### PR DESCRIPTION
### Motivation
- Provide a UI affordance and actionable event for fields marked with `is_field_user: true` so editors can expose per-field user actions from the form renderer.

### Description
- In `FieldComponent.vue` added a three-dots button (`more_horiz`) next to the label that renders only when `field.is_field_user` is `true` and emits `field-user-menu-click` with `{ fieldId, field }` on click.
- In `FormSection.vue` the component now listens to `field-user-menu-click` from children and re-emits it including `sectionId` so the caller receives `{ sectionId, fieldId, field }`.
- In `wwElement.vue` wired the section-level event to emit a WeWeb trigger-event named `fieldUserMenuClick` containing `sectionId`, `fieldId` and `field` so workflows can react to the click.
- Registered the new trigger event `fieldUserMenuClick` in `ww-config.js` and added minimal styles for the new button in `FieldComponent.vue`.

### Testing
- No automated tests were executed for this change.
- Repository state and changes were verified locally via `git status` and committing the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01fb6279c88330959e4bc42a79f52b)