### PR TITLE
FormRender: show user 3-dot menu only when value present, add configurable visibility and translated hint

### DIFF
--- a/Project/FormRender/Component/components/FieldComponent.vue
+++ b/Project/FormRender/Component/components/FieldComponent.vue
@@ -7,10 +7,11 @@
     <label v-if="!field.is_hide_legend" class="field-label">
       <span class="field-label-text">{{ field.name }}</span>
       <button
-        v-if="field.is_field_user"
+        v-if="showFieldUserMenuButton"
         type="button"
         class="field-user-menu-button material-symbols-outlined"
         :aria-label="t('Field options')"
+        :title="t('User details')"
         @click="onFieldUserMenuClick"
       >
         more_horiz
@@ -202,6 +203,10 @@ export default {
     ticketClosed: {
       type: Boolean,
       default: false
+    },
+    showFieldUserMenu: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -401,6 +406,16 @@ export default {
       if (isNaN(deadline.getTime())) return false;
       const now = new Date();
       return (deadline - now) < 0;
+    },
+    hasSelectedValue() {
+      const value = this.localValue;
+      if (Array.isArray(value)) return value.length > 0;
+      if (value === null || value === undefined) return false;
+      if (typeof value === 'string') return value.trim() !== '';
+      return true;
+    },
+    showFieldUserMenuButton() {
+      return Boolean(this.field.is_field_user && this.showFieldUserMenu && this.hasSelectedValue);
     },
     fieldTip() {
       const lang = window?.wwLib?.wwVariable?.getValue('aa44dc4c-476b-45e9-a094-16687e063342') || 'en-US';

--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -23,6 +23,7 @@ class="action-icon-section"
             :user-id="userId"
             :auto-save="autoSave"
             :ticket-closed="ticketClosed"
+            :show-field-user-menu="showFieldUserMenu"
             @update:value="value => updateFieldValue(field.id, value)"
             @field-user-menu-click="payload => onFieldUserMenuClick(payload)"
           />
@@ -90,6 +91,10 @@ export default {
     ticketClosed: {
       type: Boolean,
       default: false
+    },
+    showFieldUserMenu: {
+      type: Boolean,
+      default: true
     }
   },
   emits: ['update:value', 'field-user-menu-click'],

--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -290,6 +290,22 @@ export default {
             }
             /* wwEditor:end */
         },
+        showFieldUserMenu: {
+            label: { en: 'Show user menu button' },
+            type: 'boolean',
+            section: 'settings',
+            bindable: true,
+            defaultValue: true,
+            /* wwEditor:start */
+            bindingValidation: {
+                type: 'boolean',
+                tooltip: 'Show or hide the 3-dot button for user fields when they have value'
+            },
+            propertyHelp: {
+                tooltip: 'Enable to show the user options button on user fields with selected value'
+            }
+            /* wwEditor:end */
+        },
         autoSave: {
             label: { en: 'Auto save fields' },
             type: 'boolean',

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -32,6 +32,7 @@
               :read-only="formReadOnly"
               :auto-save="autoSave"
               :ticket-closed="ticketIsClosed"
+              :show-field-user-menu="showFieldUserMenu"
               @update-section="updateFormState"
               @edit-section="editSection"
               @edit-field="editFormField"
@@ -145,6 +146,12 @@ export default {
       const contentVal = parseAutoSave(props.content.autoSave);
       if (contentVal !== undefined) return contentVal;
 
+      return true;
+    });
+
+    const showFieldUserMenu = computed(() => {
+      if (typeof props.content.showFieldUserMenu === 'boolean') return props.content.showFieldUserMenu;
+      if (typeof props.content.showFieldUserMenu === 'string') return props.content.showFieldUserMenu.toLowerCase() === 'true';
       return true;
     });
 
@@ -489,6 +496,7 @@ export default {
       onFieldUserMenuClick,
       autoSave,
       ticketIsClosed,
+      showFieldUserMenu,
       sectionComponents,
       validateRequiredFields,
       t


### PR DESCRIPTION
### Motivation
- Reduce UI noise by showing the 3-dot user menu only for `is_field_user` fields that actually have a selected value. 
- Provide a global toggle so authors can enable/disable the 3-dot button via component configuration. 
- Surface a localized hint for the menu using the existing translation mechanism.

### Description
- Changed the Field label button to render with `v-if=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a021938b03c8330a77717bac6037c41)