### PR TITLE
feat(FormRender): add action to refresh list field data source

### DIFF
--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -322,6 +322,21 @@ export default {
       });
     };
 
+    const refreshListFieldOptions = async (fieldId) => {
+      const field = sectionFields.value.find(
+        currentField =>
+          currentField.id === fieldId ||
+          currentField.field_id === fieldId ||
+          currentField.ID === fieldId
+      );
+      if (!field) return false;
+      if (!(field.fieldType === 'LIST' || field.fieldType === 'CONTROLLED_LIST')) return false;
+      if (!field.dataSource) return false;
+
+      await loadOptions(field);
+      return true;
+    };
+
     onMounted(() => {
       // Load options for all LIST fields
       sectionFields.value.forEach(field => {
@@ -355,7 +370,8 @@ export default {
       fieldRows,
       autoSave,
       fieldComponents,
-      validateFields
+      validateFields,
+      refreshListFieldOptions
     };
   }
 };

--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -387,6 +387,17 @@ export default {
             action: 'validateRequiredFields',
             label: { en: 'Validate required fields' },
             args: []
+        },
+        {
+            action: 'refreshListFieldDataSource',
+            label: { en: 'Refresh list field data source' },
+            args: [
+                {
+                    name: 'fieldId',
+                    type: 'string',
+                    label: { en: 'Field ID' }
+                }
+            ]
         }
     ]
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -471,6 +471,40 @@ export default {
       return valid;
     };
 
+    const refreshListFieldDataSource = async (fieldId) => {
+      if (!fieldId) return false;
+
+      const currentValueByFieldId = new Map();
+      formSections.value.forEach(section => {
+        section.fields.forEach(field => {
+          currentValueByFieldId.set(field.id || field.field_id || field.ID, field.value);
+        });
+      });
+
+      const targets = Array.isArray(sectionComponents.value) ? sectionComponents.value : [];
+      let refreshed = false;
+      for (const sectionComponent of targets) {
+        if (sectionComponent && typeof sectionComponent.refreshListFieldOptions === 'function') {
+          const didRefresh = await sectionComponent.refreshListFieldOptions(fieldId);
+          if (didRefresh) refreshed = true;
+        }
+      }
+
+      if (refreshed) {
+        formSections.value.forEach(section => {
+          section.fields.forEach(field => {
+            const key = field.id || field.field_id || field.ID;
+            if (currentValueByFieldId.has(key)) {
+              field.value = currentValueByFieldId.get(key);
+            }
+          });
+        });
+        updateFormState({ forceRerender: false });
+      }
+
+      return refreshed;
+    };
+
     return {
       isEditing,
       formData,
@@ -499,6 +533,7 @@ export default {
       showFieldUserMenu,
       sectionComponents,
       validateRequiredFields,
+      refreshListFieldDataSource,
       t
     };
   }


### PR DESCRIPTION
### Motivation
- Permitir que o componente FormRender refaça o fetch do `dataSource` de um campo do tipo lista sem alterar o `value` atual do campo. 

### Description
- Adicionada a action `refreshListFieldDataSource(fieldId)` no componente principal (`Project/FormRender/Component/wwElement.vue`) que cria um snapshot dos valores, aciona a recarga nas seções e reaplica os valores antes de atualizar o estado sem forçar re-render completo.  
- Implementada `refreshListFieldOptions(fieldId)` em `Project/FormRender/Component/components/FormSection.vue` para recarregar opções apenas quando o campo for `LIST` ou `CONTROLLED_LIST` e possuir `dataSource`, reaproveitando `loadOptions`.  
- Registrada a nova action em `Project/FormRender/Component/ww-config.js` com o argumento `fieldId` para tornar a ação acessível externamente.  
- Exportados os novos métodos no `return` dos componentes para uso por integrações externas e fluxo de ações do componente. 

### Testing
- Execução de checks automatizados de repositório e geração de metadados do PR concluída com sucesso.  
- Não houve execução de testes unitários ou de integração automatizados no repositório durante esta alteração.  
- As mudanças são localizadas nos arquivos `Project/FormRender/Component/wwElement.vue`, `Project/FormRender/Component/components/FormSection.vue` e `Project/FormRender/Component/ww-config.js` e mantêm o fluxo existente de carregamento de opções e atualização de estado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0228bdd1ec8330be9ad8a1a50b84bb)