### PR TITLE
Refresh dynamic LIST field options and add action to trigger refresh

### DIFF
--- a/Project/FormRender/Component/components/FormSection.vue
+++ b/Project/FormRender/Component/components/FormSection.vue
@@ -322,6 +322,21 @@ export default {
       });
     };
 
+    const refreshListFieldOptions = async (fieldId) => {
+      const field = sectionFields.value.find(
+        currentField =>
+          currentField.id === fieldId ||
+          currentField.field_id === fieldId ||
+          currentField.ID === fieldId
+      );
+      if (!field) return false;
+      if (!(field.fieldType === 'LIST' || field.fieldType === 'CONTROLLED_LIST')) return false;
+      if (!field.dataSource) return false;
+
+      await loadOptions(field);
+      return true;
+    };
+
     onMounted(() => {
       // Load options for all LIST fields
       sectionFields.value.forEach(field => {
@@ -355,7 +370,8 @@ export default {
       fieldRows,
       autoSave,
       fieldComponents,
-      validateFields
+      validateFields,
+      refreshListFieldOptions
     };
   }
 };

--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -387,6 +387,11 @@ export default {
             action: 'validateRequiredFields',
             label: { en: 'Validate required fields' },
             args: []
+        },
+        {
+            action: 'refreshListFieldDataSource',
+            label: { en: 'Refresh list field data source' },
+            args: []
         }
     ]
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -471,6 +471,47 @@ export default {
       return valid;
     };
 
+    const refreshListFieldDataSource = async () => {
+      const currentValueByFieldId = new Map();
+      const userFieldIds = new Set();
+
+      formSections.value.forEach(section => {
+        section.fields.forEach(field => {
+          const fieldId = field.id || field.field_id || field.ID;
+          currentValueByFieldId.set(fieldId, field.value);
+          if (field.is_field_user) {
+            userFieldIds.add(fieldId);
+          }
+        });
+      });
+
+      if (!userFieldIds.size) return false;
+
+      const targets = Array.isArray(sectionComponents.value) ? sectionComponents.value : [];
+      let refreshed = false;
+      for (const sectionComponent of targets) {
+        if (sectionComponent && typeof sectionComponent.refreshListFieldOptions === 'function') {
+          for (const fieldId of userFieldIds) {
+            const didRefresh = await sectionComponent.refreshListFieldOptions(fieldId);
+            if (didRefresh) refreshed = true;
+          }
+        }
+      }
+
+      if (!refreshed) return false;
+
+      formSections.value.forEach(section => {
+        section.fields.forEach(field => {
+          const key = field.id || field.field_id || field.ID;
+          if (currentValueByFieldId.has(key)) {
+            field.value = currentValueByFieldId.get(key);
+          }
+        });
+      });
+      updateFormState({ forceRerender: false });
+      return true;
+    };
+
     return {
       isEditing,
       formData,
@@ -499,6 +540,7 @@ export default {
       showFieldUserMenu,
       sectionComponents,
       validateRequiredFields,
+      refreshListFieldDataSource,
       t
     };
   }


### PR DESCRIPTION
### Motivation
- Allow LIST/CONTROLLED_LIST fields that use remote or dynamic data sources to be refreshed on demand when related user fields change.
- Preserve current field values while updating list options to avoid losing user input after a refresh.
- Expose a top-level action so external callers can trigger a data-source refresh for list fields across the form.

### Description
- Added `refreshListFieldOptions` to `FormSection.vue` which locates a field by several ID variants and reloads options via `loadOptions` for `LIST`/`CONTROLLED_LIST` fields with a `dataSource`. 
- Added `refreshListFieldDataSource` to `wwElement.vue` which collects user-linked field IDs, invokes `refreshListFieldOptions` on section components, restores preserved field values, and calls `updateFormState` without forcing a rerender.
- Exposed `refreshListFieldOptions` and `refreshListFieldDataSource` in the components' returned interfaces so they can be invoked by parent components or external actions. 
- Registered a new action `refreshListFieldDataSource` in `ww-config.js` so the refresh can be triggered via the configuration/action system.

### Testing
- Ran the project's automated test suite with `npm test` which completed successfully. 
- Ran the linter with `npm run lint` which reported no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0228bdd1ec8330be9ad8a1a50b84bb)