### PR TITLE
Corrige piscar de miniaturas de imagem em AnexosGenerico

### DIFF
--- a/Project/AnexosGenerico/src/components/FileItem.vue
+++ b/Project/AnexosGenerico/src/components/FileItem.vue
@@ -163,18 +163,35 @@ export default {
         });
 
         const previewUrl = ref(null);
+        const localObjectUrl = ref(null);
+
+        const revokeLocalObjectUrl = () => {
+            if (localObjectUrl.value) {
+                URL.revokeObjectURL(localObjectUrl.value);
+                localObjectUrl.value = null;
+            }
+        };
 
         const updatePreviewUrl = () => {
             const currentValue = props.file?.previewUrl || props.file?.url || null;
             if (currentValue) {
-                previewUrl.value = currentValue;
+                if (previewUrl.value !== currentValue) {
+                    revokeLocalObjectUrl();
+                    previewUrl.value = currentValue;
+                }
                 return;
             }
+
             const localFile = props.file instanceof File ? props.file : props.file?.file;
             if (localFile instanceof File && isImage.value) {
-                previewUrl.value = URL.createObjectURL(localFile);
+                if (!localObjectUrl.value) {
+                    localObjectUrl.value = URL.createObjectURL(localFile);
+                }
+                previewUrl.value = localObjectUrl.value;
                 return;
             }
+
+            revokeLocalObjectUrl();
             previewUrl.value = null;
         };
 
@@ -197,7 +214,6 @@ export default {
             } catch (e) {
                 removeIcon.value = null;
             }
-            updatePreviewUrl();
         });
 
         watch(
@@ -207,9 +223,7 @@ export default {
         );
 
         onBeforeUnmount(() => {
-            if (previewUrl.value && previewUrl.value.startsWith('blob:')) {
-                URL.revokeObjectURL(previewUrl.value);
-            }
+            revokeLocalObjectUrl();
         });
 
         return {


### PR DESCRIPTION
### Motivation
- Corrigir o comportamento em que miniaturas de anexos do tipo imagem piscavam devido à recriação contínua de URLs de preview (object URLs) ao exibir as imagens.

### Description
- Adicionada a referência `localObjectUrl` e a função `revokeLocalObjectUrl` em `Project/AnexosGenerico/src/components/FileItem.vue` para controlar o ciclo de vida do `URL.createObjectURL`.
- Atualizada a função `updatePreviewUrl` para reutilizar a `localObjectUrl` quando possível, evitar recriações desnecessárias e revogar a URL local ao mudar para uma URL remota.
- Removida a chamada redundante que inicializava o preview em `onMounted`, e agora a limpeza da URL local é feita em `onBeforeUnmount` via `revokeLocalObjectUrl`.

### Testing
- Nenhum teste automatizado foi executado para esta mudança.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cd5803b083308014cd7f1ded4583)