### PR TITLE
feat(SearchBox): add `activeColor` for filled search input

### DIFF
--- a/Project/SearchBox/src/wwElement.vue
+++ b/Project/SearchBox/src/wwElement.vue
@@ -579,10 +579,27 @@ export default {
             { immediate: true }
         );
         const searchInputStyle = computed(() => {
-            if (!searchIcon.value) return {};
-            return searchIconPosition.value === 'right' ? { paddingRight: '2.2em' } : { paddingLeft: '2.2em' };
+            const style = {};
+            if (searchIcon.value) {
+                Object.assign(
+                    style,
+                    searchIconPosition.value === 'right' ? { paddingRight: '2.2em' } : { paddingLeft: '2.2em' }
+                );
+            }
+
+            if (isSearchActive.value && props.content.activeColor) {
+                style.borderColor = props.content.activeColor;
+            }
+
+            return style;
         });
-        const searchIconStyle = computed(() => ({ color: props.content.searchIconColor || undefined }));
+        const isSearchActive = computed(() => props.content.type === 'search' && !!displayValue.value);
+        const searchIconStyle = computed(() => ({
+            color:
+                isSearchActive.value && props.content.activeColor
+                    ? props.content.activeColor
+                    : props.content.searchIconColor || undefined,
+        }));
 
         const inputClasses = computed(() => ({
             hideArrows: props.content.hideArrows && inputType.value === 'number',
@@ -710,6 +727,7 @@ export default {
             searchIconPosition,
             searchIconStyle,
             searchInputStyle,
+            isSearchActive,
             // Currency-related
             handleCurrencyInput,
             handleCurrencyKeydown,

--- a/Project/SearchBox/ww-config.js
+++ b/Project/SearchBox/ww-config.js
@@ -14,7 +14,7 @@ export default {
             'placeholder',
             'readonly',
             'required',
-            ['searchIcon', 'searchIconPosition', 'searchIconColor'],
+            ['searchIcon', 'searchIconPosition', 'searchIconColor', 'activeColor'],
             'debounce',
             'debounceDelay',
         ],
@@ -279,6 +279,23 @@ export default {
         },
         searchIconColor: {
             label: { en: 'Icon color' },
+            type: 'Color',
+            section: 'settings',
+            options: {
+                nullable: true,
+            },
+            bindable: true,
+            hidden: content => content.type !== 'search',
+            /* wwEditor:start */
+            bindingValidation: {
+                cssSupports: 'color',
+                type: 'string',
+                tooltip: 'A string that represents a color code: `"rebeccapurple" | "#00ff00" | "rgb(214, 122, 127)"`',
+            },
+            /* wwEditor:end */
+        },
+        activeColor: {
+            label: { en: 'Active color' },
             type: 'Color',
             section: 'settings',
             options: {


### PR DESCRIPTION
### Motivation
- Allow the SearchBox to visually indicate an active (non-empty) state by using a configurable color for the input border and icon via a new property `activeColor`.
- Make this color configurable in the editor only for `type: 'search'` so authors can style filled search fields consistently.

### Description
- Added the `activeColor` property to `Project/SearchBox/ww-config.js` and included it in the search-related settings group so it appears only when `type === 'search'`.
- Added an `isSearchActive` computed and updated `searchInputStyle` in `Project/SearchBox/src/wwElement.vue` to set `borderColor` to `props.content.activeColor` when the search has content.
- Updated `searchIconStyle` to use `activeColor` when the field is active and fall back to `searchIconColor` when inactive or `activeColor` is not set, while preserving existing icon padding logic.

### Testing
- Ran repository operations and commit commands which succeeded: `git status`/`git add`/`git commit` (changes committed).
- No automated unit/integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061b56cc4c8330a8e0e37b6ffbbfed)