### PR TITLE
Search input: add active color/text styling and editor settings

### DIFF
--- a/Project/SearchBox/src/wwElement.vue
+++ b/Project/SearchBox/src/wwElement.vue
@@ -54,6 +54,7 @@
         v-else-if="content.type == 'search'"
         class="search-input-wrapper"
         :class="`icon-${searchIconPosition}`"
+        :style="searchWrapperStyle"
         @click="focusInput"
     >
         <div v-if="searchIcon" class="search-icon" :style="searchIconStyle">
@@ -579,10 +580,31 @@ export default {
             { immediate: true }
         );
         const searchInputStyle = computed(() => {
-            if (!searchIcon.value) return {};
-            return searchIconPosition.value === 'right' ? { paddingRight: '2.2em' } : { paddingLeft: '2.2em' };
+            const style = {};
+            if (searchIcon.value) {
+                Object.assign(
+                    style,
+                    searchIconPosition.value === 'right' ? { paddingRight: '2.2em' } : { paddingLeft: '2.2em' }
+                );
+            }
+
+            if (isSearchActive.value && props.content.activeColorText) {
+                style.color = props.content.activeColorText;
+            }
+
+            return style;
         });
-        const searchIconStyle = computed(() => ({ color: props.content.searchIconColor || undefined }));
+        const isSearchActive = computed(() => props.content.type === 'search' && !!displayValue.value);
+        const searchWrapperStyle = computed(() => ({
+            backgroundColor:
+                isSearchActive.value && props.content.activeColor ? props.content.activeColor : undefined,
+        }));
+        const searchIconStyle = computed(() => ({
+            color:
+                isSearchActive.value && props.content.activeColorText
+                    ? props.content.activeColorText
+                    : props.content.searchIconColor || undefined,
+        }));
 
         const inputClasses = computed(() => ({
             hideArrows: props.content.hideArrows && inputType.value === 'number',
@@ -708,8 +730,10 @@ export default {
             searchIcon,
             searchIconHtml,
             searchIconPosition,
+            searchWrapperStyle,
             searchIconStyle,
             searchInputStyle,
+            isSearchActive,
             // Currency-related
             handleCurrencyInput,
             handleCurrencyKeydown,

--- a/Project/SearchBox/ww-config.js
+++ b/Project/SearchBox/ww-config.js
@@ -14,7 +14,7 @@ export default {
             'placeholder',
             'readonly',
             'required',
-            ['searchIcon', 'searchIconPosition', 'searchIconColor'],
+            ['searchIcon', 'searchIconPosition', 'searchIconColor', 'activeColor', 'activeColorText'],
             'debounce',
             'debounceDelay',
         ],
@@ -279,6 +279,40 @@ export default {
         },
         searchIconColor: {
             label: { en: 'Icon color' },
+            type: 'Color',
+            section: 'settings',
+            options: {
+                nullable: true,
+            },
+            bindable: true,
+            hidden: content => content.type !== 'search',
+            /* wwEditor:start */
+            bindingValidation: {
+                cssSupports: 'color',
+                type: 'string',
+                tooltip: 'A string that represents a color code: `"rebeccapurple" | "#00ff00" | "rgb(214, 122, 127)"`',
+            },
+            /* wwEditor:end */
+        },
+        activeColor: {
+            label: { en: 'Active color' },
+            type: 'Color',
+            section: 'settings',
+            options: {
+                nullable: true,
+            },
+            bindable: true,
+            hidden: content => content.type !== 'search',
+            /* wwEditor:start */
+            bindingValidation: {
+                cssSupports: 'color',
+                type: 'string',
+                tooltip: 'A string that represents a color code: `"rebeccapurple" | "#00ff00" | "rgb(214, 122, 127)"`',
+            },
+            /* wwEditor:end */
+        },
+        activeColorText: {
+            label: { en: 'Active color text' },
             type: 'Color',
             section: 'settings',
             options: {


### PR DESCRIPTION
### Motivation

- Enable a visual "active" state for the search input so the input, icon, and wrapper can change colors when the field contains text. 

### Description

- Add `isSearchActive`, `searchWrapperStyle`, and enhance `searchInputStyle` and `searchIconStyle` in `wwElement.vue` to apply `activeColor` and `activeColorText` when the search field has a value. 
- Bind `:style="searchWrapperStyle"` to the search wrapper and expose `searchWrapperStyle` and `isSearchActive` from the setup return. 
- Make `searchInputStyle` only apply padding when a `searchIcon` exists and apply `color` when `activeColorText` is set and the search is active. 
- Add `activeColor` and `activeColorText` properties to `ww-config.js`, include them in `customSettingsPropertiesOrder`, and add editor metadata and binding validation for both settings.

### Testing

- Ran the project's unit tests and linting; all checks passed. 
- Built the component bundle locally to verify the new styles were applied; the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061b56cc4c8330a8e0e37b6ffbbfed)