### PR TITLE
Apply `activeColor` to SearchBox input when active

### DIFF
--- a/Project/SearchBox/src/wwElement.vue
+++ b/Project/SearchBox/src/wwElement.vue
@@ -592,6 +592,10 @@ export default {
                 style.color = props.content.activeColorText;
             }
 
+            if (isSearchActive.value && props.content.activeColor) {
+                style.backgroundColor = props.content.activeColor;
+            }
+
             return style;
         });
         const isSearchActive = computed(() => props.content.type === 'search' && !!displayValue.value);


### PR DESCRIPTION
### Motivation
- Garantir que, no componente `SearchBox`, ao digitar um valor no `input` a cor de fundo definida em `activeColor` seja aplicada e tenha precedência sobre qualquer `Background` pré-configurado.

### Description
- Em `Project/SearchBox/src/wwElement.vue` foi atualizado o `computed` `searchInputStyle` para definir `style.backgroundColor = props.content.activeColor` quando `isSearchActive` for verdadeiro e `content.activeColor` estiver presente.

### Testing
- Nenhum teste automatizado foi executado para esta alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0622088434833084fc2833c3f4c89e)