### PR TITLE
feat(FormContainer): add validateRequiredFields action to highlight invalid inputs

### DIFF
--- a/Project/FormContainer/src/wwElement.vue
+++ b/Project/FormContainer/src/wwElement.vue
@@ -121,6 +121,34 @@ export default {
             updateFormData();
         }
 
+        function setInputBorderValidity(inputName, isInvalid) {
+            if (!formRef.value || !inputName) return;
+
+            const escapedInputName = String(inputName).replace(/"/g, '\\"');
+            const matchingInputs = formRef.value.querySelectorAll(`[name="${escapedInputName}"]`);
+
+            matchingInputs.forEach(inputElement => {
+                if (!inputElement?.style) return;
+
+                if (isInvalid) {
+                    inputElement.style.setProperty('border-color', '#ff4d4f');
+                } else {
+                    inputElement.style.removeProperty('border-color');
+                }
+            });
+        }
+
+        function validateRequiredFields() {
+            const validationResult = forceValidateAllFields();
+            const invalidFieldNames = new Set(validationResult.invalidFields.map(field => field.name));
+
+            Object.keys(formInputs.value || {}).forEach(fieldName => {
+                setInputBorderValidity(fieldName, invalidFieldNames.has(fieldName));
+            });
+
+            return validationResult.isValid;
+        }
+
         const { setValue } = wwLib.wwVariable.useComponentVariable({
             uid: props.wwElementState.uid,
             name: 'form',
@@ -180,6 +208,15 @@ export default {
                     ],
                 },
             },
+            validateRequiredFields: {
+                method: validateRequiredFields,
+                editor: {
+                    label: 'Validate required fields',
+                    elementName: 'Form',
+                    description: 'Validate form required fields and highlight invalid fields with red borders',
+                    args: [],
+                },
+            },
         };
 
         watch(data, newData => setValue(newData), { deep: true, immediate: true });
@@ -221,6 +258,7 @@ Object containing all form inputs. Each input contains:
             formState,
             _setFormState,
             resetForm,
+            validateRequiredFields,
         };
     },
 };

--- a/Project/FormContainer/ww-config.js
+++ b/Project/FormContainer/ww-config.js
@@ -69,6 +69,10 @@ export default {
                 },
             ],
         },
+        {
+            label: 'Validate required fields',
+            action: 'validateRequiredFields',
+        },
     ],
     triggerEvents: [
         {


### PR DESCRIPTION
### Motivation
- Provide a component action to programmatically validate the form and visually mark missing/invalid required fields with a red border.
- Reuse the existing `forceValidateAllFields()` validation flow so behavior is consistent with form submit validation.

### Description
- Added `validateRequiredFields()` in `Project/FormContainer/src/wwElement.vue` which calls `forceValidateAllFields()` and returns `true`/`false` depending on validity.
- Added `setInputBorderValidity(inputName, isInvalid)` helper to set or remove `border-color: #ff4d4f` on DOM inputs matching the field `name` attribute.
- Exposed the new action in the component `methods` and registered it in `Project/FormContainer/ww-config.js` under the label `Validate required fields` so it can be invoked from editor/workflows.
- No changes were made to the existing validation logic; the feature only maps validation results to DOM styling for invalid fields.

### Testing
- Ran repository checks and recorded changes with `git status --short` which showed staged modifications and then committed with `git commit -m "feat(FormContainer): add required-fields validation action"`, both commands completed successfully.
- Verified modified files contain the new action and config: `Project/FormContainer/src/wwElement.vue` and `Project/FormContainer/ww-config.js`.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0745f87c8c8330b7907a23f4d4f88f)