### PR TITLE
feat(FormRender): add actions to set/check field by tag_control_pre_update

### DIFF
--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -392,6 +392,33 @@ export default {
             action: 'refreshListFieldDataSource',
             label: { en: 'Refresh list field data source' },
             args: []
+        },
+        {
+            action: 'setFieldValueByTagControlPreUpdate',
+            label: { en: 'Set field value by pre-update tag' },
+            args: [
+                {
+                    name: 'tag_control_pre_update',
+                    type: 'string',
+                    label: { en: 'Pre-update tag' }
+                },
+                {
+                    name: 'value',
+                    type: 'string',
+                    label: { en: 'New value' }
+                }
+            ]
+        },
+        {
+            action: 'hasFieldByTagControlPreUpdate',
+            label: { en: 'Check field exists by pre-update tag' },
+            args: [
+                {
+                    name: 'tag_control_pre_update',
+                    type: 'string',
+                    label: { en: 'Pre-update tag' }
+                }
+            ]
         }
     ]
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -389,6 +389,34 @@ export default {
       });
     };
 
+    const findFieldByTagControlPreUpdate = tagControlPreUpdate => {
+      if (!tagControlPreUpdate) return null;
+
+      for (const section of formSections.value) {
+        const field = (section.fields || []).find(
+          currentField => currentField?.tag_control_pre_update === tagControlPreUpdate
+        );
+        if (field) {
+          return { section, field };
+        }
+      }
+
+      return null;
+    };
+
+    const setFieldValueByTagControlPreUpdate = ({ tag_control_pre_update: tagControlPreUpdate, value }) => {
+      const fieldInfo = findFieldByTagControlPreUpdate(tagControlPreUpdate);
+      if (!fieldInfo) return false;
+
+      fieldInfo.field.value = value;
+      updateFormState({ forceRerender: false, changedField: { ...fieldInfo.field } });
+      return true;
+    };
+
+    const hasFieldByTagControlPreUpdate = ({ tag_control_pre_update: tagControlPreUpdate }) => {
+      return Boolean(findFieldByTagControlPreUpdate(tagControlPreUpdate));
+    };
+
     // Watch for changes in formJson
     watch(() => props.content.formJson, (newValue) => {
       loadFormData();
@@ -541,6 +569,8 @@ export default {
       sectionComponents,
       validateRequiredFields,
       refreshListFieldDataSource,
+      setFieldValueByTagControlPreUpdate,
+      hasFieldByTagControlPreUpdate,
       t
     };
   }


### PR DESCRIPTION
### Motivation
- Permitir que fluxos de ação alterem o valor de um campo do formulário usando seu `tag_control_pre_update` e também oferecer uma verificação se o campo existe por esse mesmo tag.

### Description
- Adicionadas as funções internas `findFieldByTagControlPreUpdate`, `setFieldValueByTagControlPreUpdate` e `hasFieldByTagControlPreUpdate` em `Project/FormRender/Component/wwElement.vue` para localizar, atualizar e verificar campos por `tag_control_pre_update`.
- Exposto `setFieldValueByTagControlPreUpdate` e `hasFieldByTagControlPreUpdate` no objeto retornado do `setup()` para disponibilizá-las como component actions em tempo de execução.
- Registradas as actions `setFieldValueByTagControlPreUpdate` e `hasFieldByTagControlPreUpdate` em `Project/FormRender/Component/ww-config.js` com os argumentos esperados (`tag_control_pre_update` e `value`).

### Testing
- Executada a validação de sintaxe do arquivo de configuração com `node -e` para avaliar `ww-config.js` e a verificação retornou com sucesso.
- Procurados os novos identificadores com `rg` para confirmar inserção dos símbolos e a pesquisa retornou os locais esperados com sucesso.
- Verificado o estado do repositório com `git status --short` e realizado o `commit`, ambos executados com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da9f852888330b8f76b6f1db0134b)