### PR TITLE
Add actions to set/check field by pre-update tag in form renderer

### DIFF
--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -392,6 +392,33 @@ export default {
             action: 'refreshListFieldDataSource',
             label: { en: 'Refresh list field data source' },
             args: []
+        },
+        {
+            action: 'setFieldValueByTagControlPreUpdate',
+            label: { en: 'Set field value by pre-update tag' },
+            args: [
+                {
+                    name: 'tag_control_pre_update',
+                    type: 'string',
+                    label: { en: 'Pre-update tag' }
+                },
+                {
+                    name: 'value',
+                    type: 'string',
+                    label: { en: 'New value' }
+                }
+            ]
+        },
+        {
+            action: 'hasFieldByTagControlPreUpdate',
+            label: { en: 'Check field exists by pre-update tag' },
+            args: [
+                {
+                    name: 'tag_control_pre_update',
+                    type: 'string',
+                    label: { en: 'Pre-update tag' }
+                }
+            ]
         }
     ]
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -389,6 +389,53 @@ export default {
       });
     };
 
+    const findFieldByTagControlPreUpdate = tagControlPreUpdate => {
+      if (!tagControlPreUpdate) return null;
+
+      for (const section of formSections.value) {
+        const field = (section.fields || []).find(
+          currentField => currentField?.tag_control_pre_update === tagControlPreUpdate
+        );
+        if (field) {
+          return { section, field };
+        }
+      }
+
+      return null;
+    };
+
+    const normalizeTagValueActionArgs = (arg1, arg2) => {
+      if (arg1 && typeof arg1 === 'object' && !Array.isArray(arg1)) {
+        return {
+          tagControlPreUpdate: arg1.tag_control_pre_update ?? arg1.tagControlPreUpdate ?? null,
+          value: Object.prototype.hasOwnProperty.call(arg1, 'value') ? arg1.value : arg2
+        };
+      }
+
+      return {
+        tagControlPreUpdate: arg1 ?? null,
+        value: arg2
+      };
+    };
+
+    const setFieldValueByTagControlPreUpdate = (arg1, arg2) => {
+      const { tagControlPreUpdate, value } = normalizeTagValueActionArgs(arg1, arg2);
+      if (!tagControlPreUpdate) return false;
+
+      const fieldInfo = findFieldByTagControlPreUpdate(tagControlPreUpdate);
+      if (!fieldInfo) return false;
+
+      fieldInfo.field.value = value;
+      updateFormState({ forceRerender: false, changedField: { ...fieldInfo.field } });
+      return true;
+    };
+
+    const hasFieldByTagControlPreUpdate = arg1 => {
+      const { tagControlPreUpdate } = normalizeTagValueActionArgs(arg1);
+      if (!tagControlPreUpdate) return false;
+      return !!findFieldByTagControlPreUpdate(tagControlPreUpdate);
+    };
+
     // Watch for changes in formJson
     watch(() => props.content.formJson, (newValue) => {
       loadFormData();
@@ -541,6 +588,8 @@ export default {
       sectionComponents,
       validateRequiredFields,
       refreshListFieldDataSource,
+      setFieldValueByTagControlPreUpdate,
+      hasFieldByTagControlPreUpdate,
       t
     };
   }


### PR DESCRIPTION
### Motivation
- Provide a way for external actions to locate a field by its `tag_control_pre_update` and set its value or check its existence at runtime.

### Description
- Add two new action definitions to `Project/FormRender/Component/ww-config.js`: `setFieldValueByTagControlPreUpdate` and `hasFieldByTagControlPreUpdate` with appropriate `args` schemas.
- Implement field lookup by pre-update tag with `findFieldByTagControlPreUpdate` in `Project/FormRender/Component/wwElement.vue` to return the matching `section` and `field`.
- Add `normalizeTagValueActionArgs` to support both object-style and positional arguments and implement `setFieldValueByTagControlPreUpdate` and `hasFieldByTagControlPreUpdate` helpers that use the lookup and update the form state via `updateFormState`.
- Expose `setFieldValueByTagControlPreUpdate` and `hasFieldByTagControlPreUpdate` from the component setup return value.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da9f852888330b8f76b6f1db0134b)