### PR TITLE
Add API to update/check field by tag_control_pre_update

### DIFF
--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -392,6 +392,34 @@ export default {
             action: 'refreshListFieldDataSource',
             label: { en: 'Refresh list field data source' },
             args: []
+        },
+
+        {
+            action: 'updateFieldValueByTagControlPreUpdate',
+            label: { en: 'Update field value by tag control pre update' },
+            args: [
+                {
+                    name: 'tagControlPreUpdate',
+                    type: 'string',
+                    label: { en: 'Tag control pre update' }
+                },
+                {
+                    name: 'value',
+                    type: 'string',
+                    label: { en: 'New field value' }
+                }
+            ]
+        },
+        {
+            action: 'hasFieldByTagControlPreUpdate',
+            label: { en: 'Check field exists by tag control pre update' },
+            args: [
+                {
+                    name: 'tagControlPreUpdate',
+                    type: 'string',
+                    label: { en: 'Tag control pre update' }
+                }
+            ]
         }
     ]
 };

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -389,6 +389,46 @@ export default {
       });
     };
 
+    const findFieldByTagControlPreUpdate = (tagControlPreUpdate) => {
+      if (!tagControlPreUpdate) return null;
+
+      for (const section of formSections.value) {
+        const field = section.fields.find(currentField => currentField.tag_control_pre_update === tagControlPreUpdate);
+        if (field) return field;
+      }
+
+      return null;
+    };
+
+    const normalizeTagControlPreUpdateArgs = (input, maybeValue) => {
+      if (typeof input === 'object' && input !== null) {
+        return {
+          tagControlPreUpdate: input.tagControlPreUpdate,
+          value: input.value
+        };
+      }
+
+      return {
+        tagControlPreUpdate: input,
+        value: maybeValue
+      };
+    };
+
+    const updateFieldValueByTagControlPreUpdate = (input, maybeValue) => {
+      const { tagControlPreUpdate, value } = normalizeTagControlPreUpdateArgs(input, maybeValue);
+      const field = findFieldByTagControlPreUpdate(tagControlPreUpdate);
+      if (!field) return false;
+
+      field.value = value;
+      updateFormState({ forceRerender: false, changedField: { ...field } });
+      return true;
+    };
+
+    const hasFieldByTagControlPreUpdate = input => {
+      const { tagControlPreUpdate } = normalizeTagControlPreUpdateArgs(input);
+      return Boolean(findFieldByTagControlPreUpdate(tagControlPreUpdate));
+    };
+
     // Watch for changes in formJson
     watch(() => props.content.formJson, (newValue) => {
       loadFormData();
@@ -541,6 +581,8 @@ export default {
       sectionComponents,
       validateRequiredFields,
       refreshListFieldDataSource,
+      updateFieldValueByTagControlPreUpdate,
+      hasFieldByTagControlPreUpdate,
       t
     };
   }


### PR DESCRIPTION
### Motivation

- Provide a runtime API to update a form field value identified by `tag_control_pre_update` and to check if such a field exists so external logic can target fields without internal IDs.  
- Expose these capabilities via the component configuration so they can be invoked as actions.  
- Improve flexibility for pre-update workflows that need to mutate form state programmatically.

### Description

- Add two new actions to `Project/FormRender/Component/ww-config.js`: `updateFieldValueByTagControlPreUpdate` (args: `tagControlPreUpdate`, `value`) and `hasFieldByTagControlPreUpdate` (arg: `tagControlPreUpdate`).  
- Implement `findFieldByTagControlPreUpdate`, `normalizeTagControlPreUpdateArgs`, `updateFieldValueByTagControlPreUpdate`, and `hasFieldByTagControlPreUpdate` in `Project/FormRender/Component/wwElement.vue`.  
- Make `updateFieldValueByTagControlPreUpdate` set `field.value`, call `updateFormState` with `changedField`, and return a boolean success flag.  
- Export the new functions from the component so they are available to consumers.

### Testing

- Ran the project's lint and existing unit test suite after the change, and they completed successfully.  
- No new automated tests were added for these helpers in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0deccdc3ec8330b24063b10fba8f08)