### PR TITLE
feat(FormRender): aceitar atualização de múltiplos campos por tag

### DIFF
--- a/Project/FormRender/Component/ww-config.js
+++ b/Project/FormRender/Component/ww-config.js
@@ -399,14 +399,9 @@ export default {
             label: { en: 'Update field value by tag control pre update' },
             args: [
                 {
-                    name: 'tagControlPreUpdate',
-                    type: 'string',
-                    label: { en: 'Tag control pre update' }
-                },
-                {
-                    name: 'value',
-                    type: 'string',
-                    label: { en: 'New field value' }
+                    name: 'fieldsToUpdate',
+                    type: 'array',
+                    label: { en: 'Fields to update by tag' }
                 }
             ]
         },

--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -415,6 +415,43 @@ export default {
     };
 
     const updateFieldValueByTagControlPreUpdate = (input, maybeValue) => {
+      const parseInputArray = (valueToParse) => {
+        if (Array.isArray(valueToParse)) return valueToParse;
+        if (typeof valueToParse !== 'string') return null;
+
+        try {
+          const parsed = JSON.parse(valueToParse);
+          return Array.isArray(parsed) ? parsed : null;
+        } catch (error) {
+          return null;
+        }
+      };
+
+      const fieldsToUpdate =
+        parseInputArray(input) ||
+        parseInputArray(input?.fieldsToUpdate) ||
+        parseInputArray(input?.values) ||
+        parseInputArray(maybeValue);
+
+      if (fieldsToUpdate?.length) {
+        let hasUpdatedAtLeastOneField = false;
+
+        for (const item of fieldsToUpdate) {
+          if (!item || typeof item !== 'object') continue;
+
+          for (const [tagControlPreUpdate, value] of Object.entries(item)) {
+            const field = findFieldByTagControlPreUpdate(tagControlPreUpdate);
+            if (!field) continue;
+
+            field.value = value;
+            updateFormState({ forceRerender: false, changedField: { ...field } });
+            hasUpdatedAtLeastOneField = true;
+          }
+        }
+
+        return hasUpdatedAtLeastOneField;
+      }
+
       const { tagControlPreUpdate, value } = normalizeTagControlPreUpdateArgs(input, maybeValue);
       const field = findFieldByTagControlPreUpdate(tagControlPreUpdate);
       if (!field) return false;


### PR DESCRIPTION
### Motivation
- Permitir que a action que atualiza campos por `tag_control_pre_update` receba um array de pares `tag -> valor` para atualizar múltiplos campos em uma única chamada em vez de somente um único identificador.

### Description
- Atualiza `updateFieldValueByTagControlPreUpdate` em `Project/FormRender/Component/wwElement.vue` para aceitar um array de objetos, fazer parsing de JSON string quando necessário e iterar atualizando cada campo correspondente por tag.
- Mantém retrocompatibilidade com o formato antigo `(tagControlPreUpdate, value)` como fallback quando não for passado um array.
- Altera `Project/FormRender/Component/ww-config.js` para expor o novo argumento `fieldsToUpdate` do tipo `array` na definição da action.

### Testing
- Executados comandos de verificação e inspeção de arquivos com `git status --short` e `nl -ba Project/FormRender/Component/wwElement.vue | sed -n '400,500p' && nl -ba Project/FormRender/Component/ww-config.js | sed -n '390,435p'`, que retornaram o conteúdo esperado com as alterações aplicadas.
- Commit automático das mudanças foi realizado com `git commit -m "feat(FormRender): aceitar array na action de update por tag"` e concluiu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0df4c6c18c833096bbad698d8421b4)