### PR TITLE
Corrige verificação de existência de campo por tag no FormRender

### DIFF
--- a/Project/FormRender/Component/wwElement.vue
+++ b/Project/FormRender/Component/wwElement.vue
@@ -389,11 +389,22 @@ export default {
       });
     };
 
+    const normalizeTagControlPreUpdate = value => {
+      if (value === null || value === undefined) return '';
+      return String(value).trim().toLowerCase();
+    };
+
+    const readFieldTagControlPreUpdate = field =>
+      field?.tag_control_pre_update ?? field?.tagControlPreUpdate ?? '';
+
     const findFieldByTagControlPreUpdate = (tagControlPreUpdate) => {
-      if (!tagControlPreUpdate) return null;
+      const normalizedTag = normalizeTagControlPreUpdate(tagControlPreUpdate);
+      if (!normalizedTag) return null;
 
       for (const section of formSections.value) {
-        const field = section.fields.find(currentField => currentField.tag_control_pre_update === tagControlPreUpdate);
+        const field = section.fields.find(currentField =>
+          normalizeTagControlPreUpdate(readFieldTagControlPreUpdate(currentField)) === normalizedTag
+        );
         if (field) return field;
       }
 
@@ -403,7 +414,7 @@ export default {
     const normalizeTagControlPreUpdateArgs = (input, maybeValue) => {
       if (typeof input === 'object' && input !== null) {
         return {
-          tagControlPreUpdate: input.tagControlPreUpdate,
+          tagControlPreUpdate: input.tagControlPreUpdate ?? input.tag_control_pre_update,
           value: input.value
         };
       }


### PR DESCRIPTION
### Motivation
- A action que verifica se um campo existe por `tagControlPreUpdate` podia falhar quando havia diferenças de casing ou espaços na tag. 
- Também havia inconsistência entre nomes de propriedade (`tag_control_pre_update` vs `tagControlPreUpdate`) levando a resultados incorretos.

### Description
- Adiciona `normalizeTagControlPreUpdate` para normalizar tags (`trim` + `toLowerCase`) antes da comparação.
- Introduz `readFieldTagControlPreUpdate` para ler a tag do campo aceitando `tag_control_pre_update` e `tagControlPreUpdate`.
- Atualiza `findFieldByTagControlPreUpdate` para comparar tags normalizadas e retorná‑las corretamente quando encontradas.
- Ajusta `normalizeTagControlPreUpdateArgs` para aceitar ambos os formatos de chave no input da action.
- Arquivo modificado: `Project/FormRender/Component/wwElement.vue`.

### Testing
- Nenhum teste automatizado foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dfc3482b08330b57a23eff9001fd7)