### PR TITLE
feat(formbuilder): add label help tooltip with info icon

### DIFF
--- a/Project/FormBuilder/Component/components/FieldComponent.vue
+++ b/Project/FormBuilder/Component/components/FieldComponent.vue
@@ -5,7 +5,11 @@
     :style="componentStyleVars"
   >
     <label v-if="!isLegendHidden" class="field-label">
-      {{ field.name }}
+      <span class="field-label-text">{{ field.name }}</span>
+      <span v-if="field.label_help" class="label-help">
+        <i class="fa-solid fa-circle-info label-help-icon" aria-hidden="true"></i>
+        <span class="label-help-balloon">{{ field.label_help }}</span>
+      </span>
       <span v-if="isMandatory" class="required-indicator">*</span>
     </label>
 
@@ -1021,11 +1025,81 @@ export default {
   }
 
   .field-label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: fit-content;
     font-size: 12px;
     font-weight: 400;
     margin-bottom: 4px;
     color: #787878;
     padding-left: 8px;
+  }
+
+  .field-label-text {
+    line-height: 1.2;
+  }
+
+  .label-help {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #699d8c;
+    cursor: help;
+  }
+
+  .label-help-icon {
+    font-size: 13px;
+  }
+
+  .label-help-balloon {
+    position: absolute;
+    left: calc(100% + 10px);
+    top: 50%;
+    transform: translateY(-50%);
+    min-width: 180px;
+    max-width: 300px;
+    background: #fff;
+    color: #556;
+    border: 2px solid #c6d7d1;
+    border-radius: 26px;
+    padding: 10px 14px;
+    line-height: 1.35;
+    font-size: 12px;
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.12);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 30;
+  }
+
+  .label-help-balloon::before,
+  .label-help-balloon::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #c6d7d1;
+  }
+
+  .label-help-balloon::before {
+    left: -14px;
+    top: calc(50% + 4px);
+    width: 10px;
+    height: 10px;
+  }
+
+  .label-help-balloon::after {
+    left: -24px;
+    top: calc(50% + 12px);
+    width: 7px;
+    height: 7px;
+  }
+
+  .label-help:hover .label-help-balloon {
+    opacity: 1;
+    visibility: visible;
   }
 
   .required-indicator {

--- a/Project/FormBuilder/Component/components/FieldPropertiesPanel.vue
+++ b/Project/FormBuilder/Component/components/FieldPropertiesPanel.vue
@@ -61,6 +61,15 @@
           :placeholder="tipPlaceholder"
         ></textarea>
       </div>
+      <div class="form-group">
+        <label>{{ labelHelpLabel }}</label>
+        <textarea
+          v-model="labelHelpText"
+          class="tip-textarea"
+          @change="updateLabelHelp"
+          :placeholder="labelHelpPlaceholder"
+        ></textarea>
+      </div>
 
       <div class="form-group end-users-group">
         <label class="group-title">End Users</label>
@@ -167,6 +176,14 @@ export default {
       type: String,
       default: 'Enter a tip for this field...'
     },
+    labelHelpLabel: {
+      type: String,
+      default: 'Label help text'
+    },
+    labelHelpPlaceholder: {
+      type: String,
+      default: 'Enter a help text shown near the label...'
+    },
     showOnlyLabel: {
       type: String,
       default: 'Show only'
@@ -186,6 +203,7 @@ export default {
     const isHideLegend = ref(false);
     const columns = ref(1);
     const tipText = ref('');
+    const labelHelpText = ref('');
     const showOnly = ref(false);
     const showOnlyGroups = ref([]);
     const showOnlyOptions = ref([]);
@@ -324,6 +342,7 @@ export default {
         // Handle tip
         const { tipText: nextTipText } = resolveTipState(newField);
         tipText.value = nextTipText;
+        labelHelpText.value = (newField.label_help || '').toString();
       } else {
         resetForm();
       }
@@ -334,6 +353,7 @@ export default {
       isRequired.value = false;
       isHideLegend.value = false;
       tipText.value = '';
+      labelHelpText.value = '';
       showOnly.value = false;
       showOnlyGroups.value = [];
       columns.value = 1;
@@ -404,6 +424,9 @@ export default {
       
       emit('update-field', updatedField);
     };
+    const updateLabelHelp = () => {
+      updateFieldProperty('label_help', (labelHelpText.value || '').toString());
+    };
 
     const loadShowOnlyOptions = () => {
       try {
@@ -473,6 +496,7 @@ export default {
       isHideLegend,
       columns,
       tipText,
+      labelHelpText,
       showOnly,
       showOnlyGroups,
       showOnlyOptions,
@@ -481,6 +505,7 @@ export default {
       isHiddenInEndUserViewTicket,
       updateFieldProperty,
       updateTip,
+      updateLabelHelp,
       updateShowOnlyGroups
     };
   }

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -1961,7 +1961,8 @@ return;
         columns: 1,
         is_mandatory: false,
         is_readonly: false,
-        is_hide_legend: false
+        is_hide_legend: false,
+        label_help: ''
       };
       isNewField.value = true;
       fieldModalVisible.value = true;


### PR DESCRIPTION
### Motivation

- Permitir adicionar um texto de ajuda associado ao label do campo e exibi-lo como um balão estilizado ao passar o mouse sobre um ícone de informação.

### Description

- Adiciona o campo configurável `label_help` nos campos criados por padrão em `Project/FormBuilder/Component/wwElement.vue` para garantir persistência inicial do valor.
- Expõe uma nova propriedade editável no painel de propriedades em `Project/FormBuilder/Component/components/FieldPropertiesPanel.vue` com `labelHelpLabel`, `labelHelpPlaceholder`, estado `labelHelpText` e ação `updateLabelHelp` que emite a alteração para `label_help`.
- Renderiza um ícone Font Awesome `circle-info` ao lado do label dentro de `Project/FormBuilder/Component/components/FieldComponent.vue` quando `field.label_help` estiver preenchido, e adiciona um balão de ajuda com estilo tipo “balão de pensamento” (bordas arredondadas, bolhinhas e sombra) exibido no hover.
- Inclui o CSS necessário para posicionamento do ícone e animação/estilo do balão no mesmo componente para preservar escopo e aparência.

### Testing

- Executado `rg -n "label_help|label-help"` para validar referências nos arquivos modificados; a busca retornou as ocorrências esperadas com sucesso.  
- Verificado o estado do repositório com `git -C /workspace/NewCode status --short` e confirmado que os arquivos foram adicionados e commitados com `git -C /workspace/NewCode commit -m "feat(formbuilder): add label help tooltip with info icon"`, ambos comandos concluíram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eed8d63b8833092f7fb5a769bea83)