### PR TITLE
feat(labelHelp): add optional help tooltip with comic-style balloon

### DIFF
--- a/Project/labelHelp/src/wwElement.vue
+++ b/Project/labelHelp/src/wwElement.vue
@@ -1,5 +1,12 @@
 <template>
-    <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+    <div class="label-help-wrapper">
+        <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+
+        <span v-if="helpText" class="label-help" :aria-label="helpText">
+            <i class="fa-solid fa-circle-info label-help-icon" aria-hidden="true"></i>
+            <span class="label-help-balloon">{{ helpText }}</span>
+        </span>
+    </div>
 </template>
 
 <script>
@@ -22,6 +29,9 @@ export default {
         },
         text() {
             return this.wwElementState.props.text;
+        },
+        helpText() {
+            return (this.wwElementState.props.helpText || '').toString().trim();
         },
         isEditing() {
             /* wwEditor:start */
@@ -77,7 +87,76 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.label-help-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .-link {
     cursor: pointer;
+}
+
+.label-help {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #699d8c;
+    cursor: help;
+    line-height: 1;
+}
+
+.label-help-icon {
+    font-size: 0.9em;
+}
+
+.label-help-balloon {
+    position: absolute;
+    left: calc(100% + 10px);
+    top: 50%;
+    transform: translateY(-50%);
+    min-width: 180px;
+    max-width: 320px;
+    background: #fff;
+    color: #556;
+    border: 2px solid #c6d7d1;
+    border-radius: 26px;
+    padding: 10px 14px;
+    line-height: 1.35;
+    font-size: 12px;
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.12);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 30;
+}
+
+.label-help-balloon::before,
+.label-help-balloon::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #c6d7d1;
+}
+
+.label-help-balloon::before {
+    left: -14px;
+    top: calc(50% + 4px);
+    width: 10px;
+    height: 10px;
+}
+
+.label-help-balloon::after {
+    left: -24px;
+    top: calc(50% + 12px);
+    width: 7px;
+    height: 7px;
+}
+
+.label-help:hover .label-help-balloon {
+    opacity: 1;
+    visibility: visible;
 }
 </style>

--- a/Project/labelHelp/ww-config.js
+++ b/Project/labelHelp/ww-config.js
@@ -41,5 +41,16 @@ export default {
             },
             defaultValue: 'p',
         },
+        helpText: {
+            label: {
+                en: 'Help text',
+                pt: 'Texto de ajuda',
+                fr: "Texte d'aide",
+            },
+            type: 'TextArea',
+            section: 'settings',
+            bindable: true,
+            defaultValue: '',
+        },
     },
 };


### PR DESCRIPTION
### Motivation
- Permitir que o componente de label exiba um texto de ajuda contextual configurável via propriedade para melhorar a usabilidade dos campos. 
- Mostrar um ícone `fa-circle-info` à direita do label quando houver ajuda disponível para sinalizar informação extra ao usuário. 
- Exibir o texto de ajuda em um balão estilizado (estética de “balão de pensamento”) para manter a apresentação visual consistente e atraente.

### Description
- Adicionada a propriedade `helpText` em `Project/labelHelp/ww-config.js` como `TextArea`, com suporte a rótulos em múltiplos idiomas, `bindable` e `defaultValue: ''` para configuração no editor. 
- Atualizado `Project/labelHelp/src/wwElement.vue` para renderizar um wrapper ao redor do texto e, quando `helpText` estiver preenchido, exibir o ícone Font Awesome `fa-circle-info` e o balão com `{{ helpText }}`. 
- Adicionado o `computed` `helpText` no componente para normalizar a propriedade e evitar renderização quando vazia. 
- Implementada a estilização SCSS do balão e das bolhas auxiliares para reproduzir o efeito de balão de pensamento, com exibição por `:hover` do ícone.

### Testing
- Nenhum teste automatizado foi executado para estas alterações.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eef0106f88330b4722c599799dd4f)