### PR TITLE
Add configurable help text tooltip to wwElement and editor config

### DIFF
--- a/Project/labelHelp/src/wwElement.vue
+++ b/Project/labelHelp/src/wwElement.vue
@@ -1,5 +1,12 @@
 <template>
-    <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+    <div class="label-help-wrapper">
+        <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+
+        <span v-if="helpText" class="label-help" :aria-label="helpText">
+            <i class="fa-solid fa-circle-info label-help-icon" aria-hidden="true"></i>
+            <span class="label-help-balloon">{{ helpText }}</span>
+        </span>
+    </div>
 </template>
 
 <script>
@@ -22,6 +29,29 @@ export default {
         },
         text() {
             return this.wwElementState.props.text;
+        },
+        helpText() {
+            const candidates = [
+                this.content?.helpText,
+                this.content?._wwText_helpText,
+                this.content?.['_ww-text_helpText'],
+                this.content?._ww_text_helpText,
+                this.content?._ww_textarea_helpText,
+                this.content?.['custom-0']?.helpText,
+                this.wwElementState?.props?.helpText,
+                this.wwElementState?.props?.['custom-0']?.helpText,
+            ];
+
+            const rawValue = candidates.find(value => value !== undefined && value !== null && value !== '');
+            if (!rawValue) return '';
+
+            if (typeof rawValue === 'object') {
+                const lang = wwLib?.wwLang?.lang;
+                const textByLang = (lang && rawValue[lang]) || rawValue.en || rawValue.pt || rawValue.pt_br;
+                return (textByLang || '').toString().trim();
+            }
+
+            return rawValue.toString().trim();
         },
         isEditing() {
             /* wwEditor:start */
@@ -77,7 +107,76 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.label-help-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .-link {
     cursor: pointer;
+}
+
+.label-help {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #699d8c;
+    cursor: help;
+    line-height: 1;
+}
+
+.label-help-icon {
+    font-size: 0.9em;
+}
+
+.label-help-balloon {
+    position: absolute;
+    left: calc(100% + 10px);
+    top: 50%;
+    transform: translateY(-50%);
+    min-width: 180px;
+    max-width: 320px;
+    background: #fff;
+    color: #556;
+    border: 2px solid #c6d7d1;
+    border-radius: 26px;
+    padding: 10px 14px;
+    line-height: 1.35;
+    font-size: 12px;
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.12);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 30;
+}
+
+.label-help-balloon::before,
+.label-help-balloon::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #c6d7d1;
+}
+
+.label-help-balloon::before {
+    left: -14px;
+    top: calc(50% + 4px);
+    width: 10px;
+    height: 10px;
+}
+
+.label-help-balloon::after {
+    left: -24px;
+    top: calc(50% + 12px);
+    width: 7px;
+    height: 7px;
+}
+
+.label-help:hover .label-help-balloon {
+    opacity: 1;
+    visibility: visible;
 }
 </style>

--- a/Project/labelHelp/ww-config.js
+++ b/Project/labelHelp/ww-config.js
@@ -41,5 +41,16 @@ export default {
             },
             defaultValue: 'p',
         },
+        helpText: {
+            label: {
+                en: 'Help text',
+                pt: 'Texto de ajuda',
+                fr: "Texte d'aide",
+            },
+            type: 'TextArea',
+            section: 'settings',
+            bindable: true,
+            defaultValue: '',
+        },
     },
 };


### PR DESCRIPTION
### Motivation
- Provide an inline help/tooltip for label elements so editors can display contextual help to end users. 
- Support multiple legacy and localized helpText sources so the component can read help strings stored under different keys and languages. 
- Make the help text configurable and bindable from the element configuration so editors can set it in the editor UI. 

### Description
- Render a help icon and balloon next to the element by wrapping `wwText` in a `.label-help-wrapper` and conditionally showing a `.label-help` block when `helpText` is present. 
- Add a computed `helpText` that checks multiple candidate keys (including legacy keys and `wwElementState.props`) and resolves localized objects to the current language before returning a trimmed string. 
- Add scoped styles for the wrapper, icon and balloon tooltip including positioning, visibility transitions, and small decorative pseudo-elements. 
- Add a `helpText` property to `Project/labelHelp/ww-config.js` with labels for `en`, `pt` and `fr`, type `TextArea`, `bindable: true`, and an empty default. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eef0106f88330b4722c599799dd4f)