### PR TITLE
Add configurable help tooltip to label element with localization support

### DIFF
--- a/Project/labelHelp/src/wwElement.vue
+++ b/Project/labelHelp/src/wwElement.vue
@@ -1,5 +1,12 @@
 <template>
-    <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+    <div class="label-help-wrapper">
+        <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+
+        <span v-if="helpText" class="label-help" :aria-label="helpText">
+            <i class="fa-solid fa-circle-info label-help-icon" aria-hidden="true"></i>
+            <span class="label-help-balloon">{{ helpText }}</span>
+        </span>
+    </div>
 </template>
 
 <script>
@@ -22,6 +29,29 @@ export default {
         },
         text() {
             return this.wwElementState.props.text;
+        },
+        helpText() {
+            const candidates = [
+                this.content?.helpText,
+                this.content?._wwText_helpText,
+                this.content?.['_ww-text_helpText'],
+                this.content?._ww_text_helpText,
+                this.content?._ww_textarea_helpText,
+                this.content?.['custom-0']?.helpText,
+                this.wwElementState?.props?.helpText,
+                this.wwElementState?.props?.['custom-0']?.helpText,
+            ];
+
+            const rawValue = candidates.find(value => value !== undefined && value !== null && value !== '');
+            if (!rawValue) return '';
+
+            if (typeof rawValue === 'object') {
+                const lang = wwLib?.wwLang?.lang;
+                const textByLang = (lang && rawValue[lang]) || rawValue.en || rawValue.pt || rawValue.pt_br;
+                return (textByLang || '').toString().trim();
+            }
+
+            return rawValue.toString().trim();
         },
         isEditing() {
             /* wwEditor:start */
@@ -77,7 +107,90 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.label-help-wrapper,
+.label-help-wrapper.ww-element {
+    display: inline-flex !important;
+    align-items: center;
+    gap: 6px;
+    vertical-align: middle;
+}
+
 .-link {
     cursor: pointer;
+}
+
+.label-help {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #699d8c;
+    cursor: help;
+    line-height: 1;
+}
+
+.label-help-icon {
+    font-size: 0.9em;
+    min-width: 1em;
+    text-align: center;
+}
+
+.label-help-icon::before {
+    font-family: 'Font Awesome 6 Free', 'Font Awesome 5 Free';
+    font-weight: 900;
+}
+
+.label-help-icon:empty::after {
+    content: 'ⓘ';
+    font-family: inherit;
+}
+
+.label-help-balloon {
+    position: absolute;
+    left: calc(100% + 10px);
+    top: 50%;
+    transform: translateY(-50%);
+    min-width: 180px;
+    max-width: 320px;
+    background: #fff;
+    color: #556;
+    border: 2px solid #c6d7d1;
+    border-radius: 26px;
+    padding: 10px 14px;
+    line-height: 1.35;
+    font-size: 12px;
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.12);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 30;
+}
+
+.label-help-balloon::before,
+.label-help-balloon::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #c6d7d1;
+}
+
+.label-help-balloon::before {
+    left: -14px;
+    top: calc(50% + 4px);
+    width: 10px;
+    height: 10px;
+}
+
+.label-help-balloon::after {
+    left: -24px;
+    top: calc(50% + 12px);
+    width: 7px;
+    height: 7px;
+}
+
+.label-help:hover .label-help-balloon {
+    opacity: 1;
+    visibility: visible;
 }
 </style>

--- a/Project/labelHelp/ww-config.js
+++ b/Project/labelHelp/ww-config.js
@@ -41,5 +41,16 @@ export default {
             },
             defaultValue: 'p',
         },
+        helpText: {
+            label: {
+                en: 'Help text',
+                pt: 'Texto de ajuda',
+                fr: "Texte d'aide",
+            },
+            type: 'TextArea',
+            section: 'settings',
+            bindable: true,
+            defaultValue: '',
+        },
     },
 };


### PR DESCRIPTION
### Motivation
- Provide an inline help UI for label/text elements so editors can attach contextual help shown to end users on hover. 
- Support multiple storage keys and localized values so existing content formats and translations are respected. 

### Description
- Wrap the existing `wwText` in a `label-help-wrapper` and render a help icon and balloon when `helpText` is present, with `aria-label` for accessibility. 
- Implement a `helpText` computed property that checks multiple possible content keys and returns a localized string fallback sequence (`lang`, `en`, `pt`, `pt_br`) and trims values. 
- Add scoped styles for `.label-help-wrapper`, `.label-help`, `.label-help-icon`, and `.label-help-balloon` to position and animate the tooltip and include a Font Awesome fallback glyph. 
- Add a new `helpText` property to `ww-config.js` with `TextArea`, `bindable: true`, localization labels, and an empty default value. 

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eef0106f88330b4722c599799dd4f)