### PR TITLE
Add help-text tooltip to wwElement with FontAwesome icon and configurable property

### DIFF
--- a/Project/labelHelp/src/wwElement.vue
+++ b/Project/labelHelp/src/wwElement.vue
@@ -1,5 +1,12 @@
 <template>
-    <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+    <div class="label-help-wrapper">
+        <wwText :tag="tag" :text="text" v-bind="properties" :class="{ '-link': hasLink && !isEditing }"></wwText>
+
+        <span v-if="helpText" class="label-help" :aria-label="helpText">
+            <i class="fa-solid fa-circle-info label-help-icon" aria-hidden="true"></i>
+            <span class="label-help-balloon">{{ helpText }}</span>
+        </span>
+    </div>
 </template>
 
 <script>
@@ -23,6 +30,29 @@ export default {
         text() {
             return this.wwElementState.props.text;
         },
+        helpText() {
+            const candidates = [
+                this.content?.helpText,
+                this.content?._wwText_helpText,
+                this.content?.['_ww-text_helpText'],
+                this.content?._ww_text_helpText,
+                this.content?._ww_textarea_helpText,
+                this.content?.['custom-0']?.helpText,
+                this.wwElementState?.props?.helpText,
+                this.wwElementState?.props?.['custom-0']?.helpText,
+            ];
+
+            const rawValue = candidates.find(value => value !== undefined && value !== null && value !== '');
+            if (!rawValue) return '';
+
+            if (typeof rawValue === 'object') {
+                const lang = wwLib?.wwLang?.lang;
+                const textByLang = (lang && rawValue[lang]) || rawValue.en || rawValue.pt || rawValue.pt_br;
+                return (textByLang || '').toString().trim();
+            }
+
+            return rawValue.toString().trim();
+        },
         isEditing() {
             /* wwEditor:start */
             return this.wwEditorState.editMode === wwLib.wwEditorHelper.EDIT_MODES.EDITION;
@@ -31,17 +61,32 @@ export default {
             return false;
         },
     },
+    mounted() {
+        this.ensureFontAwesome();
+        /* wwEditor:start */
+        this.checkListTags(this.content['_ww-text_text']);
+        /* wwEditor:end */
+    },
     /* wwEditor:start */
     watch: {
         'content._ww-text_text'() {
             this.checkListTags(this.content['_ww-text_text']);
         },
     },
-    mounted() {
-        this.checkListTags(this.content['_ww-text_text']);
-    },
     /* wwEditor:end */
     methods: {
+        ensureFontAwesome() {
+            if (typeof document === 'undefined') return;
+            const id = 'label-help-fontawesome-6';
+            if (document.getElementById(id)) return;
+
+            const link = document.createElement('link');
+            link.id = id;
+            link.rel = 'stylesheet';
+            link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css';
+            link.referrerPolicy = 'no-referrer';
+            document.head.appendChild(link);
+        },
         /* wwEditor:start */
         checkListTags(text) {
             if (this.content.tag === 'p' && text && text[wwLib.wwLang.lang] && text[wwLib.wwLang.lang].indexOf) {
@@ -77,7 +122,90 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.label-help-wrapper,
+.label-help-wrapper.ww-element {
+    display: inline-flex !important;
+    align-items: center;
+    gap: 6px;
+    vertical-align: middle;
+}
+
 .-link {
     cursor: pointer;
+}
+
+.label-help {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    color: #699d8c;
+    cursor: help;
+    line-height: 1;
+}
+
+.label-help-icon {
+    font-size: 0.9em;
+    min-width: 1em;
+    text-align: center;
+}
+
+.label-help-icon::before {
+    font-family: 'Font Awesome 6 Free', 'Font Awesome 5 Free';
+    font-weight: 900;
+}
+
+.label-help-icon:empty::after {
+    content: 'ⓘ';
+    font-family: inherit;
+}
+
+.label-help-balloon {
+    position: absolute;
+    left: calc(100% + 10px);
+    top: calc(50% - 12px);
+    transform: translateY(-100%);
+    min-width: 180px;
+    max-width: 320px;
+    background: #fff;
+    color: #556;
+    border: 2px solid #c6d7d1;
+    border-radius: 26px;
+    padding: 10px 14px;
+    line-height: 1.35;
+    font-size: 12px;
+    box-shadow: 0 10px 18px rgba(0, 0, 0, 0.12);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    z-index: 30;
+}
+
+.label-help-balloon::before,
+.label-help-balloon::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    background: #fff;
+    border: 2px solid #c6d7d1;
+}
+
+.label-help-balloon::before {
+    left: -14px;
+    top: calc(100% - 10px);
+    width: 10px;
+    height: 10px;
+}
+
+.label-help-balloon::after {
+    left: -24px;
+    top: calc(100% - 2px);
+    width: 7px;
+    height: 7px;
+}
+
+.label-help:hover .label-help-balloon {
+    opacity: 1;
+    visibility: visible;
 }
 </style>

--- a/Project/labelHelp/ww-config.js
+++ b/Project/labelHelp/ww-config.js
@@ -41,5 +41,16 @@ export default {
             },
             defaultValue: 'p',
         },
+        helpText: {
+            label: {
+                en: 'Help text',
+                pt: 'Texto de ajuda',
+                fr: "Texte d'aide",
+            },
+            type: 'TextArea',
+            section: 'settings',
+            bindable: true,
+            defaultValue: '',
+        },
     },
 };


### PR DESCRIPTION
### Motivation
- Provide inline contextual help for label elements by showing a tooltip when a help text is available. 
- Support multiple legacy data keys and i18n values so help text works with existing content shapes and languages.

### Description
- Wrap the existing `wwText` output in a `.label-help-wrapper` and render a help icon and balloon when `helpText` is present, including `aria-label` for accessibility. 
- Add a `helpText` computed property that selects the first non-empty candidate from several legacy and modern keys and resolves language variants when the value is an object. 
- Ensure Font Awesome is available by adding an `ensureFontAwesome` method called on `mounted`, and merge this with the existing `checkListTags` invocation. 
- Add scoped styles for the wrapper, help icon, and balloon, and add a `helpText` property to `ww-config.js` with translations and `bindable: true`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0eef0106f88330b4722c599799dd4f)