### PR TITLE
feat(treeGrid): suporte a chipList com contador e popup de overflow

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -121,6 +121,43 @@
                                     <span v-html="highlightCell(row, column)"></span>
                                 </div>
                             </template>
+                            <template v-else-if="column.type === 'chiplist'">
+                                <div
+                                    class="tree-cell-chip-list"
+                                    @mouseenter="onChipCellHover(row, column, true)"
+                                    @mouseleave="onChipCellHover(row, column, false)"
+                                >
+                                    <div class="tree-cell-chip-list__chips">
+                                        <span
+                                            v-for="(chip, index) in getVisibleChips(row, column)"
+                                            :key="`chip-${row.id}-${column.field}-${index}`"
+                                            class="tree-cell-chip"
+                                            :style="getChipStyle(chip)"
+                                        >
+                                            {{ chip.label }}
+                                        </span>
+                                        <span
+                                            v-if="getHiddenChipCount(row, column) > 0"
+                                            class="tree-cell-chip tree-cell-chip--counter"
+                                        >
+                                            +{{ getHiddenChipCount(row, column) }}
+                                        </span>
+                                    </div>
+                                    <div
+                                        v-if="shouldShowChipPopup(row, column)"
+                                        class="tree-cell-chip-list__popup"
+                                    >
+                                        <span
+                                            v-for="(chip, index) in getChipList(row, column)"
+                                            :key="`popup-chip-${row.id}-${column.field}-${index}`"
+                                            class="tree-cell-chip"
+                                            :style="getChipStyle(chip)"
+                                        >
+                                            {{ chip.label }}
+                                        </span>
+                                    </div>
+                                </div>
+                            </template>
                             <template v-else>
                                 <span v-html="highlightCell(row, column)"></span>
                             </template>
@@ -205,6 +242,7 @@
             draggingRowDepth: null,
             dropTargetRowId: null,
             orderOverrides: {},
+            hoveredChipCellKey: null,
             editingNodeId: null,
             editingLabel: '',
             labelOverrides: {},
@@ -558,6 +596,93 @@
             return `${value}`;
         },
 
+
+        getChipCellKey(row, column) {
+            return `${row?.id ?? ''}::${column?.field ?? ''}`;
+        },
+        onChipCellHover(row, column, isHover) {
+            const key = this.getChipCellKey(row, column);
+            this.hoveredChipCellKey = isHover ? key : null;
+        },
+        parseChipList(value) {
+            if (!value) return [];
+            const parsedValue = typeof value === 'string' ? JSON.parse(value) : value;
+            const tags = Array.isArray(parsedValue) ? parsedValue : parsedValue?.tags;
+            if (!Array.isArray(tags)) return [];
+            return tags
+                .map(item => ({
+                    label: `${item?.label ?? ''}`.trim(),
+                    color: `${item?.color ?? ''}`.trim(),
+                }))
+                .filter(item => item.label);
+        },
+        getChipList(row, column) {
+            try {
+                return this.parseChipList(row?.raw?.[column.field]);
+            } catch (error) {
+                return [];
+            }
+        },
+        measureChipWidth(label, isCounter = false) {
+            if (typeof document === 'undefined') return 0;
+            const el = document.createElement('span');
+            el.className = isCounter ? 'tree-cell-chip tree-cell-chip--counter' : 'tree-cell-chip';
+            el.style.position = 'absolute';
+            el.style.visibility = 'hidden';
+            el.style.pointerEvents = 'none';
+            el.style.left = '-9999px';
+            el.textContent = label;
+            document.body.appendChild(el);
+            const width = el.offsetWidth;
+            document.body.removeChild(el);
+            return width;
+        },
+        getChipListLayout(row, column) {
+            const chips = this.getChipList(row, column);
+            const widthRaw = column?.width && `${column.width}`.trim() ? `${column.width}`.trim() : '';
+            const containerWidth = Number.parseFloat(widthRaw);
+            if (!Number.isFinite(containerWidth) || containerWidth <= 0) {
+                return { visible: chips, hiddenCount: 0 };
+            }
+
+            const gap = 4;
+            let usedWidth = 0;
+            let visibleCount = 0;
+
+            for (let index = 0; index < chips.length; index += 1) {
+                const chip = chips[index];
+                const chipWidth = this.measureChipWidth(chip.label);
+                const remaining = chips.length - (index + 1);
+                const counterWidth = remaining > 0 ? this.measureChipWidth(`+${remaining}`, true) + gap : 0;
+                const space = visibleCount > 0 ? gap : 0;
+                if (usedWidth + chipWidth + space + counterWidth <= containerWidth) {
+                    usedWidth += chipWidth + space;
+                    visibleCount += 1;
+                    continue;
+                }
+                break;
+            }
+
+            if (visibleCount === 0 && chips.length > 0) visibleCount = 1;
+            const hiddenCount = Math.max(0, chips.length - visibleCount);
+            return { visible: chips.slice(0, visibleCount), hiddenCount };
+        },
+        getVisibleChips(row, column) {
+            return this.getChipListLayout(row, column).visible;
+        },
+        getHiddenChipCount(row, column) {
+            return this.getChipListLayout(row, column).hiddenCount;
+        },
+        shouldShowChipPopup(row, column) {
+            const key = this.getChipCellKey(row, column);
+            return this.hoveredChipCellKey === key && this.getHiddenChipCount(row, column) > 0;
+        },
+        getChipStyle(chip) {
+            return {
+                backgroundColor: chip.color || '#E5E7EB',
+                color: '#1f2937',
+            };
+        },
         getDivColorStyle(row, column) {
             const style = {
                 padding: '3px 10px',
@@ -1312,6 +1437,55 @@
         text-align: right;
         font-size: 12px;
         color: #495057;
+    }
+
+
+    .tree-cell-chip-list {
+        position: relative;
+        display: inline-flex;
+        max-width: 100%;
+    }
+
+    .tree-cell-chip-list__chips {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        overflow: hidden;
+        max-width: 100%;
+    }
+
+    .tree-cell-chip {
+        display: inline-flex;
+        align-items: center;
+        padding: 2px 8px;
+        border-radius: 999px;
+        font-size: 12px;
+        line-height: 16px;
+        white-space: nowrap;
+        flex: 0 0 auto;
+    }
+
+    .tree-cell-chip--counter {
+        background: #e5e7eb;
+        color: #374151;
+        font-weight: 600;
+    }
+
+    .tree-cell-chip-list__popup {
+        position: absolute;
+        z-index: 20;
+        top: calc(100% + 6px);
+        left: 0;
+        min-width: 220px;
+        max-width: 340px;
+        padding: 10px;
+        border-radius: 10px;
+        border: 1px solid #e5e7eb;
+        background: #fff;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
     }
 
     .empty-state {


### PR DESCRIPTION
### Motivation
- Adicionar suporte ao tipo de coluna `chipList` no componente `treeGrid` para renderizar valores JSON de tags como chips dentro das células e apresentar um comportamento de overflow com contador e popup.

### Description
- Inclui um bloco de template para `column.type === 'chiplist'` que renderiza chips visíveis e um chip contador `+N` quando houver overflow, além de um popup com todos os chips quando o usuário posiciona o mouse sobre a célula.
- Adiciona propriedades e métodos de parsing e layout: `parseChipList`, `getChipList`, `measureChipWidth`, `getChipListLayout`, `getVisibleChips`, `getHiddenChipCount`, `getChipCellKey`, `onChipCellHover`, `shouldShowChipPopup` e `getChipStyle` para lidar com leitura do JSON, cálculo de quantos chips cabem e controle de hover para o popup.
- Inclui um estado reativo `hoveredChipCellKey` no `data()` para rastrear a célula em hover e condiciona a exibição do popup somente quando houver chips ocultos.
- Adiciona estilos CSS específicos para `tree-cell-chip-list`, `tree-cell-chip`, `tree-cell-chip--counter` e `tree-cell-chip-list__popup` para apresentação inline, contador e popup estilizado.

### Testing
- Executado `cd Project/treeGrid && npm run -s lint` e a validação de lint não pôde ser executada por ausência de `package.json` na pasta, portanto não foi possível concluir o lint (falha automática).
- Executado `cd Project/treeGrid && npm run` e a execução falhou com `ENOENT` por falta de `package.json`, logo nenhum script de build/test foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10991412bc8330ad1b661b9400d375)