### PR TITLE
Fix treeGrid row icon class resolution for Font Awesome 6

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -57,7 +57,7 @@
                 </button>
                 <span v-else class="toggle-placeholder"></span>
 
-                <i v-if="row.icon" class="fa node-icon" :class="normalizeNodeIconClass(row.icon)" aria-hidden="true"></i>
+                <i v-if="row.icon" class="node-icon" :class="normalizeNodeIconClass(row.icon)" aria-hidden="true"></i>
                 <span v-else-if="showIconColumn" class="node-icon node-icon--placeholder"></span>
                 <template v-if="isRowBeingEdited(row)">
                     <div class="node-label-edit" @click.stop>
@@ -788,8 +788,14 @@
         normalizeNodeIconClass(icon) {
             const value = `${icon || ''}`.trim();
             if (!value) return '';
-            if (value.includes('fa-')) return value;
-            return `fa-${value}`;
+
+            const hasStylePrefix = /(^|\s)fa-(solid|regular|light|thin|duotone|brands)(\s|$)/.test(value);
+            const hasIconClass = /(^|\s)fa-[\w-]+(\s|$)/.test(value);
+
+            if (hasStylePrefix && hasIconClass) return value;
+            if (hasIconClass) return `fa-solid ${value}`;
+
+            return `fa-solid fa-${value}`;
         },
         escapeRegex(value) {
             return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
### Motivation
- Row icons provided via the `iconField` (e.g. `icon: "box-archive"`) were not displayed because the component forced the old `fa` base class and did not generate Font Awesome 6 style class combinations expected by project assets. 

### Description
- Removed the forced `fa` base class in the row icon element so the `<i>` only includes `node-icon` plus resolved classes by using `normalizeNodeIconClass`. 
- Reworked `normalizeNodeIconClass` to produce FA6-compatible class lists and to preserve already-qualified classes, including handling raw icon names (e.g. `box-archive` → `fa-solid fa-box-archive`), single `fa-xxx` classes (e.g. `fa-box-archive` → `fa-solid fa-box-archive`), and full class lists (e.g. `fa-solid fa-box-archive`) unchanged. 
- Modified file: `Project/treeGrid/src/wwElement.vue`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a89a1dd48330ad80d3ac702f4670)