### PR TITLE
Normalize FontAwesome icon classes and update icon rendering

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -57,7 +57,7 @@
                 </button>
                 <span v-else class="toggle-placeholder"></span>
 
-                <i v-if="row.icon" class="fa node-icon" :class="normalizeNodeIconClass(row.icon)" aria-hidden="true"></i>
+                <i v-if="row.icon" class="node-icon" :class="normalizeNodeIconClass(row.icon)" aria-hidden="true"></i>
                 <span v-else-if="showIconColumn" class="node-icon node-icon--placeholder"></span>
                 <template v-if="isRowBeingEdited(row)">
                     <div class="node-label-edit" @click.stop>
@@ -788,8 +788,15 @@
         normalizeNodeIconClass(icon) {
             const value = `${icon || ''}`.trim();
             if (!value) return '';
-            if (value.includes('fa-')) return value;
-            return `fa-${value}`;
+
+            const parts = value.split(/\s+/).filter(Boolean);
+            const iconClass = parts.find(part => /^fa-[\w-]+$/.test(part) && !/^fa-(solid|regular|light|thin|duotone|brands)$/.test(part));
+            const styleClass = parts.find(part => /^fa-(solid|regular|light|thin|duotone|brands)$/.test(part));
+
+            const normalizedIconClass = iconClass || `fa-${value.replace(/^fa-/, '')}`;
+            const normalizedStyleClass = styleClass || 'fa-solid';
+
+            return `fa ${normalizedStyleClass} ${normalizedIconClass}`;
         },
         escapeRegex(value) {
             return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
### Motivation
- Ensure node icons render reliably with FontAwesome v5/6 style prefixes and icon names by normalizing incoming icon strings.
- Avoid duplicating base `fa` class in the template while guaranteeing a style class (like `fa-solid`) is present.
- Fix cases where multiple class tokens or style-only tokens were provided and produced incorrect or missing icon classes.

### Description
- Removed the hard-coded `fa` class from the template `i` element so classes are fully provided by the normalization routine. 
- Rewrote `normalizeNodeIconClass` to parse space-separated tokens, pick a specific icon token matching `fa-<name>` and a style token (e.g. `fa-solid`, `fa-regular`), and fall back to `fa-solid` when no style is found. 
- Ensure the returned class string always includes the base `fa`, a style class, and an icon class, and return an empty string when no icon is provided.

### Testing
- Ran lint with `npm run lint` and it completed successfully. 
- Ran unit tests with `npm test` and all tests passed. 
- Performed a production build with `npm run build` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a89a1dd48330ad80d3ac702f4670)