### PR TITLE
treeGrid: adicionar tipo de coluna `icon` e remover símbolo de moeda em `currency`

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -158,6 +158,13 @@
                                     </div>
                                 </div>
                             </template>
+                            <template v-else-if="column.type === 'icon'">
+                                <i
+                                    v-if="normalizeFontAwesomeIconClass(row?.raw?.[column.field])"
+                                    :class="normalizeFontAwesomeIconClass(row?.raw?.[column.field])"
+                                    aria-hidden="true"
+                                ></i>
+                            </template>
                             <template v-else>
                                 <span v-html="highlightCell(row, column)"></span>
                             </template>
@@ -588,8 +595,8 @@
                 const numberValue = Number(value);
                 if (!Number.isFinite(numberValue)) return `${value}`;
                 return new Intl.NumberFormat(undefined, {
-                    style: 'currency',
-                    currency: this.content.currencyCode || 'BRL',
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
                 }).format(numberValue);
             }
 
@@ -785,6 +792,21 @@
         hideContextActions() {
             this.contextNodeId = null;
         },
+
+        normalizeFontAwesomeIconClass(icon) {
+            const value = `${icon || ''}`.trim();
+            if (!value) return '';
+
+            const parts = value.split(/\s+/).filter(Boolean);
+            const iconClass = parts.find(part => /^fa-[\w-]+$/.test(part) && !/^fa-(solid|regular|light|thin|duotone|brands)$/.test(part));
+            const styleClass = parts.find(part => /^fa-(solid|regular|light|thin|duotone|brands)$/.test(part));
+
+            const normalizedIconClass = iconClass || `fa-${value.replace(/^fa-/, '')}`;
+            const normalizedStyleClass = styleClass || 'fa-solid';
+
+            return `fa ${normalizedStyleClass} ${normalizedIconClass}`;
+        },
+
         normalizeNodeIconClass(icon) {
             const value = `${icon || ''}`.trim();
             if (!value) return '';


### PR DESCRIPTION
### Motivation
- Permitir exibir ícones Font Awesome em colunas do componente `treeGrid` e ajustar a apresentação de valores monetários para mostrar apenas o número com duas casas decimais.

### Description
- Adicionei a renderização para colunas com `column.type === 'icon'` exibindo um elemento `<i>` com classes FA normalizadas. (arquivo `Project/treeGrid/src/wwElement.vue`).
- Implementei o método `normalizeFontAwesomeIconClass(icon)` para normalizar entradas como `box-archive` em classes Font Awesome válidas (`fa-solid fa-box-archive`).
- Altereis a formatação de `currency` em `formatColumnValue` para usar `Intl.NumberFormat` com `minimumFractionDigits: 2` e `maximumFractionDigits: 2` e sem `style: 'currency'`, removendo assim o símbolo da moeda.

### Testing
- Executado `git -C /workspace/NewCode status --short` e verificado que o arquivo `Project/treeGrid/src/wwElement.vue` foi modificado; comando retornou com sucesso.
- Executado `git -C /workspace/NewCode diff -- Project/treeGrid/src/wwElement.vue` para revisar o diff; comando retornou com sucesso.
- Executado `git -C /workspace/NewCode add Project/treeGrid/src/wwElement.vue && git -C /workspace/NewCode commit -m "treeGrid: support icon column and remove currency symbol"` e o commit foi criado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10adcceca88330acca76de6c2ecb9a)