### PR TITLE
Add FontAwesome icon column support and auto-load stylesheet; adjust column title and currency formatting

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -158,6 +158,13 @@
                                     </div>
                                 </div>
                             </template>
+                            <template v-else-if="column.type === 'icon'">
+                                <i
+                                    v-if="normalizeFontAwesomeIconClass(row?.raw?.[column.field])"
+                                    :class="normalizeFontAwesomeIconClass(row?.raw?.[column.field])"
+                                    aria-hidden="true"
+                                ></i>
+                            </template>
                             <template v-else>
                                 <span v-html="highlightCell(row, column)"></span>
                             </template>
@@ -251,6 +258,9 @@
     created() {
         this.initializePublicVariables();
     },
+    mounted() {
+        this.ensureFontAwesome();
+    },
     computed: {
         translatedTexts() {
             return {
@@ -302,7 +312,7 @@
                 .filter(column => column && typeof column === 'object' && `${column.field ?? ''}`.trim())
                 .map(column => {
                     const field = `${column.field}`.trim();
-                    const title = `${column.title ?? field}`.trim() || field;
+                    const title = `${column.title ?? ''}`.trim();
                     const position = Number(column.position);
                     const width = typeof column.width === 'string' ? column.width.trim() : '';
                     const flex = Number(column.flex);
@@ -529,6 +539,18 @@
         translate(phrase) {
             return translatePhrase(phrase);
         },
+        ensureFontAwesome() {
+            if (typeof document === 'undefined') return;
+            const id = 'tree-grid-fontawesome-6';
+            if (document.getElementById(id)) return;
+
+            const link = document.createElement('link');
+            link.id = id;
+            link.rel = 'stylesheet';
+            link.href = 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css';
+            link.referrerPolicy = 'no-referrer';
+            document.head.appendChild(link);
+        },
         initializePublicVariables() {
             if (typeof wwLib === 'undefined' || !wwLib?.wwVariable?.useComponentVariable) return;
 
@@ -588,8 +610,8 @@
                 const numberValue = Number(value);
                 if (!Number.isFinite(numberValue)) return `${value}`;
                 return new Intl.NumberFormat(undefined, {
-                    style: 'currency',
-                    currency: this.content.currencyCode || 'BRL',
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
                 }).format(numberValue);
             }
 
@@ -785,6 +807,21 @@
         hideContextActions() {
             this.contextNodeId = null;
         },
+
+        normalizeFontAwesomeIconClass(icon) {
+            const value = `${icon || ''}`.trim();
+            if (!value) return '';
+
+            const parts = value.split(/\s+/).filter(Boolean);
+            const iconClass = parts.find(part => /^fa-[\w-]+$/.test(part) && !/^fa-(solid|regular|light|thin|duotone|brands)$/.test(part));
+            const styleClass = parts.find(part => /^fa-(solid|regular|light|thin|duotone|brands)$/.test(part));
+
+            const normalizedIconClass = iconClass || `fa-${value.replace(/^fa-/, '')}`;
+            const normalizedStyleClass = styleClass || 'fa-solid';
+
+            return `${normalizedStyleClass} ${normalizedIconClass}`;
+        },
+
         normalizeNodeIconClass(icon) {
             const value = `${icon || ''}`.trim();
             if (!value) return '';


### PR DESCRIPTION
### Motivation
- Add explicit support for rendering FontAwesome icons in a column of type `icon` so icons can be displayed per-row.  
- Ensure the FontAwesome stylesheet is available by auto-injecting it when the component mounts to avoid missing icon styles.  
- Normalize icon class handling and make currency cell formatting use fixed two decimal places.  
- Make column title normalization stricter to avoid implicit fallback to the field name.

### Description
- Added a new template branch to render an `<i>` element for columns where `column.type === 'icon'` and bound its classes using `normalizeFontAwesomeIconClass`.  
- Introduced `ensureFontAwesome()` and call it from the `mounted()` hook to inject the FontAwesome 6.5.2 stylesheet into `document.head`.  
- Added `normalizeFontAwesomeIconClass()` to normalize incoming icon class strings into a style class and icon class.  
- Changed `normalizedColumns` title derivation to use `column.title ?? ''` and `.trim()` instead of defaulting to the field name.  
- Updated `formatColumnValue()` for `currency` to format numbers with `minimumFractionDigits: 2` and `maximumFractionDigits: 2` instead of using the `currency` style and `currency` option.

### Testing
- Ran the component build with `npm run build` which completed successfully.  
- Executed the unit test suite with `npm test` and all tests for the `treeGrid` component passed.  
- Ran linting with `npm run lint` and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10adcceca88330acca76de6c2ecb9a)