### PR TITLE
Ajusta hover e tamanho dos ícones de ação no treeGrid

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -174,7 +174,6 @@
                 </template>
 
                 <div class="row-actions"
-                    :class="{ 'row-actions--visible': (selectedNodeId === row.id) && !isReadOnly && !isEditingAnyNode }"
                     @click.stop>
                     <button
                         v-if="row.canAddChild && !isRowBeingEdited(row) && !isReadOnly && !isEditingAnyNode"
@@ -1398,7 +1397,7 @@
         pointer-events: none;
     }
 
-    .row-actions--visible {
+    .tree-row:hover .row-actions {
         visibility: visible;
         pointer-events: auto;
     }
@@ -1406,6 +1405,10 @@
     .row-actions .row-action-button,
     .row-actions .row-action-button:hover {
         background: transparent;
+    }
+
+    .row-actions .row-action-button .node-icon {
+        font-size: 18px;
     }
 
     .row-action-button--cancel,


### PR DESCRIPTION
### Motivation
- Tornar os botões de ação da linha (adicionar, editar, excluir) visíveis ao passar o mouse sobre a linha em vez de depender da seleção, melhorando a usabilidade. 
- Reduzir o tamanho dos ícones de ação para `18px` para um layout mais compacto e consistente.

### Description
- Removida a vinculação condicional `:class="{ 'row-actions--visible': (selectedNodeId === row.id) && !isReadOnly && !isEditingAnyNode }"` do bloco de ações da linha no template. 
- Adicionada a regra CSS `.tree-row:hover .row-actions` para controlar a visibilidade das ações via `hover` em vez de seleção. 
- Adicionada a regra CSS `.row-actions .row-action-button .node-icon { font-size: 18px; }` para reduzir o tamanho dos ícones de ação. 
- Arquivo alterado: `Project/treeGrid/src/wwElement.vue`.

### Testing
- Executada busca de referências com `rg` para localizar o template e estilos afetados e confirmar pontos de alteração, que retornou resultados esperados (sucesso). 
- Commit do arquivo modificado com `git commit` para garantir que a alteração foi aplicada ao repositório (sucesso). 
- Inspeção das linhas relevantes usando `nl`/`sed` para validar a presença das novas regras CSS e a remoção da condicional no template (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a142eb734948330901927c8108aab52)