### PR TITLE
treeGrid: trigger rename event without opening inline rename editor

### DIFF
--- a/Project/treeGrid/src/wwElement.vue
+++ b/Project/treeGrid/src/wwElement.vue
@@ -193,7 +193,7 @@
                         :style="iconButtonStyle"
                         :title="translatedTexts.rename"
                         :aria-label="translatedTexts.rename"
-                        @click.stop="startRenameEdit(row)"
+                        @click.stop="onRename(row.raw)"
                     >
                         <i class="fa fa-pencil node-icon" aria-hidden="true"></i>
                     </button>


### PR DESCRIPTION
### Motivation
- The rename icon should not open the inline label editor and must only fire the rename/on-edit event so consumers can handle the editing flow.

### Description
- Updated the rename button handler in `Project/treeGrid/src/wwElement.vue` to call `onRename(row.raw)` instead of `startRenameEdit(row)`, removing the inline edit activation.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14317dc6c48330a39a8150334fd5e7)