### PR TITLE
feat(RichText): adicionar propriedades iniciais de tamanho e cor da fonte

### DIFF
--- a/Project/RichText/src/wwElement.vue
+++ b/Project/RichText/src/wwElement.vue
@@ -1164,6 +1164,8 @@ export default {
                 '--table-cell-color': this.content.table?.cellColor || '#000',
                 '--table-cell-padding-x': this.content.table?.cellPaddingX || '8px',
                 '--table-cell-padding-y': this.content.table?.cellPaddingY || '6px',
+                '--initial-font-size': this.content.initialFontSize || this.content.p.fontSize,
+                '--initial-text-color': this.content.initialTextColor || this.content.p.color,
             };
         },
         delay() {
@@ -2418,11 +2420,11 @@ export default {
         width: 100%;
         overflow: auto;
         padding: 8px;
-        font-size: var(--p-fontSize);
+        font-size: var(--initial-font-size, var(--p-fontSize));
         font-family: var(--p-fontFamily);
         font-weight: var(--p-fontSize);
         text-align: var(--p-textAlign);
-        color: var(--p-color);
+        color: var(--initial-text-color, var(--p-color));
         line-height: var(--p-lineHeight);
         &-focused {
             outline: unset;

--- a/Project/RichText/ww-config.js
+++ b/Project/RichText/ww-config.js
@@ -51,6 +51,7 @@ export default {
             'hideMenu',
             'wrapMenu',
             'initialValue',
+            ['initialFontSize', 'initialTextColor'],
             'orderedLines',
             'output',
             'placeholder',
@@ -260,6 +261,31 @@ export default {
             },
             type: 'Textarea',
             defaultValue: '',
+            bindable: true,
+        },
+        initialFontSize: {
+            section: 'settings',
+            label: {
+                en: 'Initial font size',
+            },
+            type: 'Length',
+            options: {
+                unitChoices: [{ value: 'px', label: 'px', min: 1, max: 100 }],
+                noRange: true,
+            },
+            defaultValue: '16px',
+            bindable: true,
+        },
+        initialTextColor: {
+            section: 'settings',
+            label: {
+                en: 'Initial text color',
+            },
+            type: 'Color',
+            options: {
+                nullable: true,
+            },
+            defaultValue: '#000000',
             bindable: true,
         },
         orderedLines: {


### PR DESCRIPTION
### Motivation
- Permitir que o componente RichText tenha valores iniciais configuráveis para tamanho da fonte e cor do texto, facilitando definir a aparência padrão do conteúdo ao editar.

### Description
- Adicionadas as propriedades `initialFontSize` (tipo `Length`, default `16px`) e `initialTextColor` (tipo `Color`, default `#000000`) em `Project/RichText/ww-config.js` e incluídas na ordem do painel de configurações logo após `initialValue`.
- Expostos os valores em runtime através de variáveis CSS `--initial-font-size` e `--initial-text-color` em `Project/RichText/src/wwElement.vue` dentro de `richStyles`.
- Atualizado o estilo base do editor `.ProseMirror` para usar `font-size: var(--initial-font-size, var(--p-fontSize))` e `color: var(--initial-text-color, var(--p-color))`, preservando os estilos de parágrafo/heading como fallback.
- Mudança limitada à aparência inicial do editor; comportamento existente de headings e estilos permanecem inalterados.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a144f019e988330a60c9c0dacb33188)