### PR TITLE
feat(combo-agrupador): suportar cores de chip por campo JSON

### DIFF
--- a/Project/ComboAgrupador/src/wwElement_Select.vue
+++ b/Project/ComboAgrupador/src/wwElement_Select.vue
@@ -165,6 +165,8 @@ export default {
         const mappingDisabled = computed(() => props.content.mappingDisabled);
         const mappingBgColor = computed(() => props.content.optionBgColorField);
         const mappingFontColor = computed(() => props.content.optionFontColorField);
+        const mappingChipBgColor = computed(() => props.content.optionChipBgColorField);
+        const mappingChipFontColor = computed(() => props.content.optionChipFontColorField);
 
         const { resolveMappingFormula } = wwLib.wwFormula.useFormula();
 
@@ -827,6 +829,12 @@ export default {
                         value: resolveMappingFormula(toValue(mappingValue), opt) ?? opt.value ?? opt,
                         label: resolveMappingFormula(toValue(mappingLabel), opt) ?? opt.label ?? opt.value ?? opt,
                         disabled: opt.disabled || false,
+                        chipBgColor: toValue(mappingChipBgColor)
+                            ? wwLib.resolveObjectPropertyPath(opt, toValue(mappingChipBgColor))
+                            : null,
+                        chipFontColor: toValue(mappingChipFontColor)
+                            ? wwLib.resolveObjectPropertyPath(opt, toValue(mappingChipFontColor))
+                            : null,
                         data: opt || {},
                     };
                 }

--- a/Project/ComboAgrupador/src/wwElement_Trigger.vue
+++ b/Project/ComboAgrupador/src/wwElement_Trigger.vue
@@ -46,7 +46,7 @@
                     :ref="setChipRef"
                     v-show="index < visibleChipCount"
                     @click="e => handleChipClick(e, option.value)"
-                    :style="chipStyle"
+                    :style="getChipStyle(option)"
                 >
                     <span v-html="option.label || ''"></span>
                     <div v-html="chipIconUnselect" :style="chipIconStyle" aria-hidden="true"></div>
@@ -222,6 +222,18 @@ export default {
             };
         });
 
+
+        const getChipStyle = option => {
+            const optionChipBgColor = option?.chipBgColor;
+            const optionChipFontColor = option?.chipFontColor;
+
+            return {
+                ...chipStyle.value,
+                'background-color': optionChipBgColor || chipStyle.value['background-color'],
+                color: optionChipFontColor || chipStyle.value.color,
+            };
+        };
+
         const chipIcon = ref(null);
         const chipIconUnselect = ref(null);
 
@@ -352,6 +364,7 @@ export default {
             placeholderStyle,
             chipIcon,
             chipStyle,
+            getChipStyle,
             chipIconStyle,
             chipIconUnselect,
             isOpen,

--- a/Project/ComboAgrupador/ww-config.js
+++ b/Project/ComboAgrupador/ww-config.js
@@ -150,6 +150,8 @@ export default {
             'showGroupCheckbox',
             'optionBgColorField',
             'optionFontColorField',
+            'optionChipBgColorField',
+            'optionChipFontColorField',
             'initValueSingle',
             'initValueSingleId',
             'initValueMulti',
@@ -384,6 +386,30 @@ export default {
                 object: sidepanelContent.optionProperties || {},
             }),
         },
+
+        optionChipBgColorField: {
+            label: 'Chip background color column',
+            section: 'settings',
+            states: true,
+            bindable: true,
+            responsive: true,
+            type: 'ObjectPropertyPath',
+            options: (_, sidepanelContent) => ({
+                object: sidepanelContent.optionProperties || {},
+            }),
+        },
+        optionChipFontColorField: {
+            label: 'Chip font color column',
+            section: 'settings',
+            states: true,
+            bindable: true,
+            responsive: true,
+            type: 'ObjectPropertyPath',
+            options: (_, sidepanelContent) => ({
+                object: sidepanelContent.optionProperties || {},
+            }),
+        },
+
         initValueSingle: {
             type: 'Text',
             label: 'Initial value (single)',


### PR DESCRIPTION
### Motivation
- Permitir que cada option do dropdown defina a cor de fundo e a cor do texto do seu chip a partir dos campos do JSON que alimenta os itens, mantendo o comportamento atual quando esses campos não estiverem preenchidos.

### Description
- Adicionadas duas novas propriedades de mapeamento de campo em `ww-config.js`: `optionChipBgColorField` e `optionChipFontColorField` para configurar quais propriedades do JSON fornecem as cores dos chips.
- Em `src/wwElement_Select.vue` foram incluídos `mappingChipBgColor` e `mappingChipFontColor` e a resolução por item agora anexa `chipBgColor` e `chipFontColor` em `selectionDetails` quando os mapeamentos são definidos.
- Em `src/wwElement_Trigger.vue` a renderização dos chips múltiplos foi alterada para usar `getChipStyle(option)` que aplica as cores por opção com fallback para os estilos globais `chipBgColor`/`chipFontColor`, preservando comportamento anterior quando não houver valores mapeados.
- Arquivos modificados: `Project/ComboAgrupador/ww-config.js`, `Project/ComboAgrupador/src/wwElement_Select.vue`, `Project/ComboAgrupador/src/wwElement_Trigger.vue`.

### Testing
- Não há testes automatizados novos, foi realizada verificação estática com buscas de código (`rg`) para confirmar as novas propriedades e pontos de uso e inspecionados os arquivos modificados sem erros detectados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a1a822188330bc2719f599a79b1f)