### PR TITLE
Add GridViewInput component with custom renderers, list filter and editor config

### DIFF
--- a/Project/GridViewInput/src/components/ActionCellRenderer.vue
+++ b/Project/GridViewInput/src/components/ActionCellRenderer.vue
@@ -1,0 +1,64 @@
+<template>
+    <div class="btn-container">
+        <button
+            @click.stop="onButtonClicked"
+            class="datagrid-btn"
+            :class="params.withFont ? 'with-font' : 'without-font'"
+        >
+            {{ params.label }}
+        </button>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "ImageCellRenderer",
+    props: {
+        params: {
+            type: Object,
+            required: true,
+        },
+    },
+    methods: {
+        onButtonClicked() {
+            this.params.trigger({
+                actionName: this.params.name,
+                id: this.params.node.id,
+                index: this.params.node.sourceRowIndex,
+                displayIndex: this.params.node.rowIndex,
+                row: this.params.data,
+            });
+        },
+    },
+};
+</script>
+
+<style scoped lang="scss">
+.btn-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+.datagrid-btn {
+    background-color: var(--ww-data-grid_action-backgroundColor, unset);
+    font-family: "Inter", sans-serif;
+    font-size: 12px;
+    color: var(--ww-data-grid_action-color, unset);
+    padding: var(--ww-data-grid_action-padding, unset);
+    border: var(--ww-data-grid_action-border, unset);
+    &.with-font {
+        font-family: "Inter", sans-serif;
+        font-size: 12px;
+    }
+    &.without-font {
+        font-size: var(--ww-data-grid_action-fontSize, 12px);
+        font-family: var(--ww-data-grid_action-fontFamily, "Inter", sans-serif);
+        font-weight: var(--ww-data-grid_action-fontWeight);
+        font-style: var(--ww-data-grid_action-fontStyle);
+        line-height: var(--ww-data-grid_action-lineHeight, normal);
+    }
+    border-radius: var(--ww-data-grid_action-borderRadius);
+    cursor: pointer;
+}
+</style>

--- a/Project/GridViewInput/src/components/DateTimeCellEditor.js
+++ b/Project/GridViewInput/src/components/DateTimeCellEditor.js
@@ -1,0 +1,80 @@
+export default class DateTimeCellEditor {
+  init(params) {
+    this.params = params;
+    const input = document.createElement('input');
+    input.type = 'datetime-local';
+    input.style.width = '100%';
+    input.style.height = '100%';
+    input.style.fontSize = '12px';
+    input.style.fontFamily = 'Inter, sans-serif';
+    input.style.borderRadius = '6px';
+    input.style.padding = '4px';
+
+    // Set initial value if provided
+    if (params.value) {
+      input.value = this.toDateTimeLocal(params.value);
+    }
+
+    // keep value in sync so getValue works even after element removal
+    this.value = input.value;
+
+    const syncValue = e => {
+      this.value = e.target.value;
+    };
+    input.addEventListener('input', syncValue);
+    input.addEventListener('change', syncValue);
+
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') {
+        e.stopPropagation();
+        e.preventDefault();
+        this.value = e.target.value;
+
+        if (this.params && this.params.api) {
+          this.params.api.stopEditing();
+        } else if (this.params && typeof this.params.stopEditing === 'function') {
+          this.params.stopEditing();
+        }
+      }
+    });
+    
+    this.eInput = input;
+  }
+
+  toDateTimeLocal(value) {
+    try {
+      // handle formats like 'YYYY-MM-DD HH:mm:ss+00' or ISO strings
+      let v = value;
+      if (/\d{4}-\d{2}-\d{2} \d{2}:\d{2}(:\d{2})?([\+\-]\d{2})?$/.test(v)) {
+        v = v.replace(' ', 'T');
+        if (/([\+\-]\d{2})(\d{2})?$/.test(v)) v = v.replace(/([\+\-]\d{2})(\d{2})?$/, '$1:$2');
+        if (/([\+\-]\d{2})$/.test(v)) v = v.replace(/([\+\-]\d{2})$/, '$1:00');
+      }
+      const d = new Date(v);
+      if (!isNaN(d.getTime())) {
+        const pad = n => n.toString().padStart(2, '0');
+        return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+      }
+    } catch(e) {}
+    return value;
+  }
+
+  getGui() {
+    return this.eInput;
+  }
+
+  afterGuiAttached() {
+    if (this.eInput) this.eInput.focus();
+  }
+
+  getValue() {
+    // return the cached value to avoid issues if the element was removed
+    return this.value;
+  }
+
+  destroy() {}
+
+  isPopup() {
+    return false;
+  }
+}

--- a/Project/GridViewInput/src/components/ImageCellRenderer.vue
+++ b/Project/GridViewInput/src/components/ImageCellRenderer.vue
@@ -1,0 +1,29 @@
+<template>
+    <div class="image-cell">
+        <img v-if="params?.value" :src="params.value" :style="{ width: params.width, height: params.height }" />
+    </div>
+</template>
+
+<script>
+export default {
+    name: "ImageCellRenderer",
+    props: {
+        params: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>
+
+<style scoped>
+.image-cell {
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
+.image-cell img {
+    object-fit: contain;
+}
+</style>

--- a/Project/GridViewInput/src/components/ListFilterRenderer.js
+++ b/Project/GridViewInput/src/components/ListFilterRenderer.js
@@ -1,0 +1,270 @@
+import { translatePhrase } from "../translation";
+
+export default class ListFilterRenderer {
+  constructor() {
+    this.searchText = '';
+    this.selectedValues = [];
+    this.allValues = [];
+    this.filteredValues = [];
+    this.selectAll = false;
+  }
+
+  init(params) {
+    this.params = params;
+    this.loadValues();
+    this.createGui();
+  }
+ 
+  createGui() {
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'list-filter';
+    this.eGui.innerHTML = `
+      <div class="field-search">
+        <input type="text" placeholder="Search..." class="search-input" />
+        <span class="search-icon">
+          <i class="material-symbols-outlined-search">search</i>
+        </span>
+      </div>
+      <div class="select-all-row">
+        <label>
+          <input type="checkbox" class="select-all-checkbox" />
+          <span>${translatePhrase("Select all")}</span>
+        </label>
+      </div>
+      <div class="filter-list"></div>
+    `;
+
+    this.searchInput = this.eGui.querySelector('.search-input');
+    this.searchInput.placeholder = translatePhrase("Search...");
+    this.filterList = this.eGui.querySelector('.filter-list');
+    this.selectAllCheckbox = this.eGui.querySelector('.select-all-checkbox');
+
+    this.setupEventListeners();
+    this.renderFilterList();
+  }
+
+  setupEventListeners() {
+    this.searchInput.addEventListener('input', (e) => {
+      this.searchText = e.target.value;
+      this.filterValues();
+    });
+
+    this.selectAllCheckbox.addEventListener('change', (e) => {
+      if (e.target.checked) {
+        this.selectedValues = [...this.filteredValues];
+      } else {
+        this.selectedValues = [];
+      }
+      this.renderFilterList();
+      this.applyFilter();
+    });
+  }
+
+  // Função utilitária para acessar campos aninhados
+  getNestedValue(obj, path) {
+    return path.split('.').reduce((o, p) => (o && o[p] !== undefined ? o[p] : undefined), obj);
+  }
+
+  // Função auxiliar igual ao FormatterCellRenderer
+  getRoundedSpanColor(value, colorArray, fieldName) {
+    if (!colorArray || !Array.isArray(colorArray) || !value) return value;
+    const matchingStyle = colorArray.find(item => item.Valor === value);
+    if (!matchingStyle) return value;
+    const borderRadius = fieldName === 'StatusID' ? '4px' : '12px';
+    const fontweight = "font-weight:bold;";
+    return `<span style="height:25px; color: ${matchingStyle.CorFonte}; background:${matchingStyle.CorFundo}; border: 1px solid ${matchingStyle.CorFundo}; border-radius: ${borderRadius}; ${fontweight} display: inline-flex; align-items: center; padding: 0 12px;">${value}</span>`;
+  }
+
+  dateFormatter(dateValue, lang) {
+    try {
+      if (!dateValue) return '';
+      const dateOptions = {
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric'
+      };
+      const timeOptions = {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false
+      };
+      const datePart = new Intl.DateTimeFormat(lang || 'en', dateOptions).format(new Date(dateValue));
+      const timePart = new Intl.DateTimeFormat(lang || 'en', timeOptions).format(new Date(dateValue));
+      return `${datePart} ${timePart}`;
+    } catch (error) {
+      return dateValue;
+    }
+  }
+
+  loadValues() {
+    const api = this.params.api;
+    const column = this.params.column;
+    const colDef = column.getColDef();
+    const field = colDef.field || column.getColId();
+    const cellRendererParams = colDef.cellRendererParams || {};
+
+    this.allValues = [];
+    this.formattedValues = [];
+    api.forEachNode(node => {
+      if (node.data) {
+        let value = this.getNestedValue(node.data, field);
+        let formatted = value;
+        // Se for booleano, exibir 'Yes' ou 'No' no label, mas manter o valor cru para filtragem
+        if (typeof value === 'boolean') {
+          formatted = value ? translatePhrase('Yes') : translatePhrase('No');
+        } else if (cellRendererParams.useCustomFormatter && typeof cellRendererParams.formatter === 'string') {
+          try {
+            const formatterFn = new Function(
+              'value',
+              'row',
+              'colDef',
+              'getRoundedSpanColor',
+              'dateFormatter',
+              cellRendererParams.formatter
+            );
+            formatted = formatterFn(
+              value,
+              node.data,
+              colDef,
+              this.getRoundedSpanColor,
+              this.dateFormatter
+            );
+          } catch (e) {
+            // Se der erro, mantém o valor original
+          }
+        }
+        if (value !== undefined && value !== null) {
+          this.allValues.push(value);
+          this.formattedValues.push(formatted);
+        }
+      }
+    });
+    // Remover duplicatas mantendo o mapeamento
+    const seen = new Set();
+    const uniqueRaw = [];
+    const uniqueFormatted = [];
+    this.allValues.forEach((raw, idx) => {
+      if (!seen.has(raw)) {
+        seen.add(raw);
+        uniqueRaw.push(raw);
+        uniqueFormatted.push(this.formattedValues[idx]);
+      }
+    });
+    // Função utilitária para extrair texto puro de HTML
+    function stripHtml(html) {
+      const tmp = document.createElement('div');
+      tmp.innerHTML = html;
+      return tmp.textContent || tmp.innerText || '';
+    }
+    // Ordena os valores alfabeticamente pelo texto visível formatado
+    const zipped = uniqueRaw.map((raw, idx) => ({ raw, formatted: uniqueFormatted[idx] }));
+    zipped.sort((a, b) => {
+      const textA = stripHtml(String(a.formatted)).toLowerCase();
+      const textB = stripHtml(String(b.formatted)).toLowerCase();
+      return textA.localeCompare(textB, undefined, { sensitivity: 'base' });
+    });
+    this.allValues = zipped.map(z => z.raw);
+    this.formattedValues = zipped.map(z => z.formatted);
+    this.filteredValues = [...this.allValues];
+  }
+
+  filterValues() {
+    if (!this.searchText) {
+      this.filteredValues = [...this.allValues];
+    } else {
+      this.filteredValues = this.allValues.filter((raw, idx) => {
+        const formatted = this.formattedValues[idx];
+        return String(formatted).toLowerCase().includes(this.searchText.toLowerCase());
+      });
+    }
+    this.renderFilterList();
+  }
+
+  renderFilterList() {
+    this.selectAllCheckbox.checked =
+      this.filteredValues.length > 0 &&
+      this.filteredValues.every(v => this.selectedValues.includes(v));
+
+    this.filterList.innerHTML = this.filteredValues.map((rawValue) => {
+      const idx = this.allValues.indexOf(rawValue);
+      const formattedValue = this.formattedValues[idx] || rawValue;
+      const checked = this.selectedValues.includes(rawValue) ? 'checked' : '';
+      return `
+        <label class="filter-item${this.selectedValues.includes(rawValue) ? ' selected' : ''}">
+          <input type="checkbox" value="${rawValue}" ${checked} />
+          <span class="filter-label" title="">${formattedValue}</span>
+        </label>
+      `;
+    }).join('');
+
+    this.filterList.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+      checkbox.addEventListener('change', (e) => {
+        let value = e.target.value;
+        // Converter string para boolean se necessário
+        if (value === 'true') value = true;
+        else if (value === 'false') value = false;
+        if (e.target.checked) {
+          if (!this.selectedValues.includes(value)) {
+            this.selectedValues.push(value);
+          }
+        } else {
+          this.selectedValues = this.selectedValues.filter(v => v !== value);
+        }
+        this.selectAllCheckbox.checked =
+          this.filteredValues.length > 0 &&
+          this.filteredValues.every(v => this.selectedValues.includes(v));
+        this.applyFilter();
+      });
+    });
+  }
+
+  applyFilter() {
+    this.params.filterChangedCallback();
+  }
+
+  clearFilter() {
+    this.selectedValues = [];
+    this.searchText = '';
+    this.searchInput.value = '';
+    this.filteredValues = [...this.allValues];
+    this.renderFilterList();
+    this.params.filterChangedCallback();
+  }
+
+  isFilterActive() {
+    return this.selectedValues.length > 0;
+  }
+
+  doesFilterPass(params) {
+    if (this.selectedValues.length === 0) return true;
+    const field = this.params.column.getColDef().field || this.params.column.getColId();
+    const value = this.getNestedValue(params.data, field);
+    return this.selectedValues.includes(value);
+  }
+
+  getModel() {
+    if (this.selectedValues.length === 0) return null;
+    return {
+      type: 'list',
+      values: this.selectedValues
+    };
+  }
+
+  setModel(model) {
+    if (model && model.values) {
+      this.selectedValues = model.values;
+    } else {
+      this.selectedValues = [];
+    }
+    this.renderFilterList();
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  onNewRowsLoaded() {
+    this.loadValues();
+    this.filterValues();
+  }
+} 

--- a/Project/GridViewInput/src/components/WewebCellRenderer.vue
+++ b/Project/GridViewInput/src/components/WewebCellRenderer.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="ww-cell-renderer">
+        <wwLayoutItemContext
+            is-repeat
+            :index="params.node.sourceRowIndex"
+            :data="{ value: params.value, row: params.data }"
+        >
+            <wwElement v-bind="params.containerId" class="ww-cell-renderer-flexbox"></wwElement>
+        </wwLayoutItemContext>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "WewebCellRenderer",
+    props: {
+        params: {
+            type: Object,
+            required: true,
+        },
+    },
+};
+</script>
+
+<style scoped lang="scss">
+.ww-cell-renderer {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+    line-height: normal;
+    :deep(.ww-cell-renderer-flexbox) {
+        flex: 1;
+    }
+}
+</style>

--- a/Project/GridViewInput/src/components/list-filter.css
+++ b/Project/GridViewInput/src/components/list-filter.css
@@ -1,0 +1,220 @@
+.list-filter {
+  padding: 12px 12px 8px 12px;
+  min-width: 260px;
+  max-width: 350px;
+  max-height: 340px;
+  background: #fff;
+  border: 1px solid #ffffff;
+  border-radius: 15px;
+  box-shadow: 0 2px 8px rgba(255, 255, 255, 0.067);
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+  overflow: hidden; /* Garante que nada "vaze" para fora da borda arredondada */
+  position: relative;
+}
+
+.filter-list {
+  max-height: 220px;
+  overflow-y: auto;
+  background: transparent;
+  border-radius: 12px;
+  margin-bottom: 10px;
+  scrollbar-width: thin;
+  scrollbar-color: #bdbdbd transparent;
+}
+
+/* Barra de rolagem moderna e sem setas */
+.filter-list::-webkit-scrollbar {
+  width: 6px;
+  background: transparent;
+  border-radius: 12px;
+}
+
+.filter-list::-webkit-scrollbar-thumb {
+  background: #bdbdbd;
+  border-radius: 12px;
+}
+
+.filter-list::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* Remove as setas (botões) da barra de rolagem no Chrome/Safari/Edge */
+.filter-list::-webkit-scrollbar-button {
+  display: none;
+  height: 0;
+}
+
+.list-filter .filter-list,
+.list-filter .filter-item,
+.list-filter .filter-label {
+  font-family: Inter, sans-serif;
+  font-size: 12px;
+}
+.list-filter .filter-header {
+  margin-bottom: 10px;
+}
+.list-filter .field-search {
+  position: relative;
+  padding: 0 0 10px 0;
+}
+
+.list-filter .search-input {
+  width: 100%;
+  padding: 7px 36px 7px 13px;
+  border: 1px solid #ddd;
+  border-radius: 20px;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+  outline: none;
+  background: #fff;
+  color: #444;
+  box-sizing: border-box;
+}
+
+.list-filter .search-input::placeholder {
+  color: #aaa;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+}
+
+.list-filter .search-icon {
+  position: absolute;
+  right: 12px;
+  top: 16px;
+  transform: translateY(-50%);
+  color: #999;
+  width: 20px;
+  height: 20px;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.list-filter .search-icon i.material-symbols-outlined-search {
+  font-family: 'Material Symbols Outlined';
+  font-size: 19px;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  vertical-align: middle;
+}
+.list-filter .filter-list {
+  max-height: 180px;
+  overflow-y: auto;
+  margin-bottom: 10px;
+}
+.list-filter .select-all-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid #e0e0e0;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+  color: #444;
+  gap: 8px;
+}
+
+.list-filter .select-all-row label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 6px 0 6px 0;
+  border-radius: 8px;
+  transition: background 0.15s;
+  width: 100%;
+}
+
+.list-filter .select-all-row label:hover {
+  background: #f6f7fa;
+}
+
+.list-filter .select-all-checkbox {
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  border: 2px solid #bfc6d1;
+  accent-color: #5e6a75;
+  background: #fff;
+  transition: border-color 0.2s, background 0.2s;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.list-filter .filter-item {
+  display: flex;
+  align-items: center;
+  padding: 6px 0 6px 0;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+  cursor: pointer;
+  gap: 8px;
+  border-radius: 8px;
+  transition: background 0.15s;
+}
+
+.list-filter .filter-item:hover {
+  background: #f6f7fa;
+}
+
+.list-filter .filter-item.selected {
+  background: #f6f7fa;
+}
+
+.list-filter .filter-item input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  border-radius: 5px;
+  border: 2px solid #bfc6d1;
+  accent-color: #5e6a75;
+  background: #fff;
+  transition: border-color 0.2s, background 0.2s;
+  margin-right: 8px;
+  flex-shrink: 0;
+}
+
+.list-filter .filter-item input[type="checkbox"]:checked {
+  background: #5e6a75;
+  border-color: #5e6a75;
+}
+
+.list-filter .filter-item input[type="checkbox"]:focus {
+  outline: 2px solid #5e6a75;
+}
+
+.list-filter .filter-label {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 180px;
+  display: inline-block;
+  color: #444;
+  font-size: 12px;
+  font-family: Inter, sans-serif;
+}
+.list-filter .filter-actions {
+  display: flex;
+  gap: 5px;
+  justify-content: flex-end;
+}
+.list-filter .apply-btn, .list-filter .clear-btn {
+  padding: 5px 10px;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 12px;
+}
+.list-filter .apply-btn:hover {
+  background: #e6f3ff;
+}
+.list-filter .clear-btn:hover {
+  background: #ffe6e6;
+} 

--- a/Project/GridViewInput/src/translation.js
+++ b/Project/GridViewInput/src/translation.js
@@ -1,0 +1,58 @@
+export function translatePhrase(phrase) {
+  if (phrase == null) {
+    return "";
+  }
+
+  const lang = window?.wwLib?.wwVariable?.getValue("aa44dc4c-476b-45e9-a094-16687e063342"); // idioma atual (ex: "pt-BR")
+  const jsonArr = window?.wwLib?.wwVariable?.getValue("4bb37062-2a1b-4cb6-a115-ae6df0c557d2"); // array de traduções
+  const allLangs = window?.wwLib?.wwVariable?.getValue("5abe8801-7f12-4c9c-b356-900431ab4491"); // lista de idiomas
+
+  if (!Array.isArray(jsonArr) || !Array.isArray(allLangs)) {
+    return String(phrase);
+  }
+
+  const isoLangs = allLangs.map((l) => l.Lang); // ["en-US", "pt-BR", ...]
+
+  // Helper para encontrar índice de um termo existente
+  function findIndexByTerm(term) {
+    return jsonArr.findIndex(
+      (obj) => obj.term?.trim().toLowerCase() === term.trim().toLowerCase()
+    );
+  }
+
+  const part = String(phrase).trim();
+  if (!part) {
+    return "";
+  }
+
+  const idx = findIndexByTerm(part);
+
+  if (idx === -1) {
+    // 🔹 Não existe → cria novo registro completo
+    const newEntry = { term: part, source: "FrontEnd" };
+
+    // Preenche cada idioma com o próprio texto (ou tradução automática se quiser depois)
+    isoLangs.forEach((code) => {
+      // Inicialmente copia o termo original para todos os idiomas
+      newEntry[code] = part;
+    });
+
+    // Adiciona ao array principal
+    jsonArr.push(newEntry);
+
+    // Retorna o texto no idioma atual (ou o termo se não houver tradução)
+    return newEntry[lang] ?? part;
+  } else {
+    // 🔹 Já existe → retorna a tradução existente (ou o próprio termo se estiver vazio)
+    const entry = jsonArr[idx];
+
+    const value = entry[lang];
+
+    // Se for string vazia, null ou undefined → retorna phrase
+    if (value === "" || value == null) {
+      return String(phrase);
+    }
+
+    return value;
+  }
+}

--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -1,0 +1,1216 @@
+<template>
+  <div ref="rootRef" class="ww-datagrid" :class="{ editing: isEditing, 'grid-hidden': !gridVisible }" :style="cssVars">
+    <ag-grid-vue :key="gridKey" :rowData="rowData" :columnDefs="columnDefs" :defaultColDef="defaultColDef"
+      :domLayout="content.layout === 'auto' ? 'autoHeight' : 'normal'" :style="style" :rowSelection="rowSelection"
+      :selection-column-def="{ pinned: true }" :theme="theme" :getRowId="getRowId" :pagination="content.pagination"
+      :getRowStyle="getRowStyle"
+      :paginationPageSize="content.paginationPageSize || 10" :paginationPageSizeSelector="false"
+      :suppressColumnMoveAnimation="true"
+      :suppressMovableColumns="!content.movableColumns" :columnHoverHighlight="content.columnHoverHighlight"
+      :singleClickEdit="content.oneClickEdit" :locale-text="localeText" @grid-ready="onGridReady"
+      @first-data-rendered="onFirstDataRendered"
+      @row-selected="onRowSelected" @selection-changed="onSelectionChanged"
+      @cell-value-changed="onCellValueChanged" @filter-changed="onFilterChanged" @sort-changed="onSortChanged"
+      @row-clicked="onRowClicked" @cell-key-down="onCellKeyDown" @cell-editing-stopped="onCellEditingStopped">
+    </ag-grid-vue>
+  </div>
+</template>
+
+<script>
+  import { onMounted, onUnmounted, shallowRef, watchEffect, computed, ref, watch } from "vue";
+import { AgGridVue } from "ag-grid-vue3";
+import {
+  AllCommunityModule,
+  ModuleRegistry,
+  themeQuartz,
+} from "ag-grid-community";
+import {
+  AG_GRID_LOCALE_EN,
+  AG_GRID_LOCALE_FR,
+  AG_GRID_LOCALE_DE,
+  AG_GRID_LOCALE_ES,
+  AG_GRID_LOCALE_PT,
+} from "@ag-grid-community/locale";
+import ActionCellRenderer from "./components/ActionCellRenderer.vue";
+import ImageCellRenderer from "./components/ImageCellRenderer.vue";
+import WewebCellRenderer from "./components/WewebCellRenderer.vue";
+import ListFilterRenderer from "./components/ListFilterRenderer.js";
+import './components/list-filter.css';
+import { translatePhrase } from "./translation";
+
+
+// TODO: maybe register less modules
+// TODO: maybe register modules per grid instead of globally
+ModuleRegistry.registerModules([AllCommunityModule]);
+
+export default {
+  components: {
+    AgGridVue,
+    ActionCellRenderer,
+    ImageCellRenderer,
+    WewebCellRenderer,
+  },
+  props: {
+    content: {
+      type: Object,
+      required: true,
+    },
+    uid: {
+      type: String,
+      required: true,
+    },
+    /* wwEditor:start */
+    wwEditorState: { type: Object, required: true },
+    /* wwEditor:end */
+  },
+  emits: ["trigger-event", "update:content:effect"],
+  setup(props, ctx) {
+    const { resolveMappingFormula } = wwLib.wwFormula.useFormula();
+
+    const gridApi = shallowRef(null);
+    const { value: selectedRows, setValue: setSelectedRows } =
+      wwLib.wwVariable.useComponentVariable({
+        uid: props.uid,
+        name: "selectedRows",
+        type: "array",
+        defaultValue: [],
+        readonly: true,
+      });
+    const { value: filterValue, setValue: setFilters } =
+      wwLib.wwVariable.useComponentVariable({
+        uid: props.uid,
+        name: "filters",
+        type: "object",
+        defaultValue: {},
+        readonly: true,
+      });
+    const { value: sortValue, setValue: setSort } =
+      wwLib.wwVariable.useComponentVariable({
+        uid: props.uid,
+        name: "sort",
+        type: "object",
+        defaultValue: {},
+        readonly: true,
+      });
+
+    const getAppLanguage = () => {
+      let value = null;
+      try {
+        if (window.wwLib?.wwVariable?.getValue) {
+          value = window.wwLib.wwVariable.getValue("aa44dc4c-476b-45e9-a094-16687e063342");
+        }
+      } catch (e) {}
+
+      switch (value) {
+        case "pt-BR":
+        case "pt":
+        case "Portuguese":
+          return "pt";
+        case "fr-FR":
+        case "fr":
+        case "French":
+          return "fr";
+        case "es-ES":
+        case "es":
+        case "Spanish":
+          return "es";
+        case "de-DE":
+        case "de":
+        case "German":
+          return "de";
+        case "en-US":
+        case "en":
+        case "English":
+          return "en";
+        default:
+          return null;
+      }
+    };
+
+    const onGridReady = (params) => {
+      gridApi.value = params.api;
+      if (
+        gridApi.value &&
+        typeof gridApi.value.doLayout !== "function" &&
+        typeof gridApi.value.onGridSizeChanged === "function"
+      ) {
+        gridApi.value.doLayout = () => gridApi.value.onGridSizeChanged();
+      }
+      trySelectInitialRows();
+    };
+
+    // Seleciona as linhas iniciais com base em initialSelectedRowIds
+    function selectInitialRows() {
+      if (!gridApi.value) return;
+      let ids = [];
+      if (Array.isArray(props.content.initialSelectedRowIds)) {
+        ids = props.content.initialSelectedRowIds.map(String);
+      } else if (props.content.initialSelectedRowIds == null) {
+        ids = [];
+      }
+      const getRowIdFn = typeof getRowId === 'function' ? getRowId : (params) => params.data?.id;
+      const allNodes = [];
+      gridApi.value.forEachNode(node => allNodes.push(node));
+      if (!ids.length) {
+        // Desmarca todas as linhas
+        allNodes.forEach(node => node.setSelected(false));
+        return;
+      }
+      allNodes.forEach(node => {
+        const rowId = String(getRowIdFn({ data: node.data }));
+        if (ids.includes(rowId)) {
+          node.setSelected(true);
+        } else {
+          node.setSelected(false);
+        }
+      });
+    }
+
+    // Garante seleção inicial após gridReady e após rowData mudar
+    const trySelectInitialRows = () => setTimeout(() => selectInitialRows(), 0);
+    watch(
+      () => props.content.rowData,
+      trySelectInitialRows,
+      { deep: true }
+    );
+
+    // Atualiza seleção sempre que initialSelectedRowIds mudar
+    watch(
+      () => props.content.initialSelectedRowIds,
+      trySelectInitialRows,
+      { deep: true }
+    );
+
+    watchEffect(() => {
+      if (!gridApi.value) return;
+      if (props.content.initialFilters) {
+        gridApi.value.setFilterModel(props.content.initialFilters);
+      }
+      if (props.content.initialSort) {
+        gridApi.value.applyColumnState({
+          state: props.content.initialSort || [],
+          defaultState: { sort: null },
+        });
+      }
+    });
+
+    const onRowSelected = (event) => {
+      const isSelected = event.node.isSelected();
+
+      if (!isSelected && gridApi.value) {
+        setSelectedRows(gridApi.value.getSelectedRows() || []);
+      }
+
+      ctx.emit("trigger-event", {
+        name: isSelected ? "rowSelected" : "rowDeselected",
+        event: { row: event.data },
+      });
+    };
+
+    const onSelectionChanged = (event) => {
+      if (!gridApi.value) return;
+      const selected = gridApi.value.getSelectedRows() || [];
+      setSelectedRows(selected);
+    };
+
+    const onFilterChanged = (event) => {
+      if (!gridApi.value) return;
+      const filterModel = gridApi.value.getFilterModel();
+      if (
+        JSON.stringify(filterModel || {}) !==
+        JSON.stringify(filterValue.value || {})
+      ) {
+        setFilters(filterModel);
+        ctx.emit("trigger-event", {
+          name: "filterChanged",
+          event: filterModel,
+        });
+      }
+    };
+
+    const onSortChanged = (event) => {
+      if (!gridApi.value) return;
+      const state = gridApi.value.getState();
+      if (
+        JSON.stringify(state.sort?.sortModel || []) !==
+        JSON.stringify(sortValue.value || [])
+      ) {
+        setSort(state.sort?.sortModel || []);
+        ctx.emit("trigger-event", {
+          name: "sortChanged",
+          event: state.sort?.sortModel || [],
+        });
+      }
+    };
+
+    /* wwEditor:start */
+    const { createElement } = wwLib.wwElement.useCreate();
+    /* wwEditor:end */
+
+    const gridKey = ref(0);
+    const rootRef = ref(null);
+    const gridVisible = ref(false);
+    let resizeObserver = null;
+
+    const showGrid = () => {
+      // Wait two frames to let flex columns settle before revealing the grid
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() => {
+          gridVisible.value = true;
+        })
+      );
+    };
+
+    watch(
+      () => props.content.rowData,
+      (newData) => {
+        gridVisible.value = false;
+        gridKey.value += 1;
+
+        const hasNoRows = !Array.isArray(newData) || newData.length === 0;
+        if (hasNoRows) {
+          showGrid();
+        }
+      },
+      { deep: true }
+    );
+
+    const onFirstDataRendered = () => {
+      showGrid();
+    };
+
+    const refreshLayout = () => {
+      if (!gridApi.value) return;
+      requestAnimationFrame(() => {
+        if (typeof gridApi.value.onGridSizeChanged === "function") {
+          gridApi.value.onGridSizeChanged();
+        } else if (typeof gridApi.value.refreshHeader === "function") {
+          gridApi.value.refreshHeader();
+        }
+      });
+    };
+
+    onMounted(() => {
+      resizeObserver = new ResizeObserver(() => refreshLayout());
+      if (rootRef.value) resizeObserver.observe(rootRef.value);
+
+      const appLanguage = getAppLanguage();
+      if (appLanguage && appLanguage !== props.content.lang) {
+        ctx.emit("update:content:effect", { lang: appLanguage });
+      }
+    });
+
+    onUnmounted(() => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
+    });
+
+    return {
+      resolveMappingFormula,
+      onGridReady,
+      onRowSelected,
+      onSelectionChanged,
+      gridApi,
+      setSelectedRows,
+      onFilterChanged,
+      onSortChanged,
+      onFirstDataRendered,
+      gridVisible,
+      showGrid,
+      rootRef,
+      localeText: computed(() => {
+        const language = getAppLanguage() || props.content.lang;
+        switch (language) {
+          case "fr":
+            return AG_GRID_LOCALE_FR;
+          case "de":
+            return AG_GRID_LOCALE_DE;
+          case "es":
+            return AG_GRID_LOCALE_ES;
+          case "pt":
+            return AG_GRID_LOCALE_PT;
+          case "custom":
+            return {
+              ...AG_GRID_LOCALE_EN,
+              ...(props.content.localeText || {}),
+            };
+          default:
+            return AG_GRID_LOCALE_EN;
+        }
+      }),
+      /* wwEditor:start */
+      createElement,
+      /* wwEditor:end */
+      gridKey,
+    };
+  },
+  data() {
+    return {
+      pendingEnterEdit: null,
+      markedRowId: null,
+    };
+  },
+  computed: {
+    rowData() {
+      const data = wwLib.wwUtils.getDataFromCollection(this.content.rowData);
+      const rows = Array.isArray(data) ? [...data] : [];
+      return [this.createBlankRow(true), ...rows.map((row) => ({ ...row, __isInputRow: false }))];
+    },
+    defaultColDef() {
+      return {
+        editable: true,
+        resizable: this.content.resizableColumns,
+      };
+    },
+    columnDefs() {
+      const actionColumn = {
+        colId: "__grid_input_actions__",
+        headerName: "",
+        pinned: "left",
+        width: 46,
+        minWidth: 46,
+        maxWidth: 46,
+        lockPosition: true,
+        sortable: false,
+        filter: false,
+        resizable: false,
+        editable: false,
+        suppressMovable: true,
+        cellStyle: { textAlign: "center", padding: "0", display: "flex", alignItems: "center", justifyContent: "center" },
+        cellRenderer: (params) => {
+          const isInputRow = !!params.data?.__isInputRow;
+          const symbol = isInputRow ? "+" : "🗑";
+          const title = isInputRow ? "Incluir linha" : "Excluir linha";
+          return `<button class="grid-input-action-btn" title="${title}">${symbol}</button>`;
+        },
+        onCellClicked: (params) => {
+          if (params.data?.__isInputRow) this.addRowFromInput(params.data);
+          else this.deleteRow(params.rowIndex);
+        },
+      };
+      const mappedColumns = this.content.columns.map((col) => {
+        
+        // Forçar cellDataType para 'dateString' se for 'date' ou 'dateString'
+        if (col.cellDataType === 'date') col.cellDataType = 'dateString';
+        const minWidth =
+          !col.minWidth || col.minWidth === "auto"
+            ? null
+            : wwLib.wwUtils.getLengthUnit(col.minWidth)?.[0];
+        const maxWidth =
+          !col.maxWidth || col.maxWidth === "auto"
+            ? null
+            : wwLib.wwUtils.getLengthUnit(col.maxWidth)?.[0];
+        const isFlex = col.flex === true || col.widthAlgo === "flex";
+        const width =
+          !col.width || col.width === "auto" || isFlex
+            ? null
+            : wwLib.wwUtils.getLengthUnit(col.width)?.[0];
+        const flex = isFlex
+          ? typeof col.flex === "number"
+            ? col.flex
+            : 1
+          : null;
+        const commonProperties = {
+          minWidth,
+          maxWidth,
+          pinned: col.pinned === "none" ? false : col.pinned,
+          width,
+          flex,
+          hide: !!col.hide,
+        };
+        
+        
+        const cellAlign = col.textAlign ?? this.content.textAlign;
+        const headerAlign = col.headerAlign ?? this.content.headerAlign;
+        const cellClass = cellAlign ? `ag-text-${cellAlign}` : undefined;
+        const headerClass = headerAlign ? `ag-header-align-${headerAlign}` : undefined;
+        const baseCellStyle = cellAlign ? { textAlign: cellAlign } : undefined;
+
+        const applyCursor = (result) => {
+          const cursor = this.content.cellCursor ?? col.cursor;
+          if (cursor) {
+            const userCellStyle = result.cellStyle;
+            result.cellStyle = (params) => ({
+              ...(typeof userCellStyle === 'function'
+                ? userCellStyle(params)
+                : userCellStyle || {}),
+              cursor,
+            });
+          }
+          return result;
+        };
+
+        switch (col.cellDataType) {
+          case "action": {
+            const result = {
+              ...commonProperties,
+              headerName: translatePhrase(col.headerName),
+              cellRenderer: "ActionCellRenderer",
+              cellRendererParams: {
+                name: col.actionName,
+                label: translatePhrase(col.actionLabel),
+                trigger: this.onActionTrigger,
+                withFont: !!this.content.actionFont,
+              },
+              sortable: false,
+
+              filter: false,
+              cellClass,
+              headerClass,
+              ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
+            };
+            return applyCursor(result);
+
+          }
+          case "custom": {
+            const result = {
+              ...commonProperties,
+              headerName: translatePhrase(col.headerName),
+              field: col.field,
+              cellRenderer: "WewebCellRenderer",
+              cellRendererParams: {
+                containerId: col.containerId,
+              },
+
+
+              sortable: col.sortable,
+              filter: col.filter,
+              cellClass,
+              headerClass,
+              ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
+            };
+            return applyCursor(result);
+          }
+
+          case "image": {
+            const result = {
+              ...commonProperties,
+              headerName: translatePhrase(col.headerName),
+              field: col.field,
+              cellRenderer: "ImageCellRenderer",
+              cellRendererParams: {
+                width: col.imageWidth,
+                height: col.imageHeight,
+              },
+
+              cellClass,
+              headerClass,
+              ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
+            };
+            return applyCursor(result);
+
+          }
+          case "boolean": {
+            const result = {
+              ...commonProperties,
+              headerName: translatePhrase(col.headerName),
+              field: col.field,
+              sortable: col.sortable,
+              filter: ListFilterRenderer, // sempre filtro tipo list
+              cellRenderer: (params) => {
+                const checked = !!params.value;
+                const color = col.booleanCheckboxColor || '#699d8c';
+                // Checkbox customizado
+                return `
+                  <span style="display:inline-flex;align-items:center;justify-content:center;width:20px;height:20px;">
+                    <span style="
+                      display:inline-flex;
+                      align-items:center;
+                      justify-content:center;
+                      width:16px;height:16px;
+                      border-radius:4px;
+                      border:1.5px solid #bfc6d1;
+                      background:${checked ? color : '#fff'};
+                      box-sizing:border-box;
+                      transition:background 0.2s,border 0.2s;
+                      padding:2px;
+                    ">
+                      ${checked ? `<svg width='12' height='12' viewBox='0 0 12 12'><polyline points='1,7 5,11 11,1' style='fill:none;stroke:white;stroke-width:2;'/></svg>` : ''}
+                    </span>
+                  </span>
+                `;
+              },              
+              cellClass,
+              headerClass,
+              ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
+            };
+            return applyCursor(result);
+          }
+          case "list":
+          default: {
+            const result = {
+              ...commonProperties,
+              headerName: translatePhrase(col.headerName),
+              field: col.field,
+              sortable: col.sortable,
+              filter: col.filter,
+              editable: col.editable,
+              cellClass,
+              headerClass,
+              ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
+            };
+            
+            if (col.useCustomLabel) {
+              result.valueFormatter = (params) => {
+                return this.resolveMappingFormula(
+                  col.displayLabelFormula,
+                  params.value
+                );
+              };
+            }
+            // Garante filtro de data para campos do tipo Date
+            if (col.cellDataType === 'dateString') {
+              result.filter = 'agDateColumnFilter';
+              result.cellDataType = 'dateString';
+              if (col.editable) {
+                result.cellEditor = 'agDateStringCellEditor';
+              }
+            }
+            // Garante filtro customizado de lista para campos do tipo List
+            if (col.cellDataType === 'list') {
+              result.filter = ListFilterRenderer;
+            }
+
+            return applyCursor(result);
+          }
+        }
+      });
+
+      if (
+        this.content.showDisabledSelectionLockIcon !== false &&
+        this.content.rowSelection === "multiple" &&
+        !this.content.disableCheckboxes
+      ) {
+        mappedColumns.push({
+          colId: "__lock_selection__",
+          headerName: "",
+          width: 52,
+          minWidth: 52,
+          maxWidth: 52,
+          sortable: false,
+          filter: false,
+          resizable: false,
+          suppressNavigable: true,
+          lockPosition: true,
+          suppressHeaderContextMenu: true,
+          suppressHeaderMenuButton: true,
+          suppressCellFocus: true,
+          suppressColumnsToolPanel: true,
+          cellStyle: {
+            right: "5px",
+            textAlign: "center",
+            paddingLeft: "0",
+            paddingRight: "0",
+            overflow: "hidden",
+          },
+          cellRenderer: (params) => {
+            const selectable = this.isRowSelectableByCondition(params?.data);
+            const lockTitle = translatePhrase("The record cannot be deleted");
+            return selectable
+              ? ""
+              : `<span><i class="fa fa-lock" style="font-size:15px;line-height:1;" aria-hidden="true" title="${lockTitle}"></i></span>`;
+          },
+        });
+      }
+
+      return [actionColumn, ...mappedColumns];
+    },
+    rowSelection() {
+      if (this.content.rowSelection === "multiple") {
+        return {
+          mode: "multiRow",
+          checkboxes: !this.content.disableCheckboxes,
+          headerCheckbox: !this.content.disableCheckboxes,
+          selectAll: this.content.selectAll || "all",
+          enableClickSelection: this.content.enableClickSelection,
+          isRowSelectable: (rowNode) => this.isRowSelectableByCondition(rowNode?.data),
+        };
+      } else if (this.content.rowSelection === "single") {
+        return {
+          mode: "singleRow",
+          checkboxes: !this.content.disableCheckboxes,
+          enableClickSelection: this.content.enableClickSelection,
+        };
+      } else {
+        return {
+          mode: "singleRow",
+          checkboxes: false,
+          isRowSelectable: () => false,
+          enableClickSelection: this.content.enableClickSelection,
+        };
+      }
+    },
+    style() {
+      if (this.content.layout === "auto") return {};
+      return {
+        height: this.content.height || "400px",
+      };
+    },
+    cssVars() {
+      return {
+        "--ww-data-grid_action-backgroundColor":
+          this.content.actionBackgroundColor,
+        "--ww-data-grid_action-color": this.content.actionColor,
+        "--ww-data-grid_action-padding": this.content.actionPadding,
+        "--ww-data-grid_action-border": this.content.actionBorder,
+        "--ww-data-grid_action-borderRadius": this.content.actionBorderRadius,
+        ...(this.content.actionFont
+          ? { "--ww-data-grid_action-font": this.content.actionFont }
+          : {
+              "--ww-data-grid_action-fontSize": this.content.actionFontSize,
+              "--ww-data-grid_action-fontFamily": this.content.actionFontFamily,
+              "--ww-data-grid_action-fontWeight": this.content.actionFontWeight,
+              "--ww-data-grid_action-fontStyle": this.content.actionFontStyle,
+              "--ww-data-grid_action-lineHeight": this.content.actionLineHeight,
+            }),
+      };
+    },
+    theme() {
+      return themeQuartz.withParams({
+        headerBackgroundColor: this.content.headerBackgroundColor,
+        headerTextColor: this.content.headerTextColor,
+        headerFontSize: "12px",
+        headerFontFamily: "Inter, sans-serif",
+        headerFontWeight: this.content.headerFontWeight,
+        borderColor: this.content.borderColor,
+        cellTextColor: this.content.cellColor,
+        cellFontFamily: "Inter, sans-serif",
+        dataFontSize: "12px",
+        oddRowBackgroundColor: this.content.rowAlternateColor,
+        backgroundColor: this.content.rowBackgroundColor,
+        rowHoverColor: this.content.rowHoverColor,
+        selectedRowBackgroundColor: this.content.selectedRowBackgroundColor,
+        rowVerticalPaddingScale: this.content.rowVerticalPaddingScale || 1,
+        menuBackgroundColor: this.content.menuBackgroundColor,
+        menuTextColor: this.content.menuTextColor,
+        columnHoverColor: this.content.columnHoverColor,
+        foregroundColor: this.content.textColor,
+        checkboxCheckedBackgroundColor: this.content.selectionCheckboxColor,
+        rangeSelectionBorderColor: this.content.cellSelectionBorderColor,
+        checkboxUncheckedBorderColor: this.content.checkboxUncheckedBorderColor,
+        focusShadow: this.content.focusShadow?.length
+          ? this.content.focusShadow
+          : undefined,
+      });
+    },
+    isEditing() {
+      /* wwEditor:start */
+      return (
+        this.wwEditorState.editMode === wwLib.wwEditorHelper.EDIT_MODES.EDITION
+      );
+      /* wwEditor:end */
+      // eslint-disable-next-line no-unreachable
+      return false;
+    },
+  },
+  methods: {
+    getRowId(params) {
+      return this.resolveMappingFormula(this.content.idFormula, params.data);
+    },
+    onActionTrigger(event) {
+      this.$emit("trigger-event", {
+        name: "action",
+        event,
+      });
+    },
+    onCellValueChanged(event) {
+      this.syncGridData();
+      this.$emit("trigger-event", {
+        name: "cellValueChanged",
+        event: {
+          oldValue: event.oldValue,
+          newValue: event.newValue,
+          columnId: event.column.getColId(),
+          row: event.data,
+        },
+      });
+    },
+    syncGridData() {
+      const rows = (this.rowData || [])
+        .filter((row) => !row?.__isInputRow)
+        .map((row) => {
+          const next = { ...row };
+          delete next.__isInputRow;
+          return next;
+        });
+      this.$emit("update:content:effect", { rowData: rows });
+    },
+    createBlankRow(isInputRow = false) {
+      return (this.content.columns || []).filter((col) => col.field).reduce((acc, col) => {
+        acc[col.field] = "";
+        return acc;
+      }, { __isInputRow: isInputRow });
+    },
+    addRowFromInput(inputRow) {
+      const newRow = { ...inputRow, __isInputRow: false };
+      delete newRow.__isInputRow;
+      const currentRows = Array.isArray(this.content.rowData) ? [...this.content.rowData] : [];
+      this.$emit("update:content:effect", { rowData: [...currentRows, newRow] });
+    },
+    deleteRow(rowIndex) {
+      const dataIndex = rowIndex - 1;
+      const currentRows = Array.isArray(this.content.rowData) ? [...this.content.rowData] : [];
+      if (dataIndex < 0 || dataIndex >= currentRows.length) return;
+      currentRows.splice(dataIndex, 1);
+      this.$emit("update:content:effect", { rowData: currentRows });
+    },
+    onCellKeyDown(event) {
+      if (!this.content.enterNextRow || !event?.event) return;
+      const keyEvent = event.event;
+      if (keyEvent.key !== "Enter" || keyEvent.shiftKey) {
+        this.pendingEnterEdit = null;
+        return;
+      }
+      const editingCells = event.api?.getEditingCells?.() || [];
+      const isEditingCurrentCell = editingCells.some(
+        (cell) =>
+          cell.rowIndex === event.rowIndex &&
+          cell.column?.getColId?.() === event.column?.getColId?.()
+      );
+      if (!isEditingCurrentCell) return;
+      keyEvent.preventDefault?.();
+      keyEvent.stopPropagation?.();
+      this.pendingEnterEdit = {
+        columnId: event.column.getColId(),
+        rowIndex: event.rowIndex,
+        pinned: event.column?.getPinned?.() || null,
+      };
+      event.api?.stopEditing?.();
+    },
+    onCellEditingStopped(event) {
+      if (!this.content.enterNextRow || !this.pendingEnterEdit) return;
+      const { columnId, rowIndex, pinned } = this.pendingEnterEdit;
+      this.pendingEnterEdit = null;
+      if (event.column.getColId() !== columnId || event.rowIndex !== rowIndex) {
+        return;
+      }
+      const nextRowIndex = rowIndex + 1;
+      if (!event.api || nextRowIndex >= event.api.getDisplayedRowCount()) {
+        return;
+      }
+      const nextRowNode = event.api.getDisplayedRowAtIndex(nextRowIndex);
+      if (!nextRowNode) return;
+      const targetColumn = event.api.getColumn(columnId);
+      if (!targetColumn || !targetColumn.isCellEditable(nextRowNode)) return;
+      const startEditParams = {
+        rowIndex: nextRowIndex,
+        colKey: targetColumn,
+      };
+      if (pinned) {
+        startEditParams.columnPinned = pinned;
+      }
+      requestAnimationFrame(() => {
+        event.api.ensureIndexVisible(nextRowIndex);
+        event.api.setFocusedCell(nextRowIndex, targetColumn);
+        event.api.startEditingCell(startEditParams);
+      });
+    },
+    isRowSelectableByCondition(rowData) {
+      const cond = this.content.disableRowSelectionCondition;
+      if (!cond) return true;
+      let expr = cond.replace(/@([a-zA-Z0-9_çÇãÃáÁéÉíÍóÓúÚêÊôÔâÂàÀèÈìÌòÒùÙüÜñÑ]+)/g, (match, p1) => {
+        const val = rowData && rowData[p1];
+        if (val === undefined || val === null) return 'null';
+        if (typeof val === 'string') return `"${val.replace(/"/g, '\\"')}"`;
+        if (typeof val === 'boolean' || typeof val === 'number') return val;
+        return 'null';
+      });
+      expr = expr.replace(/\bAND\b/gi, '&&').replace(/\bOR\b/gi, '||');
+      expr = expr.replace(/([^=!<>])=([^=])/g, '$1===$2');
+      try {
+        return !eval(expr);
+      } catch (e) {
+        return true;
+      }
+    },
+    onRowClicked(event) {
+      const colId = event.column && event.column.getColId && event.column.getColId();
+      const colDef = event.column && event.column.colDef;
+      const field = colDef && colDef.field;
+      const clickedTarget = event.event && event.event.target;
+      const clickedOnSelection =
+        clickedTarget &&
+        clickedTarget.closest &&
+        clickedTarget.closest(
+          '.ag-selection-checkbox, .ag-checkbox-input-wrapper, .ag-cell-checkbox'
+        );
+      const isSelectionCol =
+        (colId && (
+          colId === 'ag-Grid-SelectionColumn' ||
+          colId === 'ag-Grid-Selection' ||
+          colId === '__selection__' ||
+          colId === 'selection' ||
+          colId.toLowerCase().includes('selection')
+        )) ||
+        (colDef && colDef.checkboxSelection) ||
+        clickedOnSelection;
+      if (isSelectionCol) return;
+      this.$emit("trigger-event", {
+        name: "rowClicked",
+        event: {
+          row: event.data,
+          id: event.node.id,
+          index: event.node.sourceRowIndex,
+          displayIndex: event.rowIndex,
+          field,
+        },
+      });
+    },
+    remountGrid() {
+      this.gridApi = null;
+      this.gridVisible = false;
+      this.gridKey += 1;
+      this.showGrid();
+    },
+    deselectAllRows() {
+      if (this.gridApi) {
+        this.gridApi.deselectAll();
+      }
+    },
+    markRow(rowId) {
+      if (rowId === undefined || rowId === null || rowId === "") {
+        this.markedRowId = null;
+      } else {
+        this.markedRowId = String(rowId);
+      }
+
+      if (this.gridApi?.redrawRows) {
+        this.gridApi.redrawRows();
+      }
+    },
+    getRowStyle(params) {
+      if (!this.content.selectedActionRowColor || this.markedRowId === null) {
+        return null;
+      }
+
+      const rowId = this.getRowId({ data: params?.data });
+      if (String(rowId) !== this.markedRowId) {
+        return null;
+      }
+
+      return {
+        backgroundColor: this.content.selectedActionRowColor,
+      };
+    },
+    /* wwEditor:start */
+    generateColumns() {
+      this.$emit("update:content", {
+        columns: this.rowData?.[0]
+          ? Object.keys(this.rowData[0]).map((key) => ({
+              field: key,
+              sortable: true,
+              filter: true,
+            }))
+          : [],
+      });
+    },
+    getOnActionTestEvent() {
+      const data = this.rowData;
+      if (!data || !data[0]) throw new Error("No data found");
+      return {
+        actionName: "actionName",
+        row: data[0],
+        id: 0,
+        index: 0,
+        displayIndex: 0,
+      };
+    },
+    getOnCellValueChangedTestEvent() {
+      const data = this.rowData;
+      if (!data || !data[0]) throw new Error("No data found");
+      return {
+        oldValue: "oldValue",
+        newValue: "newValue",
+        columnId: "columnId",
+        row: data[0],
+      };
+    },
+    getSelectionTestEvent() {
+      const data = this.rowData;
+      if (!data || !data[0]) throw new Error("No data found");
+      return {
+        row: data[0],
+      };
+    },
+    getRowClickedTestEvent() {
+      const data = this.rowData;
+      if (!data || !data[0]) throw new Error("No data found");
+      return {
+        row: data[0],
+        id: 0,
+        index: 0,
+        displayIndex: 0,
+        field: Object.keys(data[0])[0],
+      };
+    },
+    /* wwEditor:end */
+  },
+  /* wwEditor:start */
+  watch: {
+    columnDefs: {
+      async handler() {
+        if (this.wwEditorState?.boundProps?.columns) return;
+        this.gridApi.resetColumnState();
+
+        if (this.wwEditorState.isACopy) return;
+
+        // We assume there will only be one custom column each time
+        const columnIndex = (this.content.columns || []).findIndex(
+          (col) => col.cellDataType === "custom" && !col.containerId
+        );
+        if (columnIndex === -1) return;
+        const newColumns = [...this.content.columns];
+        let column = { ...newColumns[columnIndex] };
+        column.containerId = await this.createElement("ww-flexbox", {
+          _state: { name: `Cell ${column.headerName || column.field}` },
+        });
+        newColumns[columnIndex] = column;
+        this.$emit("update:content:effect", { columns: newColumns });
+      },
+      deep: true,
+    },
+    rowData: {
+      handler() {
+        if (this.gridApi) {
+          this.gridApi.setFilterModel(null);
+        }
+      },
+      deep: true,
+    },
+    'content.selectAllRows'(newValue) {
+      if (!this.gridApi) return;
+      if (newValue === 'S') {
+        this.gridApi.selectAll();
+      } else if (newValue === 'N') {
+        this.gridApi.deselectAll();
+        setTimeout(() => {
+          this.gridApi.deselectAll(); // Garante que todas sejam desmarcadas
+          this.setSelectedRows([]);
+        }, 0);
+      }
+    },
+  },
+  /* wwEditor:end */
+};
+</script>
+
+<style scoped lang="scss">
+.ww-datagrid {
+    position: relative;
+
+    &.grid-hidden {
+      visibility: hidden;
+}
+.grid-input-action-btn {
+  width: 24px;
+  height: 24px;
+  border: 1px solid #d0d7de;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 700;
+  line-height: 1;
+}
+
+    /* wwEditor:start */
+    &.editing {
+      &::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        display: block;
+        pointer-events: initial;
+        z-index: 10;
+      }
+    }
+
+    /* wwEditor:end */
+
+
+    :deep(.ag-root-wrapper),
+    :deep(.ag-header),
+    :deep(.ag-header-cell-text),
+    :deep(.ag-cell),
+    :deep(.ag-paging-panel),
+    :deep(.ag-menu),
+    :deep(.ag-input-field-input) {
+      font-family: "Inter", sans-serif !important;
+      font-size: 12px !important;
+    }
+
+
+    :deep(.ag-selection-checkbox .ag-checkbox-input-wrapper.ag-disabled),
+    :deep(.ag-selection-checkbox .ag-checkbox-input-wrapper.ag-disabled *),
+    :deep(.ag-selection-checkbox input[type="checkbox"]:disabled) {
+      cursor: not-allowed !important;
+    }
+
+    :deep(.ag-header-cell .ag-header-cell-menu-button),
+    :deep(.ag-header-cell .ag-header-cell-menu-button-wrapper),
+    :deep(.ag-header-cell .ag-header-icon) {
+      opacity: 0 !important;
+      pointer-events: none !important;
+      transition: opacity 0.2s;
+    }
+
+    :deep(.ag-header-cell:hover .ag-header-icon),
+    :deep(.ag-header-cell.ag-header-cell-filtered .ag-header-icon) {
+      opacity: 1 !important;
+      pointer-events: auto !important;
+    }
+
+    :deep(.ag-header-cell .ag-header-icon) {
+      opacity: 0 !important;
+      pointer-events: none !important;
+      transition: opacity 0.2s;
+    }
+
+    :deep(.ag-header-cell.ag-header-cell-filtered .ag-header-icon) {
+      color: rgb(105, 157, 140) !important;
+      filter: drop-shadow(0 0 2px rgb(105, 157, 140));
+    }
+
+    /* Evita o efeito de redimensionamento animado ao carregar o grid */
+    :deep(.ag-header-cell),
+    :deep(.ag-cell) {
+      transition: none !important;
+    }
+
+    :deep(.ag-text-left) {
+      text-align: left !important;
+    }
+
+    :deep(.ag-text-center) {
+      text-align: center !important;
+    }
+
+    :deep(.ag-text-right) {
+      text-align: right !important;
+    }
+
+    :deep(.ag-header-align-left .ag-header-cell-label) {
+      justify-content: flex-start !important;
+    }
+
+    :deep(.ag-header-align-center .ag-header-cell-label) {
+      justify-content: center !important;
+      display: flex !important;
+      align-items: center !important;
+      gap: 4px;
+      width: 100%;
+      text-align: center !important;
+    }
+
+    :deep(.ag-header-align-center .ag-header-cell-label .ag-header-cell-text) {
+      flex: none !important;
+      text-align: center !important;
+      margin: 0 auto !important;
+    }
+
+    :deep(.ag-header-align-center .ag-header-icon) {
+      position: static !important;
+      margin-left: 2px !important;
+    }
+
+    :deep(.ag-header-align-right .ag-header-cell-label) {
+      justify-content: flex-end !important;
+    }
+
+    :deep(.ag-cell.ag-text-left) {
+      justify-content: flex-start !important;
+      display: flex !important;
+      padding-right: 24px !important;
+    }
+
+    :deep(.ag-cell.ag-text-center) {
+      justify-content: center !important;
+      display: flex !important;
+      padding-right: 24px !important;
+    }
+
+    :deep(.ag-cell.ag-text-right) {
+      justify-content: flex-end !important;
+      display: flex !important;
+      padding-right: 24px !important;
+    }
+  }
+
+
+
+  :deep(.ag-paging-row-summary-panel) {
+    display: none !important;
+  }
+
+  /* CSS para o filtro customizado ListFilterRenderer */
+  .list-filter {
+    padding: 10px;
+    min-width: 200px;
+    max-height: 300px;
+    overflow-y: auto;
+    font-family: "Inter", sans-serif;
+    font-size: 12px;
+  }
+
+  .list-filter .filter-header {
+    margin-bottom: 10px;
+  }
+
+  .list-filter .search-input {
+    width: 100%;
+    padding: 5px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font-size: 12px;
+    font-family: "Inter", sans-serif;
+  }
+
+  .list-filter .filter-list {
+    max-height: 200px;
+    overflow-y: auto;
+    margin-bottom: 10px;
+  }
+
+  .list-filter .filter-item {
+    display: flex;
+    align-items: center;
+    padding: 3px 0;
+    font-size: 12px;
+    font-family: "Inter", sans-serif;
+    cursor: pointer;
+  }
+
+  .list-filter .filter-item:hover {
+    background-color: #f5f5f5;
+  }
+
+  .list-filter .filter-item input[type="checkbox"] {
+    margin-right: 8px;
+  }
+
+  .list-filter .filter-actions {
+    display: flex;
+    gap: 5px;
+    justify-content: space-between;
+  }
+
+  .list-filter .apply-btn,
+  .list-filter .clear-btn {
+    padding: 5px 10px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 12px;
+    font-family: "Inter", sans-serif;
+  }
+
+  .list-filter .apply-btn:hover {
+    background: #e6f3ff;
+  }
+
+  .list-filter .clear-btn:hover {
+    background: #ffe6e6;
+  }
+</style>

--- a/Project/GridViewInput/ww-config.js
+++ b/Project/GridViewInput/ww-config.js
@@ -1,0 +1,1443 @@
+export default {
+  editor: {
+    label: {
+      en: "GridView Input",
+    },
+    icon: "table",
+    customStylePropertiesOrder: [
+      ["layout", "height", "textColor", "borderColor"],
+      [
+        "headerTitle",
+        "headerBackgroundColor",
+        "headerTextColor",
+        "headerFontWeight",
+        "headerFontSize",
+        "headerFontFamily",
+      ],
+      [
+        "rowTitle",
+        "rowBackgroundColor",
+        "rowAlternateColor",
+        "rowHoverColor",
+        "rowVerticalPaddingScale",
+      ],
+      ["columnTitle", "columnHoverHighlight", "columnHoverColor"],
+      [
+        "cellTitle",
+        "cellColor",
+        "cellFontFamily",
+        "cellFontSize",
+        "cellSelectionBorderColor",
+        "cellCursor",
+      ],
+      ["menuTitle", "menuTextColor", "menuBackgroundColor"],
+      [
+        "selectionTitle",
+        "selectedRowBackgroundColor",
+        "selectionCheckboxColor",
+        "focusShadow",
+        "checkboxUncheckedBorderColor",
+      ],
+      [
+        "actionTitle",
+        "actionColor",
+        "actionBackgroundColor",
+        "actionPadding",
+        "actionBorder",
+        "actionBorderRadius",
+        "actionFont",
+        "actionFontSize",
+        "actionFontFamily",
+        "actionFontWeight",
+        "actionFontStyle",
+        "actionLineHeight",
+        "selectedActionRowColor",
+      ],
+    ],
+    customSettingsPropertiesOrder: [
+      "rowData",
+      "idFormula",
+      "generateColumns",
+      "columns",
+      ["oneClickEdit", "enterNextRow"],
+      ["pagination", "paginationPageSize"],
+      [
+        "rowSelection",
+        "enableClickSelection",
+        "disableCheckboxes",
+        "showDisabledSelectionLockIcon",
+        "selectAll",
+        "selectAllRows",
+        "disableRowSelectionCondition",
+        "initialSelectedRowIds"
+      ],
+      "movableColumns",
+      "resizableColumns",
+      "initialFilters",
+      "initialSort",
+      ["lang", "localeText"],
+    ],
+  },
+  triggerEvents: [
+    {
+      name: "action",
+      label: { en: "On Action" },
+      event: { actionName: "", row: null, id: 0, index: 0, displayIndex: 0 },
+      getTestEvent: "getOnActionTestEvent",
+      default: true,
+    },
+    {
+      name: "cellValueChanged",
+      label: { en: "On Cell Value Changed" },
+      event: {
+        oldValue: null,
+        newValue: null,
+        columnId: "id",
+        row: null,
+      },
+      getTestEvent: "getOnCellValueChangedTestEvent",
+    },
+    {
+      name: "rowSelected",
+      label: { en: "On Row Selected" },
+      event: {
+        row: null,
+      },
+      getTestEvent: "getSelectionTestEvent",
+    },
+    {
+      name: "rowDeselected",
+      label: { en: "On Row Deselected" },
+      event: {
+        row: null,
+      },
+      getTestEvent: "getSelectionTestEvent",
+    },
+    {
+      name: "filterChanged",
+      label: { en: "On Filter Changed" },
+    },
+    {
+      name: "sortChanged",
+      label: { en: "On Sort Changed" },
+    },
+    {
+      name: "rowClicked",
+      label: { en: "On Row Clicked" },
+      event: {
+        row: null,
+        id: 0,
+        index: 0,
+        displayIndex: 0,
+        field: "field",
+      },
+      getTestEvent: "getRowClickedTestEvent",
+    },
+  ],
+  actions: [
+    {
+      action: "deselectAllRows",
+      label: { en: "Deselect All Rows" },
+      args: [],
+    },
+    {
+      action: "remountGrid",
+      label: { en: "Remount Grid" },
+      args: [],
+    },
+    {
+      action: "markRow",
+      label: { en: "Mark Row Background", pt: "Marcar fundo da linha" },
+      args: [
+        {
+          name: "rowId",
+          type: "string",
+          label: { en: "Row id", pt: "ID da linha" },
+        },
+      ],
+    },
+  ],
+  properties: {
+    headerTitle: {
+      type: "Title",
+      label: "Header",
+      editorOnly: true,
+    },
+    rowTitle: {
+      type: "Title",
+      label: "Row",
+      editorOnly: true,
+    },
+    columnTitle: {
+      type: "Title",
+      label: "Column",
+      editorOnly: true,
+    },
+    cellTitle: {
+      type: "Title",
+      label: "Cell",
+      editorOnly: true,
+    },
+    menuTitle: {
+      type: "Title",
+      label: "Menu",
+      editorOnly: true,
+    },
+    actionTitle: {
+      type: "Title",
+      label: "Action",
+      editorOnly: true,
+    },
+    selectionTitle: {
+      type: "Title",
+      label: "Selection",
+      editorOnly: true,
+    },
+    showDisabledSelectionLockIcon: {
+      label: { en: "Show lock on disabled selection" },
+      type: "OnOff",
+      section: "settings",
+      defaultValue: true,
+      bindable: true,
+      propertyHelp: {
+        tooltip:
+          "Display a lock icon in rows where selection checkbox is disabled.",
+      },
+    },
+    layout: {
+      type: "TextSelect",
+      label: "Height Mode",
+      options: {
+        options: [
+          { value: "fixed", label: "Fixed", default: true },
+          { value: "auto", label: "Auto" },
+        ],
+      },
+      bindable: true,
+      responsive: true,
+      propertyHelp: {
+        tooltip:
+          "Be cautious when using auto mode with a large number of rows, as it may slow down page rendering",
+      },
+      bindingValidation: {
+        type: "string",
+        tooltip: "fixed | auto",
+      },
+    },
+    height: {
+      label: { en: "Grid Height" },
+      type: "Length",
+      section: "style",
+      options: {
+        noRange: true,
+      },
+      bindable: true,
+      classes: true,
+      responsive: true,
+      states: true,
+      defaultValue: "400px",
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "string",
+        tooltip: "Height of the grid (e.g., 400px)",
+      },
+      hidden: (content) => content.layout === "auto",
+      /* wwEditor:end */
+    },
+    headerBackgroundColor: {
+      type: "Color",
+      label: "Background Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    headerTextColor: {
+      type: "Color",
+      label: "Text Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    headerFontWeight: {
+      label: "Font weight",
+      type: "TextSelect",
+      category: "text",
+      options: {
+        options: [
+          { value: null, label: "Default", default: true },
+          { value: 100, label: "100 - Thin" },
+          { value: 200, label: "200 - Extra Light" },
+          { value: 300, label: "300 - Light" },
+          { value: 400, label: "400 - Normal" },
+          { value: 500, label: "500 - Medium" },
+          { value: 600, label: "600 - Semi Bold" },
+          { value: 700, label: "700 - Bold" },
+          { value: 800, label: "800 - Extra Bold" },
+          { value: 900, label: "900 - Black" },
+        ],
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      bindingValidation: {
+        markdown: "font-weight",
+        type: "string",
+        cssSupports: "font-weight",
+      },
+    },
+    headerFontSize: {
+      label: "Font Size",
+      type: "Length",
+      options: {
+        unitChoices: [
+          { value: "px", label: "px", min: 1, max: 100, default: true },
+          { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+          { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+        ],
+        noRange: true,
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      bindingValidation: {
+        markdown: "font-size",
+        type: "string",
+        cssSupports: "font-size",
+      },
+    },
+    textColor: {
+      label: "Text Color",
+      type: "Color",
+      category: "text",
+      options: { nullable: true },
+      bindable: true,
+      bindingValidation: {
+        markdown: "color",
+        type: "string",
+        cssSupports: "color",
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+    },
+    headerFontFamily: {
+      label: "Font family",
+      type: "FontFamily",
+      category: "text",
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      bindingValidation: {
+        markdown: "font-family",
+        type: "string",
+        cssSupports: "font-family",
+      },
+    },
+    borderColor: {
+      type: "Color",
+      label: "Border Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    cellColor: {
+      type: "Color",
+      label: "Text Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    cellFontFamily: {
+      label: "Font family",
+      type: "FontFamily",
+      category: "text",
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      bindingValidation: {
+        markdown: "font-family",
+        type: "string",
+        cssSupports: "font-family",
+      },
+    },
+    cellFontSize: {
+      type: "Length",
+      label: "Font Size",
+      options: {
+        unitChoices: [
+          { value: "px", label: "px", min: 1, max: 100, default: true },
+          { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+          { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+        ],
+        noRange: true,
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      bindingValidation: {
+        markdown: "font-size",
+        type: "string",
+        cssSupports: "font-size",
+      },
+    },
+    cellSelectionBorderColor: {
+      type: "Color",
+      label: "Selection Border Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      bindingValidation: {
+        markdown: "color",
+        type: "string",
+        cssSupports: "color",
+      },
+    },
+    cellCursor: {
+      type: "TextSelect",
+      label: "Cursor",
+      options: {
+        options: [
+          { value: null, label: "Default", default: true },
+          { value: "default", label: "Default Cursor" },
+          { value: "pointer", label: "Pointer (mãozinha)" },
+          { value: "text", label: "Text (texto)" },
+          { value: "move", label: "Move (mover)" },
+          { value: "crosshair", label: "Crosshair (mira)" },
+          { value: "not-allowed", label: "Not Allowed (proibido)" },
+          { value: "help", label: "Help (ajuda)" },
+          { value: "wait", label: "Wait (aguarde)" },
+          { value: "progress", label: "Progress (progresso)" },
+          { value: "copy", label: "Copy (copiar)" },
+          { value: "grab", label: "Grab (pegar)" },
+          { value: "zoom-in", label: "Zoom In" },
+          { value: "zoom-out", label: "Zoom Out" }
+        ],
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "string",
+        tooltip: "Tipo de cursor ao passar o mouse sobre as células",
+      },
+      propertyHelp: {
+        tooltip:
+          "Defina o cursor do mouse para todas as células da grid. Se vazio, será usado o cursor de cada coluna.",
+      },
+      /* wwEditor:end */
+    },
+    columnHoverHighlight: {
+      type: "OnOff",
+      label: "Hover Highlight",
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    columnHoverColor: {
+      type: "Color",
+      label: "Hover Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      propertyHelp: {
+        tooltip: `Should be a semi-transparent color to allow the background color to show through.`,
+      },
+      hidden: (content) => !content.columnHoverHighlight,
+    },
+    rowBackgroundColor: {
+      type: "Color",
+      label: "Background Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    rowAlternateColor: {
+      type: "Color",
+      label: "Alternate Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    rowHoverColor: {
+      type: "Color",
+      label: "Hover Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      propertyHelp: {
+        tooltip: `Should be a semi-transparent color to allow the background color to show through.`,
+      },
+    },
+    selectedRowBackgroundColor: {
+      type: "Color",
+      label: "Selected Background Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      propertyHelp: {
+        tooltip: `Should be a semi-transparent color to allow the background color to show through.`,
+      },
+    },
+    selectionCheckboxColor: {
+      type: "Color",
+      label: "Selection Checkboxes Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      bindingValidation: {
+        markdown: "color",
+        type: "string",
+        cssSupports: "color",
+      },
+    },
+    checkboxUncheckedBorderColor: {
+      type: "Color",
+      label: "Checkbox Unchecked Border Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      bindingValidation: {
+        markdown: "color",
+        type: "string",
+        cssSupports: "color",
+      },
+    },
+    focusShadow: {
+      type: "Shadows",
+      label: "Focus Shadow",
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      bindingValidation: {
+        markdown: "shadow",
+        type: "string",
+        cssSupports: "shadow",
+      },
+    },
+    rowVerticalPaddingScale: {
+      type: "Number",
+      label: "Vertical Padding Scale",
+      options: {
+        min: 0,
+        max: 5,
+        step: 0.1,
+        default: 1,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    menuTextColor: {
+      label: "Text color",
+      type: "Color",
+      category: "text",
+      options: { nullable: true },
+      bindable: true,
+      bindingValidation: {
+        markdown: "color",
+        type: "string",
+        cssSupports: "color",
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+    },
+    menuBackgroundColor: {
+      label: "Background color",
+      type: "Color",
+      category: "background",
+      options: { nullable: true },
+      bindable: true,
+      bindingValidation: {
+        markdown: "background-color",
+        type: "string",
+        cssSupports: "background-color",
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+    },
+    actionColor: {
+      label: "Text color",
+      type: "Color",
+      category: "text",
+      options: { nullable: true },
+      bindable: true,
+      bindingValidation: {
+        markdown: "color",
+        type: "string",
+        cssSupports: "color",
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+    },
+    actionBackgroundColor: {
+      label: "Background color",
+      type: "Color",
+      category: "background",
+      options: { nullable: true },
+      bindable: true,
+      bindingValidation: {
+        markdown: "background-color",
+        type: "string",
+        cssSupports: "background-color",
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+    },
+    actionPadding: {
+      label: "Padding",
+      type: "Spacing",
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      bindingValidation: {
+        markdown: "padding",
+        type: "string",
+        cssSupports: "padding",
+      },
+    },
+    actionBorder: {
+      label: "Border",
+      type: "Border",
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      bindingValidation: {
+        markdown: "border",
+        type: "string",
+        cssSupports: "border",
+      },
+    },
+    actionBorderRadius: {
+      label: "Border radius",
+      type: "Spacing",
+      options: {
+        isCorner: true,
+        unitChoices: [
+          { value: "px", label: "px", min: 0, max: 50, default: true },
+          { value: "%", label: "%", min: 0, max: 100, digits: 2, step: 1 },
+        ],
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+      bindingValidation: {
+        markdown: "border-radius",
+        type: "string",
+        cssSupports: "border-radius",
+      },
+    },
+    actionFont: {
+      label: "Typography",
+      type: "Typography",
+      category: "text",
+      options: (content, sidepanelContent, boundProperties) => ({
+        initialValue: {
+          fontSize: content["actionFontSize"],
+          fontFamily: content["actionFontFamily"],
+          fontWeight: content["actionFontWeight"],
+          fontStyle: content["actionFontStyle"],
+          lineHeight: content["actionLineHeight"],
+        },
+        creationDisabled:
+          boundProperties["actionFontSize"] ||
+          boundProperties["actionFontFamily"] ||
+          boundProperties["actionFontWeight"] ||
+          boundProperties["actionFontStyle"] ||
+          boundProperties["actionLineHeight"],
+        creationDisabledMessage:
+          "Cannot create typography from bound properties",
+      }),
+      bindable: true,
+      responsive: true,
+      states: true,
+      classes: true,
+    },
+    actionFontSize: {
+      label: "Size",
+      type: "Length",
+      category: "text",
+      options: {
+        unitChoices: [
+          { value: "px", label: "px", min: 1, max: 100, default: true },
+          { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+          { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+        ],
+        noRange: true,
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      hidden: (content, _, boundProps) =>
+        content["actionFont"] || boundProps["actionFont"],
+      bindingValidation: {
+        markdown: "font-size",
+        type: "string",
+        cssSupports: "font-size",
+      },
+    },
+    actionFontFamily: {
+      label: "Font family",
+      type: "FontFamily",
+      category: "text",
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      hidden: (content, _, boundProps) =>
+        content["actionFont"] || boundProps["actionFont"],
+      bindingValidation: {
+        markdown: "font-family",
+        type: "string",
+        cssSupports: "font-family",
+      },
+    },
+    actionFontWeight: {
+      label: "Font weight",
+      type: "TextSelect",
+      category: "text",
+      options: {
+        options: [
+          { value: null, label: "Default", default: true },
+          { value: 100, label: "100 - Thin" },
+          { value: 200, label: "200 - Extra Light" },
+          { value: 300, label: "300 - Light" },
+          { value: 400, label: "400 - Normal" },
+          { value: 500, label: "500 - Medium" },
+          { value: 600, label: "600 - Semi Bold" },
+          { value: 700, label: "700 - Bold" },
+          { value: 800, label: "800 - Extra Bold" },
+          { value: 900, label: "900 - Black" },
+        ],
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      hidden: (content, _, boundProps) =>
+        content["actionFont"] || boundProps["actionFont"],
+      bindingValidation: {
+        markdown: "font-weight",
+        type: "string",
+        cssSupports: "font-weight",
+      },
+    },
+    actionFontStyle: {
+      label: "Font Style",
+      type: "TextRadioGroup",
+      category: "text",
+      options: {
+        choices: [
+          {
+            value: null,
+            title: "Default",
+            icon: "typo-default",
+            default: true,
+          },
+          { value: "italic", title: "Italic", icon: "typo-italic" },
+        ],
+      },
+      responsive: true,
+      states: true,
+      bindable: true,
+      classes: true,
+      hidden: (content, _, boundProps) =>
+        content["actionFont"] || boundProps["actionFont"],
+      bindingValidation: {
+        markdown: "font-style",
+        type: "string",
+        cssSupports: "font-style",
+      },
+    },
+    actionLineHeight: {
+      label: "Line height",
+      type: "Length",
+      category: "text",
+      options: {
+        unitChoices: [
+          { value: "normal", label: "auto", default: true },
+          { value: "px", label: "px", min: 0, max: 100 },
+          { value: "%", label: "%", min: 0, max: 100 },
+          { value: "em", label: "em", min: 0, max: 10, digits: 3, step: 0.1 },
+          { value: "rem", label: "rem", min: 0, max: 10, digits: 3, step: 0.1 },
+          { value: "unset", label: "none" },
+        ],
+        noRange: true,
+      },
+      responsive: true,
+      states: true,
+      classes: true,
+      bindable: true,
+      hidden: (content, _, boundProps) =>
+        content["actionFont"] || boundProps["actionFont"],
+      bindingValidation: {
+        markdown: "line-height",
+        type: "string",
+        cssSupports: "line-height",
+      },
+    },
+    selectedActionRowColor: {
+      type: "Color",
+      label: "Selected Row Color",
+      options: {
+        nullable: true,
+      },
+      responsive: true,
+      bindable: true,
+      states: true,
+      classes: true,
+    },
+    rowData: {
+      label: { en: "Data" },
+      type: "ObjectList",
+      options: {
+        useSchema: true,
+      },
+      section: "settings",
+      bindable: true,
+      defaultValue: [],
+      /* wwEditor:start */
+      bindingValidation: {
+        validations: [
+          {
+            type: "array",
+          },
+          {
+            type: "object",
+          },
+        ],
+        tooltip:
+          "A collection or an array of data: \n\n`myCollection` or `[{}, {}, ...]`",
+      },
+      /* wwEditor:end */
+    },
+    idFormula: {
+      type: "Formula",
+      label: "Unique Row Id",
+      options: (content) => ({
+        template: wwLib.wwUtils.getDataFromCollection(content.rowData)?.[0],
+      }),
+      section: "settings",
+      propertyHelp: {
+        tooltip:
+          "A unique id per row. Very useful for performance optimization.",
+      },
+    },
+    generateColumns: {
+      type: "Button",
+      options: {
+        text: "Generate columns",
+        color: "blue",
+        action: "generateColumns",
+      },
+      section: "settings",
+      editorOnly: true,
+    },
+    columns: {
+      label: {
+        en: "Columns",
+      },
+      type: "Array",
+      options: {
+        item: {
+          type: "Object",
+          options: (
+            content,
+            sidePanelContent,
+            boundProperties,
+            wwProps,
+            array
+          ) => ({
+            item: {
+              headerName: {
+                label: "Header Name",
+                type: "Text",
+                bindable: true,
+              },
+              cellDataType: {
+                label: "Type",
+                type: "TextSelect",
+                options: {
+                  options: [
+                    { value: undefined, label: "Auto", default: true },
+                    { value: "text", label: "Text" },
+                    { value: "list", label: "List" },
+                    { value: "number", label: "Number" },
+                    { value: "boolean", label: "Boolean" },
+                    { value: "dateString", label: "Date" },
+                    { value: "image", label: "Image" },
+                    { value: "action", label: "Action" },
+                    { value: "custom", label: "Custom" },
+                  ],
+                },
+              },
+              info: {
+                type: "InfoBox",
+                options: {
+                  variant: "warning",
+                  content: "To select your custom cell, use the Layout view",
+                },
+                editorOnly: true,
+                hidden: array?.item?.cellDataType !== "custom",
+              },
+              field: {
+                label: "Key",
+                type: "Text",
+                hidden: array?.item?.cellDataType === "action",
+              },
+              useCustomLabel: {
+                label: "Custom display value",
+                type: "OnOff",
+                hidden:
+                  array?.item?.cellDataType === "action" ||
+                  array?.item?.cellDataType === "image" ||
+                  array?.item?.cellDataType === "custom",
+              },
+              displayLabelFormula: {
+                label: "Display value",
+                type: "Formula",
+                options: {
+                  template: _.get(
+                    wwLib.wwUtils.getDataFromCollection(content.rowData)?.[0],
+                    array?.item?.field
+                  ),
+                },
+                hidden:
+                  array?.item?.cellDataType === "action" ||
+                  array?.item?.cellDataType === "image" ||
+                  !array?.item?.useCustomLabel ||
+                  array?.item?.cellDataType === "custom",
+              },
+              widthAlgo: {
+                type: "TextRadioGroup",
+                label: "Width",
+                options: {
+                  choices: [
+                    { value: "fixed", label: "Fixed", default: true },
+                    { value: "flex", label: "Flex" },
+                  ],
+                },
+              },
+              flex: {
+                label: "Flex",
+                type: "Number",
+                options: {
+                  min: 1,
+                  max: 10,
+                  step: 1,
+                  noRange: true,
+                  defaultValue: 1,
+                },
+                hidden: array?.item?.widthAlgo !== "flex",
+              },
+              width: {
+                type: "Length",
+                options: {
+                  noRange: true,
+                  unitChoices: [
+                    { value: "px", label: "px", min: 0, max: 1300 },
+                    { value: "auto", label: "auto" },
+                  ],
+                },
+                hidden: array?.item?.widthAlgo === "flex",
+              },
+              minWidth: {
+                label: "Min Width",
+                type: "Length",
+                options: {
+                  noRange: true,
+                  unitChoices: [
+                    { value: "px", label: "px", min: 0, max: 1300 },
+                    { value: "auto", label: "auto" },
+                  ],
+                },
+              },
+              maxWidth: {
+                label: "Max Width",
+                type: "Length",
+                options: {
+                  noRange: true,
+                  unitChoices: [
+                    { value: "px", label: "px", min: 0, max: 1300 },
+                    { value: "auto", label: "auto" },
+                  ],
+                },
+              },
+              pinned: {
+                label: "Pinned",
+                type: "TextRadioGroup",
+                options: {
+                  choices: [
+                    { value: "none", label: "None", default: true },
+                    { value: "left", label: "Left" },
+                    { value: "right", label: "Right" },
+                  ],
+                },
+              },
+              hide: {
+                label: "Hidden",
+                type: "OnOff",
+                bindable: true,
+                bindingValidation: {
+                  type: "boolean",
+                  tooltip: "True to hide the column",
+                },
+              },
+              editable: {
+                label: "Editable",
+                type: "OnOff",
+                hidden:
+                  array?.item?.cellDataType === "action" ||
+                  array?.item?.cellDataType === "image" ||
+                  array?.item?.cellDataType === "custom",
+                bindable: true,
+              },
+              filter: {
+                label: "Filter",
+                type: "OnOff",
+                hidden:
+                  array?.item?.cellDataType === "action" ||
+                  array?.item?.cellDataType === "image",
+                  bindable: true,
+              },
+              sortable: {
+                label: "Sortable",
+                type: "OnOff",
+                hidden:
+                  array?.item?.cellDataType === "action" ||
+                  array?.item?.cellDataType === "image",
+                  bindable: true,
+              },
+              actionName: {
+                label: "Action Name",
+                type: "Text",
+                hidden: array?.item?.cellDataType !== "action",
+              },
+              actionLabel: {
+                label: "Action Label",
+                type: "Text",
+                hidden: array?.item?.cellDataType !== "action",
+              },
+              imageWidth: {
+                label: "Image width",
+                type: "Length",
+                options: {
+                  noRange: true,
+                },
+                hidden: array?.item?.cellDataType !== "image",
+              },
+              imageHeight: {
+                label: "Image height",
+                type: "Length",
+                options: {
+                  noRange: true,
+                },
+                hidden: array?.item?.cellDataType !== "image",
+              },
+              headerAlign: {
+                label: "Header Alignment",
+                type: "TextSelect",
+                options: {
+                  options: [
+                    { value: undefined, label: "Default", default: true },
+                    { value: "left", label: "Left" },
+                    { value: "center", label: "Center" },
+                    { value: "right", label: "Right" },
+                  ],
+                },
+                bindable: true,
+              },
+              textAlign: {
+                label: "Cell Alignment",
+                type: "TextSelect",
+                options: {
+                  options: [
+                    { value: undefined, label: "Default", default: true },
+                    { value: "left", label: "Left" },
+                    { value: "center", label: "Center" },
+                    { value: "right", label: "Right" },
+                  ],
+                },
+                bindable: true,
+              },
+              cursor: {
+                label: "Cursor",
+                type: "TextSelect",
+                options: {
+                  options: [
+                    { value: "default", label: "Default", default: true },
+                    { value: "pointer", label: "Pointer (mãozinha)" },
+                    { value: "text", label: "Text (texto)" },
+                    { value: "move", label: "Move (mover)" },
+                    { value: "crosshair", label: "Crosshair (mira)" },
+                    { value: "not-allowed", label: "Not Allowed (proibido)" },
+                    { value: "help", label: "Help (ajuda)" },
+                    { value: "wait", label: "Wait (aguarde)" },
+                    { value: "progress", label: "Progress (progresso)" },
+                    { value: "copy", label: "Copy (copiar)" },
+                    { value: "grab", label: "Grab (pegar)" },
+                    { value: "zoom-in", label: "Zoom In" },
+                    { value: "zoom-out", label: "Zoom Out" }
+                  ]
+                },
+                /* wwEditor:start */
+                bindingValidation: {
+                  type: "string",
+                  tooltip: "Tipo de cursor ao passar o mouse sobre as células desta coluna"
+                },
+                propertyHelp: {
+                  tooltip: "Escolha o tipo de cursor do mouse para as células desta coluna."
+                }
+                /* wwEditor:end */
+              },
+              booleanCheckboxColor: {
+                label: "Boolean Checkbox Color",
+                type: "Color",
+                bindable: true,
+                hidden: array?.item?.cellDataType !== "boolean",
+                options: { nullable: true },
+              },
+            },
+          }),
+        },
+        defaultValue: {
+          filter: false,
+          sortable: false,
+        },
+        movable: true,
+        expandable: true,
+        getItemLabel(item, index) {
+          return item?.headerName?.length
+            ? item?.headerName
+            : item?.field?.length
+            ? item?.field
+            : `Column ${index + 1}`;
+        },
+      },
+      defaultValue: [],
+      section: "settings",
+      bindable: true,
+    },
+    oneClickEdit: {
+      label: { en: "One Click To Edit" },
+      type: "OnOff",
+      section: "settings",
+      bindable: true,
+      defaultValue: false,
+      propertyHelp: {
+        tooltip:
+          "Enable to start editing an editable cell with a single click instead of a double click.",
+      },
+      bindingValidation: {
+        type: "boolean",
+        tooltip: "True to enable single click editing on editable cells",
+      },
+    },
+    enterNextRow: {
+      label: { en: "Enter Edits Next Row" },
+      type: "OnOff",
+      section: "settings",
+      bindable: true,
+      defaultValue: false,
+      propertyHelp: {
+        tooltip:
+          "When enabled, pressing Enter while editing moves to and starts editing the cell directly below.",
+      },
+      bindingValidation: {
+        type: "boolean",
+        tooltip: "True to finish the current edit and begin editing the cell in the next row",
+      },
+    },
+    pagination: {
+      label: { en: "Pagination" },
+      type: "OnOff",
+      section: "settings",
+      bindable: true,
+      defaultValue: false,
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "boolean",
+        tooltip: "Enable or disable pagination",
+      },
+      /* wwEditor:end */
+    },
+    paginationPageSize: {
+      label: { en: "Rows Per Page" },
+      type: "Number",
+      section: "settings",
+      bindable: true,
+      defaultValue: 10,
+      options: {
+        noRange: true,
+      },
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "number",
+        tooltip: "Number of rows to display per page",
+      },
+      hidden: (content) => !content.pagination,
+      /* wwEditor:end */
+    },
+    rowSelection: {
+      label: { en: "Row Selection" },
+      type: "TextSelect",
+      section: "settings",
+      bindable: true,
+      options: {
+        options: [
+          { value: "none", label: "None", default: true },
+          { value: "single", label: "Single" },
+          { value: "multiple", label: "Multiple" },
+        ],
+      },
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "string",
+        tooltip: "Type of row selection: none or single or multiple",
+      },
+      /* wwEditor:end */
+    },
+    enableClickSelection: {
+      label: { en: "Enable Click Selection" },
+      type: "OnOff",
+      section: "settings",
+      bindable: true,
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "boolean",
+        tooltip: "True to enable row selection on click",
+      },
+      hidden: (content) =>
+        content.rowSelection === "none" || content.rowSelection === undefined,
+      /* wwEditor:end */
+    },
+    disableCheckboxes: {
+      label: { en: "Disable Checkboxes" },
+      type: "OnOff",
+      section: "settings",
+      bindable: true,
+      defaultValue: false,
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "boolean",
+        tooltip: "True to disable checkboxes",
+      },
+      hidden: (content) =>
+        content.rowSelection === "none" || content.rowSelection === undefined,
+      /* wwEditor:end */
+    },
+    selectAll: {
+      label: { en: "Select All behavior" },
+      type: "TextSelect",
+      section: "settings",
+      bindable: true,
+      defaultValue: "all",
+      options: {
+        options: [
+          { value: "all", label: "All", default: true },
+          { value: "filtered", label: "Filtered" },
+          { value: "currentPage", label: "Current Page" },
+        ],
+      },
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "string",
+        enum: ["all", "filtered", "currentPage"],
+        tooltip:
+          "Select all behavior: 'all' to select all rows, 'filtered' to select filtered rows, 'currentPage' to select current page rows",
+      },
+      hidden: (content) => content.rowSelection !== "multiple",
+      /* wwEditor:end */
+    },
+    selectAllRows: {
+      label: { en: "Select/Deselect All Rows" },
+      type: "TextSelect",
+      bindable: true,
+      section: "settings",
+      defaultValue: null,
+      options: {
+        options: [
+          { value: null, label: "No Action", default: true },
+          { value: "S", label: "Select All" },
+          { value: "N", label: "Deselect All" }
+        ]
+      },
+      propertyHelp: {
+        tooltip: "Set to 'S' to select all rows, 'N' to deselect all rows, or null to do nothing. Has o mesmo efeito do checkbox do header."
+      },
+      bindingValidation: {
+        type: ["string", "null"],
+        enum: ["S", "N", null],
+        tooltip: "'S' para selecionar todas, 'N' para desmarcar todas, null para não fazer nada"
+      }
+    },
+    initialSelectedRowIds: {
+      label: { en: 'Initial selected row IDs' },
+      type: 'array',
+      bindable: true,
+      section: "settings",
+      defaultValue: [],
+      description: 'Array de IDs (strings) das linhas que devem ser selecionadas inicialmente. Os valores devem corresponder ao Unique Row Id de cada linha.'
+    },
+    movableColumns: {
+      label: { en: "Movable Columns" },
+      type: "OnOff",
+      section: "settings",
+      bindable: true,
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "boolean",
+        tooltip: "Enable or disable movable columns",
+      },
+      /* wwEditor:end */
+    },
+    resizableColumns: {
+      label: { en: "Resizable Columns" },
+      type: "OnOff",
+      section: "settings",
+      bindable: true,
+      defaultValue: true,
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "boolean",
+        tooltip: "Enable or disable resizable columns",
+      },
+      /* wwEditor:end */
+    },
+    initialFilters: {
+      label: { en: "Initial Filters" },
+      type: "RawObject",
+      section: "settings",
+      bindable: true,
+      defaultValue: null,
+      bindingValidation: {
+        type: "object",
+        tooltip: "An object representing the initial filter model",
+      },
+    },
+    initialSort: {
+      label: { en: "Initial Sort" },
+      type: "RawObject",
+      section: "settings",
+      bindable: true,
+      defaultValue: null,
+      bindingValidation: {
+        type: "array",
+        tooltip: "An array representing the initial sort model",
+      },
+    },
+    lang: {
+      label: { en: "Language" },
+      type: "TextSelect",
+      section: "settings",
+      bindable: true,
+      options: {
+        options: [
+          { value: "en", label: "English", default: true },
+          { value: "fr", label: "French" },
+          { value: "es", label: "Spanish" },
+          { value: "de", label: "German" },
+          { value: "pt", label: "Portuguese" },
+          { value: "custom", label: "Custom" },
+        ],
+      },
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "string",
+        tooltip:
+          "Localisation to use. Default is English. Possible values: en, fr, es, de, pt, custom. Use custom to set your own locale texts.",
+      },
+      /* wwEditor:end */
+    },
+    localeText: {
+      label: { en: "Locale texts" },
+      type: "RawObject",
+      section: "settings",
+      bindable: true,
+      defaultValue: {},
+      hidden: (content) => content.lang !== "custom",
+      /* wwEditor:start */
+      bindingValidation: {
+        type: "object",
+        tooltip:
+          'See <a href="https://github.com/ag-grid/ag-grid/blob/latest/community-modules/locale/src/en-US.ts" target="_blank">Aggrid website</a> for the list of texts to localise',
+      },
+      /* wwEditor:end */
+    },
+    disableRowSelectionCondition: {
+      label: { en: "Disable row selection condition" },
+      type: "Text",
+      section: "settings",
+      bindable: true,
+      defaultValue: "",
+      propertyHelp: {
+        tooltip: "Exemplo: @status=Ativo AND @dataDeCriação < 10/10/2025. Use @ para referenciar campos da linha."
+      }
+    },
+  },
+};


### PR DESCRIPTION
### Motivation
- Implement a reusable data-grid input component based on ag-grid to support editable rows, selection, sorting, filtering and localization.
- Provide custom cell types and editing experiences (actions, images, custom layout cells, datetime editor and searchable list filter) required by the UI.
- Surface a full editor configuration and a runtime translation helper so the component can be configured and localized in the editor environment.

### Description
- Add the main Vue grid component `wwElement.vue` which integrates `ag-grid-vue3`, registers modules and wires props, events, selection, initial selection IDs, filters, sorting, editing flows and theme/CSS variables.
- Add custom cell renderers and editors: `ActionCellRenderer.vue`, `ImageCellRenderer.vue`, `WewebCellRenderer.vue`, `DateTimeCellEditor.js`, plus the filter implementation `ListFilterRenderer.js` and its styles in `list-filter.css`.
- Add `translation.js` runtime helper to look up (and auto-register) phrases from the editor translation store, and add a comprehensive editor configuration `ww-config.js` describing properties, triggers and actions for the GridView Input.
- Implement UI details and behavior including custom list filter UI and logic, cursor handling, enter-to-edit-next-row flow, add/delete input-row actions, theme CSS variables and scrollbar / accessibility refinements.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15b0d8dce8833082d9fe625608f95c)