### PR TITLE
Add mandatory status selection for required fields and enhance multi-select grouping/visuals

### DIFF
--- a/Project/FormBuilder/Component/components/FieldPropertiesPanel.vue
+++ b/Project/FormBuilder/Component/components/FieldPropertiesPanel.vue
@@ -36,6 +36,16 @@
           </div>
         </div>
       </div>
+      <div class="form-group" v-if="isRequired">
+        <label>Status obrigatório</label>
+        <QueryMultiSelect
+          :model-value="mandatoryStatuses"
+          :options="mandatoryStatusOptions"
+          :loading="mandatoryStatusesLoading"
+          placeholder="Selecione status"
+          @update:modelValue="updateMandatoryStatuses"
+        />
+      </div>
 
       <div class="form-group toggle">
         <div class="toggle-container">
@@ -209,6 +219,10 @@ export default {
     const showOnlyOptions = ref([]);
     const showOnlyLoading = ref(false);
     const SHOW_ONLY_GROUPS_VARIABLE_ID = '79df4513-8ec5-4a4b-8f2c-d055d9eb30f4';
+    const MANDATORY_STATUS_COLLECTION_ID = '95233031-3746-48c8-8c3c-8722b0075d61';
+    const mandatoryStatuses = ref([]);
+    const mandatoryStatusOptions = ref([]);
+    const mandatoryStatusesLoading = ref(false);
 
     const normalizeBoolean = (value) => {
       if (typeof value === 'boolean') return value;
@@ -295,6 +309,7 @@ export default {
     watch(() => props.selectedField, (newField) => {
       if (newField) {
         isRequired.value = normalizeBoolean(newField.is_mandatory);
+        mandatoryStatuses.value = normalizeShowOnlyGroups(newField.mandatory_statuses);
         isHideLegend.value = normalizeBoolean(newField.is_hide_legend);
         const normalizedShowOnlyGroups = normalizeShowOnlyGroups(
           newField.show_only_groups || newField.show_only_groups_json
@@ -351,6 +366,7 @@ export default {
     // Reset form values
     const resetForm = () => {
       isRequired.value = false;
+      mandatoryStatuses.value = [];
       isHideLegend.value = false;
       tipText.value = '';
       labelHelpText.value = '';
@@ -391,6 +407,15 @@ export default {
           [property]: normalizedGroups,
           show_only: showOnly.value,
           show_only_groups_json: JSON.stringify(normalizedGroups)
+        });
+        return;
+      }
+      if (property === 'is_mandatory' && !value) {
+        mandatoryStatuses.value = [];
+        emit('update-field', {
+          ...props.selectedField,
+          is_mandatory: false,
+          mandatory_statuses: []
         });
         return;
       }
@@ -471,6 +496,52 @@ export default {
       showOnlyGroups.value = normalizedValue;
       updateFieldProperty('show_only_groups', normalizedValue);
     };
+    const loadMandatoryStatusOptions = () => {
+      try {
+        const wwVariable = window?.wwLib?.wwVariable;
+        const wwCollection = window?.wwLib?.wwCollection;
+        const collectionData =
+          typeof wwCollection?.getCollection === 'function'
+            ? wwCollection.getCollection(MANDATORY_STATUS_COLLECTION_ID)
+            : undefined;
+        const getters = wwVariable
+          ? [
+              wwVariable.getValue?.bind(wwVariable),
+              wwVariable.getComponentValue?.bind(wwVariable),
+              wwVariable.get?.bind(wwVariable)
+            ].filter(Boolean)
+          : [];
+        const variableData = getters.reduce((acc, getter) => {
+          if (acc !== undefined) return acc;
+          try {
+            return getter(MANDATORY_STATUS_COLLECTION_ID);
+          } catch (error) {
+            return undefined;
+          }
+        }, undefined);
+        const rawData = Array.isArray(collectionData) ? collectionData : variableData;
+        if (!Array.isArray(rawData)) {
+          mandatoryStatusOptions.value = [];
+          return;
+        }
+        mandatoryStatusOptions.value = rawData
+          .map(item => ({
+            value: item?.id,
+            label: item?.status,
+            group: item?.statusClassTitle || 'Outros',
+            backgroundColor: item?.BackgroundColor,
+            textColor: item?.TextColor
+          }))
+          .filter(item => item.value && item.label);
+      } catch (error) {
+        mandatoryStatusOptions.value = [];
+      }
+    };
+    const updateMandatoryStatuses = (value) => {
+      const normalized = normalizeShowOnlyGroups(value);
+      mandatoryStatuses.value = normalized;
+      updateFieldProperty('mandatory_statuses', normalized);
+    };
 
     watch(showOnly, (value) => {
       if (!value) {
@@ -483,6 +554,9 @@ export default {
     });
 
     onMounted(() => {
+      mandatoryStatusesLoading.value = true;
+      loadMandatoryStatusOptions();
+      mandatoryStatusesLoading.value = false;
       if (showOnly.value) {
         showOnlyLoading.value = true;
         loadShowOnlyOptions();
@@ -501,12 +575,16 @@ export default {
       showOnlyGroups,
       showOnlyOptions,
       showOnlyLoading,
+      mandatoryStatuses,
+      mandatoryStatusOptions,
+      mandatoryStatusesLoading,
       isHiddenInEndUserNewTicket,
       isHiddenInEndUserViewTicket,
       updateFieldProperty,
       updateTip,
       updateLabelHelp,
-      updateShowOnlyGroups
+      updateShowOnlyGroups,
+      updateMandatoryStatuses
     };
   }
 };

--- a/Project/FormBuilder/Component/components/QueryMultiSelect.vue
+++ b/Project/FormBuilder/Component/components/QueryMultiSelect.vue
@@ -21,6 +21,7 @@
                             :key="option.value"
                             class="query-multi-select__chip"
                             :class="{ 'query-multi-select__chip--hidden': index >= visibleChipCount }"
+                            :style="getChipStyle(option)"
                             :ref="setChipRef"
                         >
                             <span class="query-multi-select__chip-label">{{ option.label }}</span>
@@ -72,30 +73,61 @@
                 <div v-if="!hasOptions" class="query-multi-select__state">{{ translateText('No options') }}</div>
                 <div v-else-if="!filteredOptions.length" class="query-multi-select__state">{{ translateText('No results found') }}</div>
                 <ul v-else class="query-multi-select__list">
-                    <li
-                        v-for="option in filteredOptions"
-                        :key="String(option.value)"
-                        class="query-multi-select__option"
-                        :class="{ 'query-multi-select__option--selected': isSelected(option.value) }"
-                    >
-                        <label v-if="isMultiple">
-                            <input
-                                type="checkbox"
-                                :value="String(option.value)"
-                                :checked="isSelected(option.value)"
-                                @change="toggleValue(option.value)"
-                            />
-                            <span>{{ option.label }}</span>
-                        </label>
-                        <button
-                            v-else
-                            type="button"
-                            class="query-multi-select__option-button"
-                            @click="selectSingleValue(option.value)"
+                    <template v-if="hasGroups">
+                        <li v-for="group in groupedFilteredOptions" :key="group.name" class="query-multi-select__group">
+                            <label class="query-multi-select__group-title" v-if="isMultiple">
+                                <input
+                                    type="checkbox"
+                                    :checked="isGroupFullySelected(group.items)"
+                                    :indeterminate.prop="isGroupPartiallySelected(group.items)"
+                                    @change="toggleGroup(group.items)"
+                                />
+                                <span>{{ group.name }}</span>
+                            </label>
+                            <div
+                                v-for="option in group.items"
+                                :key="String(option.value)"
+                                class="query-multi-select__option"
+                                :class="{ 'query-multi-select__option--selected': isSelected(option.value) }"
+                            >
+                                <label v-if="isMultiple">
+                                    <input
+                                        type="checkbox"
+                                        :value="String(option.value)"
+                                        :checked="isSelected(option.value)"
+                                        @change="toggleValue(option.value)"
+                                    />
+                                    <span class="query-multi-select__option-chip" :style="getOptionStyle(option)">{{ option.label }}</span>
+                                </label>
+                            </div>
+                        </li>
+                    </template>
+                    <template v-else>
+                        <li
+                            v-for="option in filteredOptions"
+                            :key="String(option.value)"
+                            class="query-multi-select__option"
+                            :class="{ 'query-multi-select__option--selected': isSelected(option.value) }"
                         >
-                            {{ option.label }}
-                        </button>
-                    </li>
+                            <label v-if="isMultiple">
+                                <input
+                                    type="checkbox"
+                                    :value="String(option.value)"
+                                    :checked="isSelected(option.value)"
+                                    @change="toggleValue(option.value)"
+                                />
+                                <span>{{ option.label }}</span>
+                            </label>
+                            <button
+                                v-else
+                                type="button"
+                                class="query-multi-select__option-button"
+                                @click="selectSingleValue(option.value)"
+                            >
+                                {{ option.label }}
+                            </button>
+                        </li>
+                    </template>
                 </ul>
             </template>
         </div>
@@ -170,6 +202,16 @@ export default {
                 return label.includes(term) || value.includes(term);
             });
         });
+        const groupedFilteredOptions = computed(() => {
+            const groups = new Map();
+            filteredOptions.value.forEach((option) => {
+                const groupName = option?.group || 'Other';
+                if (!groups.has(groupName)) groups.set(groupName, []);
+                groups.get(groupName).push(option);
+            });
+            return Array.from(groups.entries()).map(([name, items]) => ({ name, items }));
+        });
+        const hasGroups = computed(() => groupedFilteredOptions.value.some(group => group.name));
 
         const hasOptions = computed(() => optionsState.value.length > 0);
 
@@ -337,6 +379,27 @@ export default {
             const values = normalizedValue.value.filter((item) => item !== stringValue);
             emitValue(values);
         };
+        const isGroupFullySelected = (items = []) => items.length > 0 && items.every(item => isSelected(item.value));
+        const isGroupPartiallySelected = (items = []) => items.some(item => isSelected(item.value)) && !isGroupFullySelected(items);
+        const toggleGroup = (items = []) => {
+            const values = normalizedValue.value.slice();
+            const itemValues = items.map(item => String(item.value));
+            const shouldSelect = !isGroupFullySelected(items);
+            const next = shouldSelect
+                ? Array.from(new Set([...values, ...itemValues]))
+                : values.filter(value => !itemValues.includes(value));
+            emitValue(next);
+        };
+        const getOptionStyle = (option) => ({
+            backgroundColor: option?.backgroundColor || 'transparent',
+            color: option?.textColor || 'inherit',
+            padding: option?.backgroundColor ? '2px 8px' : '0',
+            borderRadius: option?.backgroundColor ? '999px' : '0',
+        });
+        const getChipStyle = (option) => ({
+            backgroundColor: option?.backgroundColor || undefined,
+            color: option?.textColor || undefined,
+        });
 
         watch(
             normalizedValue,
@@ -449,6 +512,13 @@ export default {
             searchTerm,
             searchInputRef,
             isMultiple,
+            groupedFilteredOptions,
+            hasGroups,
+            isGroupFullySelected,
+            isGroupPartiallySelected,
+            toggleGroup,
+            getOptionStyle,
+            getChipStyle,
             selectSingleValue,
             selectedOption,
             translateText,
@@ -639,6 +709,16 @@ export default {
 .query-multi-select__option {
     padding: 8px 12px;
     border-radius: 4px;
+}
+.query-multi-select__group-title {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    padding: 8px 12px 4px;
+}
+.query-multi-select__option-chip {
+    display: inline-block;
 }
 
 .query-multi-select__option--selected {

--- a/Project/FormBuilder/Component/wwElement.vue
+++ b/Project/FormBuilder/Component/wwElement.vue
@@ -152,6 +152,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('category')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('category').length === 0"
                       class="custom-dropdown-no-options"
@@ -171,7 +172,6 @@
                     </div>
                   </div>
                 </div>
-                <button type="button" class="header-inline-clear-link" @click.stop="clearHeaderSelection('category')">Clear</button>
               </div>
               <div
                 class="select-wrapper tag-select-wrapper"
@@ -208,6 +208,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('subcategory')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('subcategory').length === 0"
                       class="custom-dropdown-no-options"
@@ -227,7 +228,6 @@
                     </div>
                   </div>
                 </div>
-                <button type="button" class="header-inline-clear-link" @click.stop="clearHeaderSelection('subcategory')">Clear</button>
               </div>
               <div
                 class="select-wrapper tag-select-wrapper"
@@ -264,6 +264,7 @@
                         @touchstart.stop
                       />
                     </div>
+                    <button type="button" class="dropdown-clear-link" @click.stop="clearHeaderSelection('thirdLevelCategory')">Clear</button>
                     <div
                       v-if="getFilteredHeaderOptions('thirdLevelCategory').length === 0"
                       class="custom-dropdown-no-options"
@@ -283,7 +284,6 @@
                     </div>
                   </div>
                 </div>
-                <button type="button" class="header-inline-clear-link" @click.stop="clearHeaderSelection('thirdLevelCategory')">Clear</button>
               </div>
             </div>
             <div class="header-tags-rigth">
@@ -2250,16 +2250,18 @@ return;
                   ? field.defaultValue
                   : field.value ?? null;
 
+            const isMandatory = normalizeBoolean(field.is_mandatory);
             return {
               id: field.id === field.field_id ? null : field.id || null,
               field_id: field.field_id || field.ID,
               position: field.position || 1,
               columns: parseInt(field.columns) || 1,
-              is_mandatory: normalizeBoolean(field.is_mandatory),
+              is_mandatory: isMandatory,
               is_readonly: normalizeBoolean(field.is_readonly),
               is_hide_legend: normalizeBoolean(field.is_hide_legend),
               show_only: normalizeBoolean(field.show_only),
               show_only_groups: normalizeStringArray(field.show_only_groups),
+              mandatory_statuses: isMandatory ? normalizeStringArray(field.mandatory_statuses) : [],
               is_hidden_in_end_user_new_ticket: normalizeBoolean(
                 field.is_hidden_in_end_user_new_ticket ??
                 field.IsHiddenInEndUserNewTicket ??
@@ -2388,6 +2390,7 @@ return;
         is_hide_legend: Boolean(field.is_hide_legend),
         show_only: normalizeBoolean(field.show_only),
         show_only_groups: normalizeStringArray(field.show_only_groups),
+        mandatory_statuses: normalizeStringArray(field.mandatory_statuses),
         is_hidden_in_end_user_new_ticket: normalizeBoolean(
           field.is_hidden_in_end_user_new_ticket ??
           field.IsHiddenInEndUserNewTicket ??
@@ -2419,6 +2422,7 @@ return;
         is_hide_legend: Boolean(updatedField.is_hide_legend),
         show_only: normalizeBoolean(updatedField.show_only),
         show_only_groups: normalizeStringArray(updatedField.show_only_groups),
+        mandatory_statuses: normalizeStringArray(updatedField.mandatory_statuses),
         is_hidden_in_end_user_new_ticket: normalizeBoolean(
           updatedField.is_hidden_in_end_user_new_ticket ??
           updatedField.IsHiddenInEndUserNewTicket ??


### PR DESCRIPTION
### Motivation
- Provide a way to associate a set of ticket statuses that make a field mandatory, and surface that configuration in the field properties UI. 
- Improve the `QueryMultiSelect` component to support grouped options and colored option/chip visuals for better status listing and selection.

### Description
- Added a `mandatory_statuses` UI to `FieldPropertiesPanel.vue` that shows a `QueryMultiSelect` when a field is required and persists selections via `updateFieldProperty('mandatory_statuses', ...)` and clears them when `is_mandatory` is turned off. 
- Implemented loading of status options from `window.wwLib` (collection/variable) using `MANDATORY_STATUS_COLLECTION_ID`, stored as `mandatoryStatusOptions`, and exposed `mandatoryStatuses`, `mandatoryStatusesLoading`, `loadMandatoryStatusOptions`, and `updateMandatoryStatuses` in the panel. 
- Enhanced `QueryMultiSelect.vue` to support grouped options (`groupedFilteredOptions`), group-level selection with indeterminate state, and colored option chips/chip styling via `getOptionStyle` and `getChipStyle`, plus layout/CSS for group titles. 
- Propagated `mandatory_statuses` into form normalization and field selection flows by updating `wwElement.vue` to include `mandatory_statuses` when selecting, normalizing, and serializing fields, and added a few inline dropdown clear buttons in headers for UX consistency.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16eddc33788330a53daae67eeb2b12)