### PR TITLE
GridViewDinamica: bloquear edição de status quando há campos obrigatórios pendentes

### DIFF
--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -16,10 +16,12 @@ export default class ListCellEditor {
         <input type="text" class="search-input" placeholder="${translatePhrase("Search...")}" />
         <span class="search-icon"><i class="material-symbols-outlined-search">search</i></span>
       </div>
+      <div class="required-fields-popup" style="display:none;"></div>
       <div class="filter-list"></div>
     `;
     this.searchInput = this.eGui.querySelector('.search-input');
     this.listEl = this.eGui.querySelector('.filter-list');
+    this.requiredPopupEl = this.eGui.querySelector('.required-fields-popup');
     this.closeBtn = this.eGui.querySelector('.editor-close');
 
     const tag =
@@ -32,6 +34,10 @@ export default class ListCellEditor {
       tag === 'RESPONSIBLEUSERID' || identifier === 'RESPONSIBLEUSERID';
     const categoryTags = ['CATEGORYID','SUBCATEGORYID','CATEGORYLEVEL3ID'];
     this.isCategoryField = categoryTags.includes(tag) || categoryTags.includes(identifier);
+
+    this.isStatusColumn = this.checkIfStatusColumn(params.colDef || {});
+    this.isBlockedByRequiredFields = false;
+    this.injectRequiredFieldsPopupCssOnce();
 
     // Build option array (supports promises)
     const normalize = (opt) => {
@@ -48,10 +54,15 @@ export default class ListCellEditor {
       return { value: opt, label: String(opt) };
     };
 
-    const resolveOptions = (arr) => {
+    const resolveOptions = async (arr) => {
       this.options = (arr || []).map(normalize);
       this.filteredOptions = [...this.options];
-      this.renderOptions();
+      if (this.isStatusColumn) {
+        await this.handleRequiredFieldsGate();
+      }
+      if (!this.isBlockedByRequiredFields) {
+        this.renderOptions();
+      }
     };
 
     let optionsPromise;
@@ -99,6 +110,85 @@ export default class ListCellEditor {
         }
       });
     }
+  }
+
+  checkIfStatusColumn(colDef) {
+    const headerName = String(colDef?.headerName || '').trim().toUpperCase();
+    const fieldDb = String(colDef?.FieldDB || '').trim().toUpperCase();
+    const tag = String(colDef?.TagControl || colDef?.tagControl || colDef?.tagcontrol || '').trim().toUpperCase();
+    return headerName === 'XXXXXXXXXXXXXXXXXXX' || fieldDb === 'STATUSID' || tag === 'STATUSID';
+  }
+
+  async handleRequiredFieldsGate() {
+    try {
+      const rowData = this.params?.data || this.params?.node?.data || {};
+      const p_workspaceid = rowData.WorkspaceID || rowData.workspace_id || rowData.workspaceid;
+      const p_ticketid = rowData.TicketID || rowData.ticket_id || rowData.ticketid;
+      const sb = window?.wwLib?.wwPlugins?.supabase;
+      if (!p_workspaceid || !p_ticketid || !sb?.callPostgresFunction) return;
+
+      const response = await sb.callPostgresFunction({
+        functionName: 'checkTicketRequiredFields',
+        params: { p_workspaceid, p_ticketid },
+      });
+      const payload = response?.data || response;
+      if (payload?.has_missing_required_fields === true) {
+        this.isBlockedByRequiredFields = true;
+        const fields = Array.isArray(payload.missing_required_fields)
+          ? payload.missing_required_fields
+          : [];
+        this.renderRequiredFieldsPopup(fields);
+      }
+    } catch (e) {
+    }
+  }
+
+  renderRequiredFieldsPopup(fields) {
+    if (!this.requiredPopupEl || !this.listEl) return;
+    this.listEl.style.display = 'none';
+    const rows = fields
+      .map(field => `<li>${field?.field_name || '-'}</li>`)
+      .join('');
+    this.requiredPopupEl.style.display = 'block';
+    this.requiredPopupEl.innerHTML = `
+      <div class="required-fields-popup__title">${translatePhrase('Status cannot be changed.')}</div>
+      <div class="required-fields-popup__subtitle">${translatePhrase('Required fields not filled:')}</div>
+      <ul class="required-fields-popup__list">${rows}</ul>
+    `;
+  }
+
+  injectRequiredFieldsPopupCssOnce() {
+    const styleId = '__grid_required_fields_popup_css__';
+    if (document.getElementById(styleId)) return;
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.textContent = `
+      .required-fields-popup {
+        margin-top: 8px;
+        background: #fff5f5;
+        border: 1px solid #f5c2c7;
+        border-radius: 8px;
+        padding: 12px;
+        color: #842029;
+        font-size: 13px;
+        max-width: 320px;
+      }
+      .required-fields-popup__title {
+        font-weight: 700;
+        margin-bottom: 8px;
+      }
+      .required-fields-popup__subtitle {
+        margin-bottom: 6px;
+      }
+      .required-fields-popup__list {
+        margin: 0;
+        padding-left: 18px;
+      }
+      .required-fields-popup__list li {
+        margin-bottom: 4px;
+      }
+    `;
+    document.head.appendChild(style);
   }
 
   filterOptions(text) {


### PR DESCRIPTION
### Motivation
- Evitar que o status de um ticket seja alterado enquanto houver campos obrigatórios não preenchidos, exibindo ao usuário quais campos estão faltando antes de permitir a edição.
- Aplicar essa verificação especificamente na coluna alvo (`headerName` = `XXXXXXXXXXXXXXXXXXX`) e em colunas com `STATUSID` como fallback.

### Description
- Atualizado `Project/GridViewDinamica/src/components/ListCellEditor.js` para inserir um container HTML do popup e um ponto de verificação antes de renderizar a lista de opções (`required-fields-popup`).
- Adicionadas as funções `checkIfStatusColumn`, `handleRequiredFieldsGate` (chama `checkTicketRequiredFields` via `supabase.callPostgresFunction` com `p_workspaceid` e `p_ticketid`) e `renderRequiredFieldsPopup` para mostrar o aviso estilizado quando `has_missing_required_fields === true`.
- Alterado o fluxo de carregamento de opções para aguardar a checagem quando for coluna de status e suprimir a lista exibida se a verificação bloquear, além de injetar CSS do popup uma única vez com `injectRequiredFieldsPopupCssOnce`.

### Testing
- Executed `git -C /workspace/NewCode diff -- Project/GridViewDinamica/src/components/ListCellEditor.js` to review the diff and it succeeded.
- Committed the change with `git -C /workspace/NewCode commit` and the commit completed successfully.
- Created the PR via the `make_pr` helper and the PR metadata was generated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a173969f2508330bf328d17f41b5457)