### PR TITLE
Ocultar campo de busca quando popup de campos obrigatórios é exibido

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -19,6 +19,7 @@ export default class FixedListCellEditor {
       <div class="required-fields-popup" style="display:none;"></div>
       <div class="filter-list"></div>
     `;
+    this.searchWrapper = this.eGui.querySelector('.field-search');
     this.searchInput = this.eGui.querySelector('.search-input');
     this.listEl = this.eGui.querySelector('.filter-list');
     this.requiredPopupEl = this.eGui.querySelector('.required-fields-popup');
@@ -248,6 +249,7 @@ export default class FixedListCellEditor {
 
   renderRequiredFieldsPopup(fields) {
     if (!this.requiredPopupEl || !this.listEl) return;
+    if (this.searchWrapper) this.searchWrapper.style.display = 'none';
     this.listEl.style.display = 'none';
     this.requiredPopupEl.style.display = 'block';
     const rows = fields.map(f => `<li>${f?.field_name || '-'}</li>`).join('');


### PR DESCRIPTION
### Motivation
- Garantir que, quando uma alteração de status for bloqueada por campos obrigatórios não preenchidos, o campo de busca não seja exibido na UI para evitar interação inconsistente.

### Description
- Armazena a referência do wrapper de busca como `this.searchWrapper = this.eGui.querySelector('.field-search')` em `Project/GridViewDinamica/src/components/FixedListCellEditor.js`.
- Ao renderizar o popup de campos obrigatórios em `renderRequiredFieldsPopup`, oculta também o wrapper de busca com `this.searchWrapper.style.display = 'none'` além de ocultar a lista de opções.

### Testing
- Verifiquei o diff com `git -C /workspace/NewCode diff -- Project/GridViewDinamica/src/components/FixedListCellEditor.js` e confirmou as mudanças esperadas.
- Realizei o commit com `git -C /workspace/NewCode commit` e o commit foi criado com sucesso; não foram adicionados testes automatizados unitários com esta mudança.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a181afce8b883308860a23c064b835f)