### PR TITLE
Detect CLOSED status in list editor and emit closedStatusClick

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -422,6 +422,53 @@ export default class FixedListCellEditor {
     return value;
   }
 
+
+  getOptionPropertyCaseInsensitive(opt, propertyName) {
+    if (!opt || typeof opt !== 'object') return undefined;
+    const key = Object.keys(opt).find(k => k.toLowerCase() === propertyName.toLowerCase());
+    return key ? opt[key] : undefined;
+  }
+
+  isClosedStatusOption(opt) {
+    if (!this.isStatusField) return false;
+    const statusClassTagControl = this.getOptionPropertyCaseInsensitive(
+      opt,
+      'statusClassTagControl'
+    );
+    return String(statusClassTagControl || '').toUpperCase() === 'CLOSED';
+  }
+
+  emitClosedStatusClick(option, selectedValue) {
+    const colDef = this.params?.colDef || {};
+    const columnId =
+      this.params?.column && typeof this.params.column.getColId === 'function'
+        ? this.params.column.getColId()
+        : colDef.colId || colDef.field || null;
+    const event = {
+      oldValue: this.value,
+      value: selectedValue,
+      option,
+      row: this.params?.data || this.params?.node?.data || null,
+      columnId,
+      fieldDB: colDef.FieldDB || null,
+      fieldID: colDef.id || null,
+    };
+
+    if (typeof this.params?.onClosedStatusClick === 'function') {
+      this.params.onClosedStatusClick(event);
+      return;
+    }
+
+    if (typeof colDef.onClosedStatusClick === 'function') {
+      colDef.onClosedStatusClick(event);
+      return;
+    }
+
+    if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+      window.dispatchEvent(new CustomEvent('closed-status-click', { detail: event }));
+    }
+  }
+
   renderOptions() {
     if (this.groupedByClassName) {
       const groups = this.filteredOptions.reduce((acc, opt) => {
@@ -440,7 +487,7 @@ export default class FixedListCellEditor {
                 .map(opt => {
                   const formatted = this.formatOption(opt);
                   const selected = opt.value == this.value ? ' selected' : '';
-                  return `<div class="filter-item grouped-option${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+                  return `<div class="filter-item grouped-option${selected}" data-value="${opt.value}" data-option-index="${this.filteredOptions.indexOf(opt)}"><span class="filter-label">${formatted}</span></div>`;
                 })
                 .join('')
             : '';
@@ -472,7 +519,7 @@ export default class FixedListCellEditor {
             ? `<img src="${photo}" alt="" />`
             : `<span class="user-initial">${initial}</span>`;
           return `
-            <div class="filter-item${selected}" data-value="${opt.value}">
+            <div class="filter-item${selected}" data-value="${opt.value}" data-option-index="${this.filteredOptions.indexOf(opt)}">
               <span class="user-option">
                 <span class="avatar-outer"><span class="avatar-middle"><span class="user-avatar">${avatar}</span></span></span>
                 <span class="filter-label">${formatted}</span>
@@ -480,13 +527,23 @@ export default class FixedListCellEditor {
             </div>`;
         }
 
-        return `<div class="filter-item${selected}" data-value="${opt.value}"><span class="filter-label">${formatted}</span></div>`;
+        return `<div class="filter-item${selected}" data-value="${opt.value}" data-option-index="${this.filteredOptions.indexOf(opt)}"><span class="filter-label">${formatted}</span></div>`;
       })
       .join('');
     }
     this.listEl.querySelectorAll('.filter-item').forEach(el => {
       el.addEventListener('click', () => {
         const selectedValue = el.getAttribute('data-value');
+        const optionIndex = Number(el.getAttribute('data-option-index'));
+        const selectedOption = Number.isInteger(optionIndex)
+          ? this.filteredOptions[optionIndex]
+          : this.filteredOptions.find(opt => String(opt.value) === String(selectedValue));
+
+        if (this.isClosedStatusOption(selectedOption)) {
+          this.emitClosedStatusClick(selectedOption, selectedValue);
+          return;
+        }
+
         this.value = selectedValue;
         this.updateDisplayLabel(selectedValue, { refresh: false });
         if (this.params.api && this.params.api.stopEditing) {

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -2842,6 +2842,7 @@ setTimeout(() => {
           editable: !!colCopy.editable, // <-- garantir editable
           FieldDB: colCopy.FieldDB, // <-- garantir FieldDB no colDef
           TagControl: colCopy.TagControl,
+          onClosedStatusClick: this.onClosedStatusClick,
           ...(colCopy.pinned === 'left' ? { lockPinned: true, lockPosition: true } : {}),
         };
 
@@ -2961,7 +2962,10 @@ setTimeout(() => {
                 });
               } else {
                 result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor;
-                result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+                result.cellEditorParams = params => ({
+                  options: getDsOptionsAsync(params),
+                  onClosedStatusClick: this.onClosedStatusClick,
+                });
                 const baseRendererParams = result.cellRendererParams;
                 result.cellRendererParams = params => ({
                   ...(typeof baseRendererParams === 'function'
@@ -2983,7 +2987,10 @@ setTimeout(() => {
           if (colCopy.dataSource && colCopy.editable) {
             result.editable = true;
             result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor;
-            result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+            result.cellEditorParams = params => ({
+              options: getDsOptionsAsync(params),
+              onClosedStatusClick: this.onClosedStatusClick,
+            });
             const baseRendererParams = result.cellRendererParams;
             result.cellRendererParams = params => ({
               ...(typeof baseRendererParams === 'function'
@@ -3142,7 +3149,10 @@ setTimeout(() => {
                   options: staticOptions,
                 };
               } else {
-                result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+                result.cellEditorParams = params => ({
+                  options: getDsOptionsAsync(params),
+                  onClosedStatusClick: this.onClosedStatusClick,
+                });
                 const baseRendererParams = result.cellRendererParams;
                 result.cellRendererParams = params => ({
                   ...(typeof baseRendererParams === 'function'
@@ -3519,7 +3529,10 @@ setTimeout(() => {
                   };
                 } else {
                   result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor :  FixedListCellEditor;
-                  result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+                  result.cellEditorParams = params => ({
+                    options: getDsOptionsAsync(params),
+                    onClosedStatusClick: this.onClosedStatusClick,
+                  });
                   const baseRendererParams = result.cellRendererParams;
                   result.cellRendererParams = params => ({
                     ...(typeof baseRendererParams === 'function'
@@ -3542,7 +3555,10 @@ setTimeout(() => {
             if (colCopy.dataSource && colCopy.editable) {
               result.editable = true;
               result.cellEditor = tagControl === 'RESPONSIBLEUSERID' ? ResponsibleUserCellEditor : FixedListCellEditor;
-              result.cellEditorParams = params => ({ options: getDsOptionsAsync(params) });
+              result.cellEditorParams = params => ({
+                options: getDsOptionsAsync(params),
+                onClosedStatusClick: this.onClosedStatusClick,
+              });
               const baseRendererParams = result.cellRendererParams;
               result.cellRendererParams = params => ({
                 ...(typeof baseRendererParams === 'function'
@@ -4218,6 +4234,20 @@ setTimeout(() => {
   index: event.index != null ? event.index : null,
   displayIndex: event.displayIndex != null ? event.displayIndex : null,
   },
+  });
+  },
+  onClosedStatusClick(event) {
+  this.$emit("trigger-event", {
+    name: "closedStatusClick",
+    event: {
+      oldValue: event?.oldValue ?? null,
+      value: event?.value ?? null,
+      option: event?.option || null,
+      row: event?.row || null,
+      columnId: event?.columnId || null,
+      fieldDB: event?.fieldDB || null,
+      fieldID: event?.fieldID || null,
+    },
   });
   },
   onCellValueChanged(event) {

--- a/Project/GridViewDinamica/ww-config.js
+++ b/Project/GridViewDinamica/ww-config.js
@@ -162,6 +162,19 @@ export default {
     getTestEvent: "getCellHoveredTestEvent"
   },
   {
+    name: "closedStatusClick",
+    label: { en: "On Closed Status Click" },
+    event: {
+      oldValue: null,
+      value: null,
+      option: null,
+      row: null,
+      columnId: "id",
+      fieldDB: null,
+      fieldID: null,
+    },
+  },
+  {
     name: "gridLoaded",
     label: { en: "On Grid Loaded" },
     event: { rows: [], totalRows: 0 },


### PR DESCRIPTION
### Motivation
- Prevent changing the editor value or triggering save when a user clicks a dropdown option whose `statusClassTagControl` is `"CLOSED"` for status-like columns.
- Provide a dedicated event to let the app react to clicks on closed statuses without mutating data or calling backend APIs.

### Description
- Added helper methods to `Project/GridViewDinamica/src/components/FixedListCellEditor.js`: `getOptionPropertyCaseInsensitive`, `isClosedStatusOption` and `emitClosedStatusClick`, and updated the options rendering to include `data-option-index` and to call `emitClosedStatusClick` when a `CLOSED` option is clicked instead of changing `this.value` or stopping editing.
- Wired a callback through the grid configuration by adding `onClosedStatusClick` into the column/common props and passing it into `cellEditorParams` where `FixedListCellEditor` is used in `Project/GridViewDinamica/src/wwElement.vue`.
- Implemented `onClosedStatusClick` in the Vue grid component to re-emit a `trigger-event` named `closedStatusClick` with a payload containing `oldValue`, `value`, `option`, `row`, `columnId`, `fieldDB` and `fieldID`.
- Registered a new trigger event `closedStatusClick` (label: `On Closed Status Click`) in `Project/GridViewDinamica/ww-config.js` so designers can hook actions to this event.

### Testing
- Ran `node --check Project/GridViewDinamica/src/components/FixedListCellEditor.js` and it succeeded.
- Extracted and type-checked the component script via `node --check /tmp/wwElement-script.mjs` and it succeeded.
- Type-checked the updated config via `node --check /tmp/ww-config.mjs` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a185e28d0588330a2c72de49b8d0280)