### PR TITLE
Open dropdown editors upward when near bottom of GridViewDinamica

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -1,4 +1,5 @@
 import { translatePhrase } from "../translation";
+import { getCellEditorPopupPosition } from "../utils/cellEditorPopupPosition";
 
 export default class FixedListCellEditor {
   init(params) {
@@ -589,5 +590,9 @@ export default class FixedListCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 }

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -1,4 +1,5 @@
 import { translatePhrase } from "../translation";
+import { getCellEditorPopupPosition } from "../utils/cellEditorPopupPosition";
 
 export default class ListCellEditor {
   init(params) {
@@ -373,5 +374,9 @@ export default class ListCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 }

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
@@ -1,3 +1,5 @@
+import { getCellEditorPopupPosition } from "../utils/cellEditorPopupPosition";
+
 export default class ResponsibleUserCellEditor {
   init(params) { 
     this.params = params;
@@ -597,6 +599,10 @@ export default class ResponsibleUserCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 
   // CSS injetado (14px, wght 400, ícone groups centralizado)

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
@@ -1,3 +1,5 @@
+import { getCellEditorPopupPosition } from "../utils/cellEditorPopupPosition";
+
 export default class ResponsibleUserCellEditor {
   init(params) { 
     this.params = params;
@@ -595,6 +597,10 @@ export default class ResponsibleUserCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 
   // CSS injetado (14px, wght 400, ícone groups centralizado)

--- a/Project/GridViewDinamica/src/utils/cellEditorPopupPosition.js
+++ b/Project/GridViewDinamica/src/utils/cellEditorPopupPosition.js
@@ -1,0 +1,70 @@
+const DEFAULT_POPUP_HEIGHT = 340;
+const MIN_USABLE_SPACE = 220;
+const POPUP_MARGIN = 8;
+
+function getElementRect(element) {
+  if (!element || typeof element.getBoundingClientRect !== 'function') return null;
+  const rect = element.getBoundingClientRect();
+  if (!rect || (rect.width === 0 && rect.height === 0 && rect.top === 0 && rect.bottom === 0)) {
+    return null;
+  }
+  return rect;
+}
+
+function findGridViewport(cellElement) {
+  if (!cellElement || typeof cellElement.closest !== 'function') return null;
+  return (
+    cellElement.closest('.ag-body-viewport') ||
+    cellElement.closest('.ag-center-cols-viewport') ||
+    cellElement.closest('.ag-root-wrapper-body') ||
+    cellElement.closest('.ag-root-wrapper') ||
+    cellElement.closest('.ww-datagrid')
+  );
+}
+
+function getViewportRect(cellElement) {
+  const gridViewport = findGridViewport(cellElement);
+  const gridRect = getElementRect(gridViewport);
+  const windowTop = 0;
+  const windowBottom = window.innerHeight || document.documentElement?.clientHeight || 0;
+
+  if (!gridRect) {
+    return { top: windowTop, bottom: windowBottom };
+  }
+
+  return {
+    top: Math.max(gridRect.top, windowTop),
+    bottom: Math.min(gridRect.bottom, windowBottom),
+  };
+}
+
+function estimatePopupHeight(editorGui) {
+  const rect = getElementRect(editorGui);
+  const measuredHeight = Math.max(
+    rect?.height || 0,
+    editorGui?.scrollHeight || 0,
+    editorGui?.offsetHeight || 0
+  );
+
+  return measuredHeight > 0 ? measuredHeight : DEFAULT_POPUP_HEIGHT;
+}
+
+export function shouldOpenCellEditorPopupAbove(params, editorGui) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+
+  const cellElement = params?.eGridCell || params?.event?.target?.closest?.('.ag-cell');
+  const cellRect = getElementRect(cellElement);
+  if (!cellRect) return false;
+
+  const viewportRect = getViewportRect(cellElement);
+  const popupHeight = estimatePopupHeight(editorGui);
+  const spaceBelow = viewportRect.bottom - cellRect.bottom;
+  const spaceAbove = cellRect.top - viewportRect.top;
+  const requiredSpaceBelow = Math.min(popupHeight + POPUP_MARGIN, MIN_USABLE_SPACE);
+
+  return spaceBelow < requiredSpaceBelow && spaceAbove > spaceBelow;
+}
+
+export function getCellEditorPopupPosition(params, editorGui) {
+  return shouldOpenCellEditorPopupAbove(params, editorGui) ? 'over' : 'under';
+}

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -44,6 +44,7 @@
   import FixedListCellEditor from "./components/FixedListCellEditor.js";
   import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
   import { translatePhrase } from "./translation";
+  import { getCellEditorPopupPosition } from "./utils/cellEditorPopupPosition";
   import {
   applyGlobalGridFontFamily,
   readTypographyVariable,
@@ -381,6 +382,7 @@
     }
     destroy() {}
     isPopup() { return true; }
+    getPopupPosition() { return getCellEditorPopupPosition(this.params, this.eGui); }
   }
   import './components/list-filter.css';
 


### PR DESCRIPTION
### Motivation
- Dropdown/list editors in `GridViewDinamica` were being clipped when opened on the last visible rows of the grid and must open upward in those cases.

### Description
- Added a shared helper `Project/GridViewDinamica/src/utils/cellEditorPopupPosition.js` that inspects the editing cell and the grid viewport and returns `'over'` when the popup should open upward (otherwise `'under'`).
- Wired the helper into list/dropdown editors by importing it and exposing `getPopupPosition()` so AG Grid can position popups: updated `ListCellEditor.js`, `FixedListCellEditor.js`, `ResponsibleUserCellEditor.js` and the `.vue` variant, and the inline editor in `wwElement.vue` to use the helper.
- The helper measures available space above/below within the grid viewport (not just the window) and estimates popup height to decide opening direction, keeping existing `isPopup()` behavior.

### Testing
- Ran static checks with `node --check Project/GridViewDinamica/src/utils/cellEditorPopupPosition.js`, `node --check` on `ListCellEditor.js`, `FixedListCellEditor.js` and `ResponsibleUserCellEditor.js`, all succeeded.
- Verified `.vue` file syntax by copying `ResponsibleUserCellEditor.vue` to a temporary `.js` file and running `node --check`, which succeeded; direct `node --check` does not natively validate `.vue` files (noted during testing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18ef27af808330b72113d4b6e25bf3)