### PR TITLE
Add cell editor popup positioning utility and integrate into list/user editors

### DIFF
--- a/Project/GridViewDinamica/src/components/FixedListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/FixedListCellEditor.js
@@ -1,4 +1,8 @@
 import { translatePhrase } from "../translation";
+import {
+  getCellEditorPopupPosition,
+  scheduleCellEditorPopupPositionUpdate,
+} from "../utils/cellEditorPopupPosition";
 
 export default class FixedListCellEditor {
   init(params) {
@@ -323,6 +327,7 @@ export default class FixedListCellEditor {
       this.ensureKnownGroups(this.filteredOptions);
     }
     this.renderOptions();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   getGroupName(opt) {
@@ -562,6 +567,7 @@ export default class FixedListCellEditor {
         }
       });
     });
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   getGui() {
@@ -570,6 +576,7 @@ export default class FixedListCellEditor {
 
   afterGuiAttached() {
     if (this.searchInput) this.searchInput.focus();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   getValue() {
@@ -589,5 +596,9 @@ export default class FixedListCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 }

--- a/Project/GridViewDinamica/src/components/ListCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ListCellEditor.js
@@ -1,4 +1,8 @@
 import { translatePhrase } from "../translation";
+import {
+  getCellEditorPopupPosition,
+  scheduleCellEditorPopupPositionUpdate,
+} from "../utils/cellEditorPopupPosition";
 
 export default class ListCellEditor {
   init(params) {
@@ -197,6 +201,7 @@ export default class ListCellEditor {
       return label.toLowerCase().includes(t);
     });
     this.renderOptions();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   stripHtml(html) {
@@ -354,6 +359,7 @@ export default class ListCellEditor {
         }
       });
     });
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   getGui() {
@@ -362,6 +368,7 @@ export default class ListCellEditor {
 
   afterGuiAttached() {
     if (this.searchInput) this.searchInput.focus();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   getValue() {
@@ -373,5 +380,9 @@ export default class ListCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 }

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.js
@@ -1,3 +1,8 @@
+import {
+  getCellEditorPopupPosition,
+  scheduleCellEditorPopupPositionUpdate,
+} from "../utils/cellEditorPopupPosition";
+
 export default class ResponsibleUserCellEditor {
   init(params) { 
     this.params = params;
@@ -121,6 +126,7 @@ export default class ResponsibleUserCellEditor {
     // Render inicial (root)
     this.applyRootFilter();
     this.render();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   // --------- HELPERS DE RESOLUÇÃO (nomes por id) ----------
@@ -308,6 +314,7 @@ export default class ResponsibleUserCellEditor {
       this.groupCount.style.display = 'none';
       this.renderRootView();
     }
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   // ROOT VIEW
@@ -579,6 +586,7 @@ export default class ResponsibleUserCellEditor {
 
   afterGuiAttached() {
     if (this.searchInput) this.searchInput.focus();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   getValue() {
@@ -597,6 +605,10 @@ export default class ResponsibleUserCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 
   // CSS injetado (14px, wght 400, ícone groups centralizado)

--- a/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
+++ b/Project/GridViewDinamica/src/components/ResponsibleUserCellEditor.vue
@@ -1,3 +1,8 @@
+import {
+  getCellEditorPopupPosition,
+  scheduleCellEditorPopupPositionUpdate,
+} from "../utils/cellEditorPopupPosition";
+
 export default class ResponsibleUserCellEditor {
   init(params) { 
     this.params = params;
@@ -121,6 +126,7 @@ export default class ResponsibleUserCellEditor {
     // Render inicial (root)
     this.applyRootFilter();
     this.render();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   // --------- HELPERS DE RESOLUÇÃO (nomes por id) ----------
@@ -307,6 +313,7 @@ export default class ResponsibleUserCellEditor {
       this.groupCount.style.display = 'none';
       this.renderRootView();
     }
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   // ROOT VIEW
@@ -577,6 +584,7 @@ export default class ResponsibleUserCellEditor {
 
   afterGuiAttached() {
     if (this.searchInput) this.searchInput.focus();
+    scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
   }
 
   getValue() {
@@ -595,6 +603,10 @@ export default class ResponsibleUserCellEditor {
 
   isPopup() {
     return true;
+  }
+
+  getPopupPosition() {
+    return getCellEditorPopupPosition(this.params, this.eGui);
   }
 
   // CSS injetado (14px, wght 400, ícone groups centralizado)

--- a/Project/GridViewDinamica/src/utils/cellEditorPopupPosition.js
+++ b/Project/GridViewDinamica/src/utils/cellEditorPopupPosition.js
@@ -1,0 +1,121 @@
+const DEFAULT_POPUP_HEIGHT = 340;
+const MIN_USABLE_SPACE = 220;
+const POPUP_MARGIN = 12;
+
+function getElementRect(element) {
+  if (!element || typeof element.getBoundingClientRect !== 'function') return null;
+  const rect = element.getBoundingClientRect();
+  if (!rect || (rect.width === 0 && rect.height === 0 && rect.top === 0 && rect.bottom === 0)) {
+    return null;
+  }
+  return rect;
+}
+
+function findGridViewport(cellElement) {
+  if (!cellElement || typeof cellElement.closest !== 'function') return null;
+  return (
+    cellElement.closest('.ag-body-viewport') ||
+    cellElement.closest('.ag-center-cols-viewport') ||
+    cellElement.closest('.ag-root-wrapper-body') ||
+    cellElement.closest('.ag-root-wrapper') ||
+    cellElement.closest('.ww-datagrid')
+  );
+}
+
+function getViewportRect(cellElement) {
+  const gridViewport = findGridViewport(cellElement);
+  const gridRect = getElementRect(gridViewport);
+  const windowTop = 0;
+  const windowBottom = window.innerHeight || document.documentElement?.clientHeight || 0;
+
+  if (!gridRect) {
+    return { top: windowTop, bottom: windowBottom };
+  }
+
+  return {
+    top: Math.max(gridRect.top, windowTop),
+    bottom: Math.min(gridRect.bottom, windowBottom),
+  };
+}
+
+function getCellElement(params) {
+  return params?.eGridCell || params?.event?.target?.closest?.('.ag-cell') || null;
+}
+
+function estimatePopupHeight(editorGui) {
+  const popupElement = getPopupElement(editorGui) || editorGui;
+  const rect = getElementRect(popupElement);
+  const measuredHeight = Math.max(
+    rect?.height || 0,
+    popupElement?.scrollHeight || 0,
+    popupElement?.offsetHeight || 0,
+    editorGui?.scrollHeight || 0,
+    editorGui?.offsetHeight || 0
+  );
+
+  return measuredHeight > 0 ? measuredHeight : DEFAULT_POPUP_HEIGHT;
+}
+
+function getPopupElement(editorGui) {
+  if (!editorGui || typeof editorGui.closest !== 'function') return null;
+  return (
+    editorGui.closest('.ag-popup-editor') ||
+    editorGui.closest('.ag-popup-child') ||
+    editorGui.parentElement
+  );
+}
+
+export function shouldOpenCellEditorPopupAbove(params, editorGui) {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return false;
+
+  const cellElement = getCellElement(params);
+  const cellRect = getElementRect(cellElement);
+  if (!cellRect) return false;
+
+  const viewportRect = getViewportRect(cellElement);
+  const popupHeight = estimatePopupHeight(editorGui);
+  const spaceBelow = viewportRect.bottom - cellRect.bottom;
+  const spaceAbove = cellRect.top - viewportRect.top;
+  const requiredSpaceBelow = Math.min(popupHeight + POPUP_MARGIN, MIN_USABLE_SPACE);
+
+  return spaceBelow < requiredSpaceBelow && spaceAbove > spaceBelow;
+}
+
+export function getCellEditorPopupPosition(params, editorGui) {
+  return shouldOpenCellEditorPopupAbove(params, editorGui) ? 'over' : 'under';
+}
+
+export function updateCellEditorPopupPosition(params, editorGui) {
+  if (!shouldOpenCellEditorPopupAbove(params, editorGui)) return;
+
+  const cellElement = getCellElement(params);
+  const cellRect = getElementRect(cellElement);
+  const popupElement = getPopupElement(editorGui);
+  const popupRect = getElementRect(popupElement || editorGui);
+  if (!cellRect || !popupElement || !popupRect) return;
+
+  const viewportRect = getViewportRect(cellElement);
+  const desiredTop = Math.max(
+    viewportRect.top + POPUP_MARGIN,
+    cellRect.top - popupRect.height - POPUP_MARGIN
+  );
+  const currentTop = parseFloat(popupElement.style.top || '0') || 0;
+  const adjustedTop = currentTop + desiredTop - popupRect.top;
+
+  popupElement.style.top = `${Math.round(adjustedTop)}px`;
+  popupElement.style.bottom = 'auto';
+}
+
+export function scheduleCellEditorPopupPositionUpdate(params, editorGui) {
+  updateCellEditorPopupPosition(params, editorGui);
+
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => updateCellEditorPopupPosition(params, editorGui));
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => updateCellEditorPopupPosition(params, editorGui));
+    });
+    return;
+  }
+
+  setTimeout(() => updateCellEditorPopupPosition(params, editorGui), 0);
+}

--- a/Project/GridViewDinamica/src/wwElement.vue
+++ b/Project/GridViewDinamica/src/wwElement.vue
@@ -45,6 +45,10 @@
   import ResponsibleUserCellEditor from "./components/ResponsibleUserCellEditor.js";
   import { translatePhrase } from "./translation";
   import {
+    getCellEditorPopupPosition,
+    scheduleCellEditorPopupPositionUpdate,
+  } from "./utils/cellEditorPopupPosition";
+  import {
   applyGlobalGridFontFamily,
   readTypographyVariable,
   DEFAULT_FONT_FAMILY,
@@ -178,6 +182,7 @@
         this.ensureKnownGroups(this.filteredOptions);
       }
       this.renderOptions();
+      scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
     }
     getGroupName(opt) {
       const groupName = opt?.class_name;
@@ -372,15 +377,20 @@
           }
         });
       });
+      scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
     }
     getGui() { return this.eGui; }
-    afterGuiAttached() { if (this.searchInput) this.searchInput.focus(); }
+    afterGuiAttached() {
+      if (this.searchInput) this.searchInput.focus();
+      scheduleCellEditorPopupPositionUpdate(this.params, this.eGui);
+    }
     getValue() {
       this.updateDisplayLabel(this.value);
       return this.value;
     }
     destroy() {}
     isPopup() { return true; }
+    getPopupPosition() { return getCellEditorPopupPosition(this.params, this.eGui); }
   }
   import './components/list-filter.css';
 


### PR DESCRIPTION
### Motivation
- Provide a consistent way to decide whether cell editor popups should open above or below the cell to avoid viewport clipping. 
- Ensure popups are repositioned after dynamic changes (filtering, rendering, initial attach) to maintain correct placement. 
- Centralize popup positioning logic to avoid duplicated heuristics across multiple editors.

### Description
- Add a new utility `src/utils/cellEditorPopupPosition.js` that exposes `getCellEditorPopupPosition`, `shouldOpenCellEditorPopupAbove`, `updateCellEditorPopupPosition`, and `scheduleCellEditorPopupPositionUpdate` with viewport-aware heuristics and RAF scheduling. 
- Import and use the new utilities in `FixedListCellEditor`, `ListCellEditor`, `ResponsibleUserCellEditor` (both `.js` and `.vue` variants) and `wwElement.vue`. 
- Call `scheduleCellEditorPopupPositionUpdate(params, eGui)` after filtering, rendering and in `afterGuiAttached` to update popup position after DOM changes. 
- Add `getPopupPosition()` implementations on popup editors that delegate to `getCellEditorPopupPosition(params, eGui)`.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18ef27af808330b72113d4b6e25bf3)