### PR TITLE
GridViewInput: usar FontAwesome e persistir inclusão/exclusão em variável interna

### DIFF
--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -92,6 +92,34 @@ export default {
         defaultValue: {},
         readonly: true,
       });
+    const { value: gridRecords, setValue: setGridRecords } =
+      wwLib.wwVariable.useComponentVariable({
+        uid: props.uid,
+        name: "gridRecords",
+        type: "array",
+        defaultValue: [],
+        readonly: true,
+      });
+
+    const sanitizeGridRow = (row) => {
+      const next = { ...(row || {}) };
+      delete next.__isInputRow;
+      delete next.__gridInputRowIndex;
+      return next;
+    };
+
+    const normalizeGridRecords = (data) => {
+      const rows = wwLib.wwUtils.getDataFromCollection(data);
+      return Array.isArray(rows) ? rows.map(sanitizeGridRow) : [];
+    };
+
+    watch(
+      () => props.content.rowData,
+      (newData) => {
+        setGridRecords(normalizeGridRecords(newData));
+      },
+      { deep: true, immediate: true }
+    );
 
     const getAppLanguage = () => {
       let value = null;
@@ -314,6 +342,9 @@ export default {
       onSelectionChanged,
       gridApi,
       setSelectedRows,
+      gridRecords,
+      setGridRecords,
+      sanitizeGridRow,
       onFilterChanged,
       onSortChanged,
       onFirstDataRendered,
@@ -354,9 +385,15 @@ export default {
   },
   computed: {
     rowData() {
-      const data = wwLib.wwUtils.getDataFromCollection(this.content.rowData);
-      const rows = Array.isArray(data) ? [...data] : [];
-      return [this.createBlankRow(true), ...rows.map((row) => ({ ...row, __isInputRow: false }))];
+      const data = Array.isArray(this.gridRecords) ? this.gridRecords : [];
+      return [
+        this.createBlankRow(true),
+        ...data.map((row, index) => ({
+          ...row,
+          __isInputRow: false,
+          __gridInputRowIndex: index,
+        })),
+      ];
     },
     defaultColDef() {
       return {
@@ -387,13 +424,13 @@ export default {
         },
         cellRenderer: (params) => {
           const isInputRow = !!params.data?.__isInputRow;
-          const symbol = isInputRow ? "+" : "🗑";
+          const iconClass = isInputRow ? "fa-solid fa-plus" : "fa-solid fa-trash";
           const title = isInputRow ? "Incluir linha" : "Excluir linha";
-          return `<button class="grid-input-action-btn" title="${title}">${symbol}</button>`;
+          return `<button class="grid-input-action-btn" type="button" title="${title}" aria-label="${title}"><i class="${iconClass}" aria-hidden="true"></i></button>`;
         },
         onCellClicked: (params) => {
           if (params.data?.__isInputRow) this.addRowFromInput(params.data);
-          else this.deleteRow(params.rowIndex);
+          else this.deleteRow(params.data);
         },
       };
       
@@ -724,7 +761,9 @@ export default {
       });
     },
     onCellValueChanged(event) {
-      this.syncGridData();
+      if (!event.data?.__isInputRow) {
+        this.syncGridData();
+      }
       this.$emit("trigger-event", {
         name: "cellValueChanged",
         event: {
@@ -738,12 +777,8 @@ export default {
     syncGridData() {
       const rows = (this.rowData || [])
         .filter((row) => !row?.__isInputRow)
-        .map((row) => {
-          const next = { ...row };
-          delete next.__isInputRow;
-          return next;
-        });
-      this.$emit("update:content:effect", { rowData: rows });
+        .map((row) => this.sanitizeGridRow(row));
+      this.setGridRecords(rows);
     },
     createBlankRow(isInputRow = false) {
       return (this.content.columns || []).filter((col) => col.field).reduce((acc, col) => {
@@ -752,17 +787,16 @@ export default {
       }, { __isInputRow: isInputRow });
     },
     addRowFromInput(inputRow) {
-      const newRow = { ...inputRow };
-      delete newRow.__isInputRow;
-      const currentRows = Array.isArray(this.content.rowData) ? [...this.content.rowData] : [];
-      this.$emit("update:content:effect", { rowData: [...currentRows, newRow] });
+      const newRow = this.sanitizeGridRow(inputRow);
+      const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
+      this.setGridRecords([...currentRows, newRow]);
     },
-    deleteRow(rowIndex) {
-      const dataIndex = rowIndex - 1;
-      const currentRows = Array.isArray(this.content.rowData) ? [...this.content.rowData] : [];
-      if (dataIndex < 0 || dataIndex >= currentRows.length) return;
+    deleteRow(row) {
+      const dataIndex = Number(row?.__gridInputRowIndex);
+      const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
+      if (!Number.isInteger(dataIndex) || dataIndex < 0 || dataIndex >= currentRows.length) return;
       currentRows.splice(dataIndex, 1);
-      this.$emit("update:content:effect", { rowData: currentRows });
+      this.setGridRecords(currentRows);
     },
     onCellKeyDown(event) {
       if (!this.content.enterNextRow || !event?.event) return;
@@ -1011,16 +1045,25 @@ export default {
     &.grid-hidden {
       visibility: hidden;
 }
-.grid-input-action-btn {
-  width: 24px;
-  height: 24px;
-  border: 1px solid #d0d7de;
-  background: #fff;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 700;
-  line-height: 1;
-}
+    :deep(.grid-input-action-btn) {
+      width: 24px;
+      height: 24px;
+      border: 1px solid #d0d7de;
+      background: #fff;
+      border-radius: 4px;
+      color: var(--ww-data-grid_action-color, #24292f);
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+      padding: 0;
+    }
+
+    :deep(.grid-input-action-btn i) {
+      font-size: 13px;
+      line-height: 1;
+    }
     /* wwEditor:start */
     &.editing {
       &::before {


### PR DESCRIPTION
### Motivation
- Padronizar os ícones de ação para a biblioteca Font Awesome nas células de ação. 
- Fazer com que a inclusão de uma linha insira os dados informados em uma variável interna que represente os registros da grid. 
- Garantir que a exclusão remova o registro tanto da variável interna quanto da visualização da grid.

### Description
- Adicionada a variável interna `gridRecords` via `wwLib.wwVariable.useComponentVariable` e inicialização a partir de `content.rowData` com sanitização dos metadados internos. 
- `rowData` agora é derivado de `gridRecords`, mantendo a linha de inclusão no topo e marcando cada linha real com `__gridInputRowIndex` para referência de remoção. 
- Os botões de ação foram alterados para renderizar ícones Font Awesome (`fa-plus` e `fa-trash`) e o clique aciona `addRowFromInput` ou `deleteRow` com os dados corretos. 
- Lógica de sincronização alterada: `syncGridData`, `addRowFromInput` e `deleteRow` atualizam `gridRecords` (`setGridRecords`) em vez de apenas emitir diretamente `update:content:effect`, e `onCellValueChanged` evita sincronizar quando o evento é da linha de input. 
- Estilos do botão de ação atualizados usando `:deep(.grid-input-action-btn)` para garantir aplicação dentro das células do AG Grid e centralização dos ícones.

### Testing
- Executado `git diff --check` e sem erros reportados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1acab1c1b883308b1eaacf67775dcc)