### PR TITLE
Use component variable for grid records, sanitize rows, and improve action button UI

### DIFF
--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -92,6 +92,35 @@ export default {
         defaultValue: {},
         readonly: true,
       });
+    const { value: gridRecords, setValue: setGridRecords } =
+      wwLib.wwVariable.useComponentVariable({
+        uid: props.uid,
+        name: "gridRecords",
+        type: "array",
+        defaultValue: [],
+        readonly: true,
+      });
+
+    const sanitizeGridRow = (row) => {
+      const next = { ...(row || {}) };
+      delete next.__isInputRow;
+      delete next.__gridInputRowIndex;
+      delete next.__gridInputRowKey;
+      return next;
+    };
+
+    const normalizeGridRecords = (data) => {
+      const rows = wwLib.wwUtils.getDataFromCollection(data);
+      return Array.isArray(rows) ? rows.map(sanitizeGridRow) : [];
+    };
+
+    watch(
+      () => props.content.rowData,
+      (newData) => {
+        setGridRecords(normalizeGridRecords(newData));
+      },
+      { deep: true, immediate: true }
+    );
 
     const getAppLanguage = () => {
       let value = null;
@@ -314,6 +343,9 @@ export default {
       onSelectionChanged,
       gridApi,
       setSelectedRows,
+      gridRecords,
+      setGridRecords,
+      sanitizeGridRow,
       onFilterChanged,
       onSortChanged,
       onFirstDataRendered,
@@ -350,13 +382,20 @@ export default {
     return {
       pendingEnterEdit: null,
       markedRowId: null,
+      inputRowKey: 0,
     };
   },
   computed: {
     rowData() {
-      const data = wwLib.wwUtils.getDataFromCollection(this.content.rowData);
-      const rows = Array.isArray(data) ? [...data] : [];
-      return [this.createBlankRow(true), ...rows.map((row) => ({ ...row, __isInputRow: false }))];
+      const data = Array.isArray(this.gridRecords) ? this.gridRecords : [];
+      return [
+        this.createBlankRow(true),
+        ...data.map((row, index) => ({
+          ...row,
+          __isInputRow: false,
+          __gridInputRowIndex: index,
+        })),
+      ];
     },
     defaultColDef() {
       return {
@@ -387,13 +426,13 @@ export default {
         },
         cellRenderer: (params) => {
           const isInputRow = !!params.data?.__isInputRow;
-          const symbol = isInputRow ? "+" : "🗑";
+          const iconClass = isInputRow ? "fa-solid fa-plus" : "fa-solid fa-trash";
           const title = isInputRow ? "Incluir linha" : "Excluir linha";
-          return `<button class="grid-input-action-btn" title="${title}">${symbol}</button>`;
+          return `<button class="grid-input-action-btn" type="button" title="${title}" aria-label="${title}"><i class="${iconClass}" aria-hidden="true"></i></button>`;
         },
         onCellClicked: (params) => {
           if (params.data?.__isInputRow) this.addRowFromInput(params.data);
-          else this.deleteRow(params.rowIndex);
+          else this.deleteRow(params.data);
         },
       };
       
@@ -715,6 +754,9 @@ export default {
   },
   methods: {
     getRowId(params) {
+      if (params.data?.__isInputRow) {
+        return `__grid_input_row_${params.data.__gridInputRowKey ?? 0}`;
+      }
       return this.resolveMappingFormula(this.content.idFormula, params.data);
     },
     onActionTrigger(event) {
@@ -724,7 +766,9 @@ export default {
       });
     },
     onCellValueChanged(event) {
-      this.syncGridData();
+      if (!event.data?.__isInputRow) {
+        this.syncGridData();
+      }
       this.$emit("trigger-event", {
         name: "cellValueChanged",
         event: {
@@ -738,31 +782,27 @@ export default {
     syncGridData() {
       const rows = (this.rowData || [])
         .filter((row) => !row?.__isInputRow)
-        .map((row) => {
-          const next = { ...row };
-          delete next.__isInputRow;
-          return next;
-        });
-      this.$emit("update:content:effect", { rowData: rows });
+        .map((row) => this.sanitizeGridRow(row));
+      this.setGridRecords(rows);
     },
     createBlankRow(isInputRow = false) {
       return (this.content.columns || []).filter((col) => col.field).reduce((acc, col) => {
         acc[col.field] = "";
         return acc;
-      }, { __isInputRow: isInputRow });
+      }, { __isInputRow: isInputRow, __gridInputRowKey: isInputRow ? this.inputRowKey : undefined });
     },
     addRowFromInput(inputRow) {
-      const newRow = { ...inputRow };
-      delete newRow.__isInputRow;
-      const currentRows = Array.isArray(this.content.rowData) ? [...this.content.rowData] : [];
-      this.$emit("update:content:effect", { rowData: [...currentRows, newRow] });
+      const newRow = this.sanitizeGridRow(inputRow);
+      const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
+      this.setGridRecords([...currentRows, newRow]);
+      this.inputRowKey += 1;
     },
-    deleteRow(rowIndex) {
-      const dataIndex = rowIndex - 1;
-      const currentRows = Array.isArray(this.content.rowData) ? [...this.content.rowData] : [];
-      if (dataIndex < 0 || dataIndex >= currentRows.length) return;
+    deleteRow(row) {
+      const dataIndex = Number(row?.__gridInputRowIndex);
+      const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
+      if (!Number.isInteger(dataIndex) || dataIndex < 0 || dataIndex >= currentRows.length) return;
       currentRows.splice(dataIndex, 1);
-      this.$emit("update:content:effect", { rowData: currentRows });
+      this.setGridRecords(currentRows);
     },
     onCellKeyDown(event) {
       if (!this.content.enterNextRow || !event?.event) return;
@@ -1011,16 +1051,25 @@ export default {
     &.grid-hidden {
       visibility: hidden;
 }
-.grid-input-action-btn {
-  width: 24px;
-  height: 24px;
-  border: 1px solid #d0d7de;
-  background: #fff;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: 700;
-  line-height: 1;
-}
+    :deep(.grid-input-action-btn) {
+      width: 24px;
+      height: 24px;
+      border: 1px solid #d0d7de;
+      background: #fff;
+      border-radius: 4px;
+      color: var(--ww-data-grid_action-color, #24292f);
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      line-height: 1;
+      padding: 0;
+    }
+
+    :deep(.grid-input-action-btn i) {
+      font-size: 13px;
+      line-height: 1;
+    }
     /* wwEditor:start */
     &.editing {
       &::before {


### PR DESCRIPTION
### Motivation
- Centralize grid data management into a component variable and avoid leaking internal helper fields into persisted data.
- Ensure stable row ids for input rows and prevent sync operations from running on the blank input row.
- Improve the action column visuals and accessibility for add/delete buttons.

### Description
- Introduce `gridRecords` as a `wwVariable` component variable with `setGridRecords`, and add `sanitizeGridRow` and `normalizeGridRecords` helpers to strip internal keys from rows.
- Add a watcher on `props.content.rowData` to populate `gridRecords` via `normalizeGridRecords` and expose `gridRecords`, `setGridRecords`, and `sanitizeGridRow` from the setup return.
- Change `rowData` computed to use `gridRecords` and annotate rows with `__gridInputRowIndex`; add `inputRowKey` to `data` and set `__gridInputRowKey` on blank rows for stable input row ids.
- Update row lifecycle methods: `syncGridData` now calls `setGridRecords` with sanitized rows, `addRowFromInput` appends sanitized rows and increments `inputRowKey`, and `deleteRow` removes rows by `__gridInputRowIndex` using `setGridRecords`.
- Adjust `getRowId` to return a stable id for input rows and make `onCellValueChanged` skip syncing for the input row.
- Replace action column symbols with FontAwesome icon markup and accessible attributes, and move button styles into scoped `:deep` selectors with icon sizing and a color variable.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1acab1c1b883308b1eaacf67775dcc)