### PR TITLE
GridViewInput: add Year/Month column types and List editor with datasource mapping

### DIFF
--- a/Project/GridViewInput/src/components/ListCellEditor.js
+++ b/Project/GridViewInput/src/components/ListCellEditor.js
@@ -1,0 +1,84 @@
+export default class ListCellEditor {
+  init(params) {
+    this.params = params;
+    const colDef = params.colDef || {};
+    this.options = this.normalizeOptions(colDef.listDataSource, colDef.listIdColumn, colDef.listLabelColumn);
+    this.filteredOptions = [...this.options];
+    this.value = params.value;
+
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'grid-list-cell-editor';
+    this.eGui.innerHTML = `
+      <input type="text" class="grid-list-cell-editor__search" placeholder="Search..." />
+      <div class="grid-list-cell-editor__options"></div>
+    `;
+
+    this.searchInput = this.eGui.querySelector('.grid-list-cell-editor__search');
+    this.optionsContainer = this.eGui.querySelector('.grid-list-cell-editor__options');
+
+    this.searchInput.addEventListener('input', event => {
+      const query = String(event.target.value || '').toLowerCase();
+      this.filteredOptions = this.options.filter(option =>
+        String(option.label ?? '').toLowerCase().includes(query)
+      );
+      this.renderOptions();
+    });
+
+    this.renderOptions();
+  }
+
+  normalizeOptions(dataSource, idColumn, labelColumn) {
+    const rows = window.wwLib?.wwUtils?.getDataFromCollection
+      ? window.wwLib.wwUtils.getDataFromCollection(dataSource)
+      : dataSource;
+
+    if (!Array.isArray(rows)) return [];
+
+    return rows.map(item => {
+      if (item && typeof item === 'object') {
+        const fallbackIdKey = Object.keys(item).find(key => key.toLowerCase() === 'id');
+        const fallbackLabelKey = Object.keys(item).find(key => ['label', 'name', 'title'].includes(key.toLowerCase()));
+        const value = idColumn ? item[idColumn] : item[fallbackIdKey] ?? item.value;
+        const label = labelColumn ? item[labelColumn] : item[fallbackLabelKey] ?? item.label ?? item.name ?? value;
+        return { value, label: label == null ? '' : String(label) };
+      }
+
+      return { value: item, label: item == null ? '' : String(item) };
+    });
+  }
+
+  renderOptions() {
+    this.optionsContainer.innerHTML = '';
+
+    this.filteredOptions.forEach(option => {
+      const optionElement = document.createElement('button');
+      optionElement.type = 'button';
+      optionElement.className = 'grid-list-cell-editor__option';
+      optionElement.textContent = option.label;
+      if (option.value === this.value) optionElement.classList.add('selected');
+
+      optionElement.addEventListener('click', () => {
+        this.value = option.value;
+        this.params.api?.stopEditing?.();
+      });
+
+      this.optionsContainer.appendChild(optionElement);
+    });
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  afterGuiAttached() {
+    this.searchInput?.focus();
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  isPopup() {
+    return true;
+  }
+}

--- a/Project/GridViewInput/src/components/YearMonthCellEditor.js
+++ b/Project/GridViewInput/src/components/YearMonthCellEditor.js
@@ -1,0 +1,123 @@
+export default class YearMonthCellEditor {
+  init(params) {
+    this.params = params;
+    this.mode = params.colDef?.cellDataType === 'month' ? 'month' : 'year';
+    this.value = this.normalizeValue(params.value);
+
+    if (this.mode === 'year') {
+      this.createYearPicker();
+      return;
+    }
+
+    this.createMonthPicker();
+  }
+
+  createMonthPicker() {
+    const input = document.createElement('input');
+    input.type = 'month';
+    input.className = 'grid-year-month-cell-editor';
+    input.style.width = '100%';
+    input.style.height = '100%';
+    input.style.boxSizing = 'border-box';
+    input.style.padding = '4px 8px';
+    input.style.border = '1px solid #cbd5e1';
+    input.style.borderRadius = '6px';
+    input.style.font = 'inherit';
+    input.value = this.value;
+    input.addEventListener('input', event => {
+      this.value = event.target.value;
+    });
+    input.addEventListener('change', event => {
+      this.value = event.target.value;
+      this.params.api?.stopEditing?.();
+    });
+    input.addEventListener('keydown', event => this.handleKeydown(event));
+
+    this.eGui = input;
+  }
+
+  createYearPicker() {
+    const currentYear = Number(this.value) || new Date().getFullYear();
+    this.decadeStart = Math.floor(currentYear / 10) * 10;
+
+    this.eGui = document.createElement('div');
+    this.eGui.className = 'grid-year-picker';
+    this.renderYearPicker();
+  }
+
+  renderYearPicker() {
+    const years = Array.from({ length: 12 }, (_, index) => this.decadeStart - 1 + index);
+    this.eGui.innerHTML = `
+      <div class="grid-year-picker__header">
+        <button type="button" class="grid-year-picker__nav" data-action="previous" aria-label="Previous years">‹</button>
+        <span>${this.decadeStart} - ${this.decadeStart + 9}</span>
+        <button type="button" class="grid-year-picker__nav" data-action="next" aria-label="Next years">›</button>
+      </div>
+      <div class="grid-year-picker__years">
+        ${years.map(year => `
+          <button type="button" class="grid-year-picker__year${String(year) === String(this.value) ? ' selected' : ''}" data-year="${year}">
+            ${year}
+          </button>
+        `).join('')}
+      </div>
+    `;
+
+    this.eGui.querySelector('[data-action="previous"]')?.addEventListener('click', () => {
+      this.decadeStart -= 10;
+      this.renderYearPicker();
+    });
+    this.eGui.querySelector('[data-action="next"]')?.addEventListener('click', () => {
+      this.decadeStart += 10;
+      this.renderYearPicker();
+    });
+    this.eGui.querySelectorAll('[data-year]').forEach(button => {
+      button.addEventListener('click', () => {
+        this.value = button.dataset.year;
+        this.params.api?.stopEditing?.();
+      });
+    });
+  }
+
+  handleKeydown(event) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      this.value = event.target.value;
+      this.params.api?.stopEditing?.();
+    }
+  }
+
+  normalizeValue(value) {
+    if (value == null || value === '') return '';
+    const stringValue = String(value);
+
+    if (this.mode === 'month') {
+      const match = stringValue.match(/^(\d{4})-(\d{2})/);
+      return match ? `${match[1]}-${match[2]}` : stringValue;
+    }
+
+    const yearMatch = stringValue.match(/\d{4}/);
+    return yearMatch ? yearMatch[0] : stringValue;
+  }
+
+  getGui() {
+    return this.eGui;
+  }
+
+  afterGuiAttached() {
+    if (this.mode === 'month') {
+      this.eGui?.focus();
+      this.eGui?.showPicker?.();
+    } else {
+      this.eGui?.querySelector('.grid-year-picker__year.selected')?.focus();
+    }
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  isPopup() {
+    return this.mode === 'year';
+  }
+}

--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -36,6 +36,8 @@ import ActionCellRenderer from "./components/ActionCellRenderer.vue";
 import ImageCellRenderer from "./components/ImageCellRenderer.vue";
 import WewebCellRenderer from "./components/WewebCellRenderer.vue";
 import ListFilterRenderer from "./components/ListFilterRenderer.js";
+import ListCellEditor from "./components/ListCellEditor.js";
+import YearMonthCellEditor from "./components/YearMonthCellEditor.js";
 import './components/list-filter.css';
 import { translatePhrase } from "./translation";
 
@@ -594,6 +596,9 @@ export default {
               sortable: col.sortable,
               filter: col.filter,
               editable: col.editable,
+              listDataSource: col.listDataSource,
+              listIdColumn: col.listIdColumn,
+              listLabelColumn: col.listLabelColumn,
               cellClass,
               headerClass,
               ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
@@ -615,9 +620,27 @@ export default {
                 result.cellEditor = 'agDateStringCellEditor';
               }
             }
+            // Garante filtro de data para campos do tipo Year/Month
+            if (col.cellDataType === 'year' || col.cellDataType === 'month') {
+              result.filter = col.cellDataType === 'year' ? 'agNumberColumnFilter' : 'agTextColumnFilter';
+              result.cellDataType = col.cellDataType === 'year' ? 'number' : 'text';
+              if (col.editable) {
+                result.cellEditor = YearMonthCellEditor;
+              }
+            }
             // Garante filtro customizado de lista para campos do tipo List
             if (col.cellDataType === 'list') {
               result.filter = ListFilterRenderer;
+              if (col.editable) {
+                result.cellEditor = ListCellEditor;
+              }
+              const listRows = wwLib.wwUtils.getDataFromCollection(col.listDataSource);
+              if (Array.isArray(listRows) && listRows.length && col.listIdColumn && col.listLabelColumn) {
+                const labelsById = new Map(
+                  listRows.map(item => [String(item?.[col.listIdColumn]), item?.[col.listLabelColumn]])
+                );
+                result.valueFormatter = params => labelsById.get(String(params.value)) ?? params.value ?? '';
+              }
             }
 
             return applyCursor(result);
@@ -1305,4 +1328,97 @@ export default {
   .list-filter .clear-btn:hover {
     background: #ffe6e6;
   }
+  :deep(.grid-list-cell-editor) {
+    min-width: 180px;
+    max-height: 260px;
+    padding: 8px;
+    border: 1px solid #d6dce5;
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.14);
+  }
+
+  :deep(.grid-list-cell-editor__search) {
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 8px;
+    padding: 6px 8px;
+    border: 1px solid #cbd5e1;
+    border-radius: 6px;
+    font: inherit;
+  }
+
+  :deep(.grid-list-cell-editor__options) {
+    max-height: 200px;
+    overflow-y: auto;
+  }
+
+  :deep(.grid-list-cell-editor__option) {
+    display: block;
+    width: 100%;
+    padding: 6px 8px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  :deep(.grid-list-cell-editor__option:hover),
+  :deep(.grid-list-cell-editor__option.selected) {
+    background: #eef2ff;
+  }
+
+
+  :deep(.grid-year-picker) {
+    width: 220px;
+    padding: 10px;
+    border: 1px solid #d6dce5;
+    border-radius: 8px;
+    background: #fff;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.14);
+  }
+
+  :deep(.grid-year-picker__header) {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 8px;
+    font-weight: 600;
+  }
+
+  :deep(.grid-year-picker__nav),
+  :deep(.grid-year-picker__year) {
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font: inherit;
+  }
+
+  :deep(.grid-year-picker__nav) {
+    width: 28px;
+    height: 28px;
+    font-size: 20px;
+    line-height: 1;
+  }
+
+  :deep(.grid-year-picker__years) {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+  }
+
+  :deep(.grid-year-picker__year) {
+    padding: 8px 4px;
+  }
+
+  :deep(.grid-year-picker__nav:hover),
+  :deep(.grid-year-picker__year:hover),
+  :deep(.grid-year-picker__year.selected) {
+    background: #eef2ff;
+  }
+
 </style>

--- a/Project/GridViewInput/ww-config.js
+++ b/Project/GridViewInput/ww-config.js
@@ -930,6 +930,8 @@ export default {
                     { value: "number", label: "Number" },
                     { value: "boolean", label: "Boolean" },
                     { value: "dateString", label: "Date" },
+                    { value: "year", label: "Year" },
+                    { value: "month", label: "Month" },
                     { value: "image", label: "Image" },
                     { value: "action", label: "Action" },
                     { value: "custom", label: "Custom" },
@@ -972,6 +974,40 @@ export default {
                   array?.item?.cellDataType === "image" ||
                   !array?.item?.useCustomLabel ||
                   array?.item?.cellDataType === "custom",
+              },
+              listDataSource: {
+                label: "List data source",
+                type: "ObjectList",
+                options: {
+                  useSchema: true,
+                },
+                bindable: true,
+                hidden: array?.item?.cellDataType !== "list",
+                bindingValidation: {
+                  validations: [
+                    { type: "array" },
+                    { type: "object" },
+                  ],
+                  tooltip: "A collection or an array of objects to load the list editor.",
+                },
+              },
+              listIdColumn: {
+                label: "List id column",
+                type: "ObjectPropertyPath",
+                options: {
+                  object: wwLib.wwUtils.getDataFromCollection(array?.item?.listDataSource)?.[0] || {},
+                },
+                bindable: true,
+                hidden: array?.item?.cellDataType !== "list",
+              },
+              listLabelColumn: {
+                label: "List label column",
+                type: "ObjectPropertyPath",
+                options: {
+                  object: wwLib.wwUtils.getDataFromCollection(array?.item?.listDataSource)?.[0] || {},
+                },
+                bindable: true,
+                hidden: array?.item?.cellDataType !== "list",
               },
               widthAlgo: {
                 type: "TextRadioGroup",


### PR DESCRIPTION
### Motivation
- Add column types that allow selecting only year or month and extend the existing `List` column so the editor can load options from a configurable datasource and map id→label.

### Description
- Expose new column types `year` and `month` in the GridViewInput configuration (`Project/GridViewInput/ww-config.js`).
- Add `listDataSource`, `listIdColumn` and `listLabelColumn` properties to column definitions so `List` columns can be configured with a datasource and id/label mapping (`Project/GridViewInput/ww-config.js`).
- Implement a searchable list cell editor `ListCellEditor` that loads options from the configured datasource and returns the selected id (`Project/GridViewInput/src/components/ListCellEditor.js`).
- Implement `YearMonthCellEditor` providing a decade-year picker for `year` and native month picker for `month`, and register both editors and the list editor in the grid logic; wire filters and `valueFormatter` mapping for `List` columns (`Project/GridViewInput/src/wwElement.vue`).
- Add styling for the list editor popup and the year picker to the component styles (`Project/GridViewInput/src/wwElement.vue`).

### Testing
- Ran `node --check /tmp/gridviewinput-wwElement-script.mjs` to validate the transformed component script and it succeeded.
- Ran `node --check Project/GridViewInput/src/components/ListCellEditor.js` and `node --check Project/GridViewInput/src/components/YearMonthCellEditor.js` and both checks succeeded.
- Ran `node --check Project/GridViewInput/ww-config.js` and `git diff --check` to ensure no trailing-errors and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b346d6b848330ad20eb791a565ce6)