### PR TITLE
Fix GridViewInput action cell activation and list dropdown styles

### DIFF
--- a/Project/GridViewInput/src/components/ActionCellRenderer.vue
+++ b/Project/GridViewInput/src/components/ActionCellRenderer.vue
@@ -1,7 +1,10 @@
 <template>
     <div class="btn-container">
         <button
-            @click.stop="onButtonClicked"
+            @pointerdown.stop.prevent="preventGridEditActivation"
+            @mousedown.stop.prevent="preventGridEditActivation"
+            @dblclick.stop.prevent="preventGridEditActivation"
+            @click.stop.prevent="onButtonClicked"
             class="datagrid-btn"
             :class="params.withFont ? 'with-font' : 'without-font'"
         >
@@ -20,7 +23,11 @@ export default {
         },
     },
     methods: {
+        preventGridEditActivation() {
+            this.params.api?.stopEditing?.();
+        },
         onButtonClicked() {
+            this.params.api?.stopEditing?.();
             this.params.trigger({
                 actionName: this.params.name,
                 id: this.params.node.id,

--- a/Project/GridViewInput/src/components/ListCellEditor.js
+++ b/Project/GridViewInput/src/components/ListCellEditor.js
@@ -20,6 +20,30 @@ export default class ListCellEditor {
     this.searchInput = this.eGui.querySelector('.grid-list-cell-editor__search');
     this.optionsContainer = this.eGui.querySelector('.grid-list-cell-editor__options');
 
+    Object.assign(this.eGui.style, {
+      maxWidth: '550px',
+      maxHeight: '350px',
+    });
+
+    Object.assign(this.searchInput.style, {
+      borderRadius: '4px',
+      outline: 'none',
+    });
+
+    Object.assign(this.optionsContainer.style, {
+      maxHeight: '294px',
+    });
+
+    this.searchInput.addEventListener('focus', () => {
+      this.searchInput.style.outline = 'none';
+      this.searchInput.style.boxShadow = 'none';
+      this.searchInput.style.borderColor = '#94a3b8';
+    });
+
+    this.searchInput.addEventListener('blur', () => {
+      this.searchInput.style.borderColor = '#cbd5e1';
+    });
+
     this.searchInput.addEventListener('input', event => {
       const query = String(event.target.value || '').toLowerCase();
       this.filteredOptions = this.options.filter(option =>

--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -419,6 +419,8 @@ export default {
         filter: false,
         resizable: false,
         editable: false,
+        suppressClickEdit: true,
+        suppressNavigable: true,
         suppressMovable: true,
         cellStyle: {
           textAlign: "center",
@@ -431,11 +433,28 @@ export default {
           const isInputRow = !!params.data?.__isInputRow;
           const iconClass = isInputRow ? "fa-solid fa-plus" : "fa-solid fa-trash";
           const title = isInputRow ? "Incluir linha" : "Excluir linha";
-          return `<button class="grid-input-action-btn" type="button" title="${title}" aria-label="${title}"><i class="${iconClass}" aria-hidden="true"></i></button>`;
-        },
-        onCellClicked: (params) => {
-          if (params.data?.__isInputRow) this.addRowFromInput(params.data);
-          else this.deleteRow(params.data);
+          const button = document.createElement("button");
+          button.className = "grid-input-action-btn";
+          button.type = "button";
+          button.title = title;
+          button.setAttribute("aria-label", title);
+          button.innerHTML = `<i class="${iconClass}" aria-hidden="true"></i>`;
+
+          const stopGridEditActivation = (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          };
+
+          button.addEventListener("pointerdown", stopGridEditActivation);
+          button.addEventListener("mousedown", stopGridEditActivation);
+          button.addEventListener("dblclick", stopGridEditActivation);
+          button.addEventListener("click", (event) => {
+            stopGridEditActivation(event);
+            if (params.data?.__isInputRow) this.addRowFromInput(params.data);
+            else this.deleteRow(params.data);
+          });
+
+          return button;
         },
       };
       
@@ -508,6 +527,9 @@ export default {
               sortable: false,
 
               filter: false,
+              editable: false,
+              suppressClickEdit: true,
+              suppressNavigable: true,
               cellClass,
               headerClass,
               ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
@@ -835,7 +857,6 @@ export default {
       const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
       this.setGridRecords([...currentRows, newRow]);
       this.inputRowKey += 1;
-      this.focusInputRowFirstEditableCell();
     },
     deleteRow(row) {
       const dataIndex = Number(row?.__gridInputRowIndex);
@@ -1442,7 +1463,8 @@ export default {
   }
   :deep(.grid-list-cell-editor) {
     min-width: 180px;
-    max-height: 260px;
+    max-width: 550px;
+    max-height: 350px;
     padding: 8px;
     border: 1px solid #d6dce5;
     border-radius: 8px;
@@ -1456,12 +1478,19 @@ export default {
     margin-bottom: 8px;
     padding: 6px 8px;
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
+    border-radius: 4px;
     font: inherit;
   }
 
+  :deep(.grid-list-cell-editor__search:focus),
+  :deep(.grid-list-cell-editor__search:focus-visible) {
+    border-color: #94a3b8;
+    outline: none;
+    box-shadow: none;
+  }
+
   :deep(.grid-list-cell-editor__options) {
-    max-height: 200px;
+    max-height: 294px;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent clicks on the grid input action cell/button from activating the editor for the adjacent column. 
- Apply visual and size constraints to list-type column dropdowns so the search field has a 4px radius and no black focus outline, and the dropdown respects maximum dimensions.

### Description
- Replaced the action cell HTML string with a DOM `button` element and attached `pointerdown`, `mousedown`, `dblclick` and `click` handlers that call `event.stopPropagation()`/`preventDefault()` to stop AG Grid from activating editors, and call `params.api?.stopEditing?.()` before triggering the action.  
- Set `suppressClickEdit` and `suppressNavigable` on the internal `__grid_input_actions__` column and on columns of type `action` to prevent accidental cell edit activation.  
- Removed the automatic focus of the first editable input cell after adding a row so the action click does not immediately open the editor to the right.  
- Constrained the list editor popup by applying `max-width: 550px` and `max-height: 350px`, set the search input `border-radius` to `4px`, and removed outline/box-shadow on focus; also limited the options list height to match the new dimensions (applied via inline styles in `ListCellEditor` and matching `:deep` CSS rules). 

### Testing
- Ran `node --check Project/GridViewInput/src/components/ListCellEditor.js` and it completed successfully.  
- Ran `git diff --check` to ensure no whitespace/merge issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d741e5df08330af3a25cb82358e40)