### PR TITLE
Prevent grid edit activation for action buttons and refine list editor UI

### DIFF
--- a/Project/GridViewInput/src/components/ActionCellRenderer.vue
+++ b/Project/GridViewInput/src/components/ActionCellRenderer.vue
@@ -1,7 +1,10 @@
 <template>
     <div class="btn-container">
         <button
-            @click.stop="onButtonClicked"
+            @pointerdown.stop.prevent="preventGridEditActivation"
+            @mousedown.stop.prevent="preventGridEditActivation"
+            @dblclick.stop.prevent="preventGridEditActivation"
+            @click.stop.prevent="onButtonClicked"
             class="datagrid-btn"
             :class="params.withFont ? 'with-font' : 'without-font'"
         >
@@ -20,7 +23,18 @@ export default {
         },
     },
     methods: {
-        onButtonClicked() {
+        preventGridEditActivation(event) {
+            event?.preventDefault?.();
+            event?.stopPropagation?.();
+            this.params.api?.stopEditing?.(true);
+            this.params.api?.clearFocusedCell?.();
+            requestAnimationFrame(() => {
+                this.params.api?.stopEditing?.(true);
+                this.params.api?.clearFocusedCell?.();
+            });
+        },
+        onButtonClicked(event) {
+            this.preventGridEditActivation(event);
             this.params.trigger({
                 actionName: this.params.name,
                 id: this.params.node.id,

--- a/Project/GridViewInput/src/components/ListCellEditor.js
+++ b/Project/GridViewInput/src/components/ListCellEditor.js
@@ -20,6 +20,30 @@ export default class ListCellEditor {
     this.searchInput = this.eGui.querySelector('.grid-list-cell-editor__search');
     this.optionsContainer = this.eGui.querySelector('.grid-list-cell-editor__options');
 
+    Object.assign(this.eGui.style, {
+      maxWidth: '550px',
+      maxHeight: '350px',
+    });
+
+    Object.assign(this.searchInput.style, {
+      borderRadius: '4px',
+      outline: 'none',
+    });
+
+    Object.assign(this.optionsContainer.style, {
+      maxHeight: '294px',
+    });
+
+    this.searchInput.addEventListener('focus', () => {
+      this.searchInput.style.outline = 'none';
+      this.searchInput.style.boxShadow = 'none';
+      this.searchInput.style.borderColor = '#94a3b8';
+    });
+
+    this.searchInput.addEventListener('blur', () => {
+      this.searchInput.style.borderColor = '#cbd5e1';
+    });
+
     this.searchInput.addEventListener('input', event => {
       const query = String(event.target.value || '').toLowerCase();
       this.filteredOptions = this.options.filter(option =>

--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -11,7 +11,7 @@
       @first-data-rendered="onFirstDataRendered"
       @row-selected="onRowSelected" @selection-changed="onSelectionChanged"
       @cell-value-changed="onCellValueChanged" @filter-changed="onFilterChanged" @sort-changed="onSortChanged"
-      @cell-clicked="onCellClicked" @row-clicked="onRowClicked" @cell-key-down="onCellKeyDown"
+      @cell-clicked="onCellClicked" @cell-mouse-down="onCellMouseDown" @row-clicked="onRowClicked" @cell-key-down="onCellKeyDown"
       @cell-editing-stopped="onCellEditingStopped">
     </ag-grid-vue>
   </div>
@@ -419,6 +419,9 @@ export default {
         filter: false,
         resizable: false,
         editable: false,
+        isGridActionColumn: true,
+        suppressClickEdit: true,
+        suppressNavigable: true,
         suppressMovable: true,
         cellStyle: {
           textAlign: "center",
@@ -431,11 +434,27 @@ export default {
           const isInputRow = !!params.data?.__isInputRow;
           const iconClass = isInputRow ? "fa-solid fa-plus" : "fa-solid fa-trash";
           const title = isInputRow ? "Incluir linha" : "Excluir linha";
-          return `<button class="grid-input-action-btn" type="button" title="${title}" aria-label="${title}"><i class="${iconClass}" aria-hidden="true"></i></button>`;
-        },
-        onCellClicked: (params) => {
-          if (params.data?.__isInputRow) this.addRowFromInput(params.data);
-          else this.deleteRow(params.data);
+          const button = document.createElement("button");
+          button.className = "grid-input-action-btn";
+          button.type = "button";
+          button.title = title;
+          button.setAttribute("aria-label", title);
+          button.innerHTML = `<i class="${iconClass}" aria-hidden="true"></i>`;
+
+          const stopGridEditActivation = (event) => {
+            this.preventActionCellEdit(params.api, event);
+          };
+
+          button.addEventListener("pointerdown", stopGridEditActivation);
+          button.addEventListener("mousedown", stopGridEditActivation);
+          button.addEventListener("dblclick", stopGridEditActivation);
+          button.addEventListener("click", (event) => {
+            stopGridEditActivation(event);
+            if (params.data?.__isInputRow) this.addRowFromInput(params.data);
+            else this.deleteRow(params.data);
+          });
+
+          return button;
         },
       };
       
@@ -504,10 +523,17 @@ export default {
                 label: translatePhrase(col.actionLabel),
                 trigger: this.onActionTrigger,
                 withFont: !!this.content.actionFont,
+                suppressMouseEventHandling: () => true,
               },
               sortable: false,
 
               filter: false,
+              editable: false,
+              isGridActionColumn: true,
+              suppressClickEdit: true,
+              suppressNavigable: true,
+              onCellMouseDown: (params) => this.preventActionCellEdit(params.api, params.event),
+              onCellClicked: (params) => this.preventActionCellEdit(params.api, params.event),
               cellClass,
               headerClass,
               ...(baseCellStyle ? { cellStyle: baseCellStyle } : {}),
@@ -835,7 +861,6 @@ export default {
       const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
       this.setGridRecords([...currentRows, newRow]);
       this.inputRowKey += 1;
-      this.focusInputRowFirstEditableCell();
     },
     deleteRow(row) {
       const dataIndex = Number(row?.__gridInputRowIndex);
@@ -844,8 +869,31 @@ export default {
       currentRows.splice(dataIndex, 1);
       this.setGridRecords(currentRows);
     },
+    isGridActionColumn(column) {
+      const colDef = column?.getColDef?.();
+      return column?.getColId?.() === "__grid_input_actions__" || colDef?.isGridActionColumn === true;
+    },
+    preventActionCellEdit(api, event) {
+      event?.preventDefault?.();
+      event?.stopPropagation?.();
+      api?.stopEditing?.(true);
+      api?.clearFocusedCell?.();
+      requestAnimationFrame(() => {
+        api?.stopEditing?.(true);
+        api?.clearFocusedCell?.();
+      });
+    },
+    onCellMouseDown(event) {
+      if (this.isGridActionColumn(event.column)) {
+        this.preventActionCellEdit(event.api || this.gridApi, event.event);
+      }
+    },
     onCellClicked(event) {
-      if (!event.data?.__isInputRow || event.column?.getColId?.() === "__grid_input_actions__") return;
+      if (this.isGridActionColumn(event.column)) {
+        this.preventActionCellEdit(event.api || this.gridApi, event.event);
+        return;
+      }
+      if (!event.data?.__isInputRow) return;
       this.startInputRowEditing(event.column);
     },
     getFirstEditableInputColumn() {
@@ -1442,7 +1490,8 @@ export default {
   }
   :deep(.grid-list-cell-editor) {
     min-width: 180px;
-    max-height: 260px;
+    max-width: 550px;
+    max-height: 350px;
     padding: 8px;
     border: 1px solid #d6dce5;
     border-radius: 8px;
@@ -1456,12 +1505,19 @@ export default {
     margin-bottom: 8px;
     padding: 6px 8px;
     border: 1px solid #cbd5e1;
-    border-radius: 6px;
+    border-radius: 4px;
     font: inherit;
   }
 
+  :deep(.grid-list-cell-editor__search:focus),
+  :deep(.grid-list-cell-editor__search:focus-visible) {
+    border-color: #94a3b8;
+    outline: none;
+    box-shadow: none;
+  }
+
   :deep(.grid-list-cell-editor__options) {
-    max-height: 200px;
+    max-height: 294px;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
### Motivation

- Prevent action buttons in action columns from accidentally activating cell editing, focusing the grid, or leaving the grid in edit mode when clicked.  
- Improve the layout and focus styling of the list cell editor so the dropdown/search UI is more consistent and constrained.

### Description

- `ActionCellRenderer.vue`: added `pointerdown`, `mousedown`, `dblclick` handlers and a `preventGridEditActivation` method that calls `event.preventDefault()`/`stopPropagation()` and invokes `api.stopEditing(true)` and `api.clearFocusedCell()` (immediate + `requestAnimationFrame`) and updated the click handler to call it before triggering the action.  
- `wwElement.vue`: mark action columns as grid action columns (`isGridActionColumn`), set `suppressClickEdit`, `suppressNavigable`, and `editable: false`, replace the HTML string renderer for the input-action column with a DOM `button` wired to pointer/mouse/dblclick/click listeners, and add helpers `isGridActionColumn`, `preventActionCellEdit`, and `onCellMouseDown` to centralize preventing grid edit activation for action cells.  
- `ListCellEditor.js` and scoped styles: constrain the editor to `max-width: 550px`/`max-height: 350px`, limit options container height to `294px`, reduce search input `border-radius` to `4px`, add focus/blur handlers and focus CSS rules to remove outlines and set a neutral border color, and set inline styling for search/options container for consistent behavior.  
- Pass `suppressMouseEventHandling: () => true` into action cell renderer params to further avoid AG Grid mouse handling on action-type renderers.

### Testing

- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d741e5df08330af3a25cb82358e40)