### PR TITLE
GridViewInput: add NumberCellEditor to restrict number input to digits, comma and dot

### DIFF
--- a/Project/GridViewInput/src/components/NumberCellEditor.js
+++ b/Project/GridViewInput/src/components/NumberCellEditor.js
@@ -1,0 +1,129 @@
+export default class NumberCellEditor {
+  init(params) {
+    this.params = params;
+    this.value = this.resolveInitialValue(params);
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.inputMode = 'decimal';
+    input.className = 'grid-number-cell-editor';
+    input.value = this.value;
+
+    Object.assign(input.style, {
+      width: '100%',
+      height: '100%',
+      boxSizing: 'border-box',
+      font: 'inherit',
+    });
+
+    input.addEventListener('keydown', event => this.handleKeydown(event));
+    input.addEventListener('beforeinput', event => this.handleBeforeInput(event));
+    input.addEventListener('paste', event => this.handlePaste(event));
+    input.addEventListener('drop', event => this.handleDrop(event));
+    input.addEventListener('input', () => this.syncValue());
+
+    this.eInput = input;
+  }
+
+  resolveInitialValue(params) {
+    const eventKey = params?.eventKey ?? params?.charPress;
+
+    if (typeof eventKey === 'string' && eventKey.length === 1) {
+      return this.sanitizeValue(eventKey);
+    }
+
+    return this.sanitizeValue(params?.value ?? '');
+  }
+
+  sanitizeValue(value) {
+    return String(value ?? '').replace(/[^0-9.,]/g, '');
+  }
+
+  isAllowedCharacter(value) {
+    return /^[0-9.,]$/.test(value);
+  }
+
+  handleKeydown(event) {
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    if (event.key.length !== 1) return;
+
+    if (!this.isAllowedCharacter(event.key)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  handleBeforeInput(event) {
+    if (!event.data) return;
+
+    if (this.sanitizeValue(event.data) !== event.data) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  handlePaste(event) {
+    const pastedValue = event.clipboardData?.getData('text') ?? '';
+    const sanitizedValue = this.sanitizeValue(pastedValue);
+
+    if (pastedValue === sanitizedValue) return;
+
+    event.preventDefault();
+    this.insertText(sanitizedValue);
+  }
+
+  handleDrop(event) {
+    const droppedValue = event.dataTransfer?.getData('text') ?? '';
+    const sanitizedValue = this.sanitizeValue(droppedValue);
+
+    if (droppedValue === sanitizedValue) return;
+
+    event.preventDefault();
+    this.insertText(sanitizedValue);
+  }
+
+  insertText(text) {
+    if (!text) return;
+
+    const input = this.eInput;
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? input.value.length;
+
+    input.value = `${input.value.slice(0, start)}${text}${input.value.slice(end)}`;
+    const cursorPosition = start + text.length;
+    input.setSelectionRange(cursorPosition, cursorPosition);
+    this.syncValue();
+  }
+
+  syncValue() {
+    const sanitizedValue = this.sanitizeValue(this.eInput.value);
+
+    if (sanitizedValue !== this.eInput.value) {
+      const cursorPosition = this.eInput.selectionStart ?? sanitizedValue.length;
+      this.eInput.value = sanitizedValue;
+      this.eInput.setSelectionRange(
+        Math.min(cursorPosition, sanitizedValue.length),
+        Math.min(cursorPosition, sanitizedValue.length)
+      );
+    }
+
+    this.value = this.eInput.value;
+  }
+
+  getGui() {
+    return this.eInput;
+  }
+
+  afterGuiAttached() {
+    this.eInput.focus();
+    this.eInput.select();
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  isPopup() {
+    return false;
+  }
+}

--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -38,6 +38,7 @@ import WewebCellRenderer from "./components/WewebCellRenderer.vue";
 import ListFilterRenderer from "./components/ListFilterRenderer.js";
 import ListCellEditor from "./components/ListCellEditor.js";
 import YearMonthCellEditor from "./components/YearMonthCellEditor.js";
+import NumberCellEditor from "./components/NumberCellEditor.js";
 import './components/list-filter.css';
 import { translatePhrase } from "./translation";
 
@@ -640,6 +641,11 @@ export default {
                 );
               };
             }
+            // Garante editor numérico para campos do tipo Number
+            if (col.cellDataType === 'number' && isEditable) {
+              result.cellEditor = NumberCellEditor;
+            }
+
             // Garante filtro de data para campos do tipo Date
             if (col.cellDataType === 'dateString') {
               result.filter = 'agDateColumnFilter';


### PR DESCRIPTION
### Motivation
- Numeric cells in the GridViewInput editor were accepting letters and other non-number characters, but number fields should only allow digits, comma and period.

### Description
- Added a dedicated numeric cell editor at `Project/GridViewInput/src/components/NumberCellEditor.js` that uses `inputMode='decimal'`, sanitizes values and blocks invalid characters on typing, `beforeinput`, paste and drop events.
- Updated `Project/GridViewInput/src/wwElement.vue` to import `NumberCellEditor` and assign it as the `cellEditor` for columns where `col.cellDataType === 'number'` and the column is editable.
- The editor keeps cursor position when sanitizing, exposes `getValue()` and focuses/selects the input on attach to match other cell editors' behavior.

### Testing
- Ran `node --check Project/GridViewInput/src/components/NumberCellEditor.js` which completed without errors.
- Ran `git diff --check` to validate whitespace/patch issues which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d79957d7483308c96692b73409ae1)