### PR TITLE
Add numeric cell editor, parsing/formatting and config for number columns

### DIFF
--- a/Project/GridViewInput/src/components/NumberCellEditor.js
+++ b/Project/GridViewInput/src/components/NumberCellEditor.js
@@ -1,0 +1,131 @@
+export default class NumberCellEditor {
+  init(params) {
+    this.params = params;
+    this.value = this.resolveInitialValue(params);
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.inputMode = 'decimal';
+    input.className = 'grid-number-cell-editor';
+    input.value = this.value;
+
+    Object.assign(input.style, {
+      width: '100%',
+      height: '100%',
+      boxSizing: 'border-box',
+      font: 'inherit',
+      outline: 'none',
+      boxShadow: 'none',
+    });
+
+    input.addEventListener('keydown', event => this.handleKeydown(event));
+    input.addEventListener('beforeinput', event => this.handleBeforeInput(event));
+    input.addEventListener('paste', event => this.handlePaste(event));
+    input.addEventListener('drop', event => this.handleDrop(event));
+    input.addEventListener('input', () => this.syncValue());
+
+    this.eInput = input;
+  }
+
+  resolveInitialValue(params) {
+    const eventKey = params?.eventKey ?? params?.charPress;
+
+    if (typeof eventKey === 'string' && eventKey.length === 1) {
+      return this.sanitizeValue(eventKey);
+    }
+
+    return this.sanitizeValue(params?.value ?? '');
+  }
+
+  sanitizeValue(value) {
+    return String(value ?? '').replace(/[^0-9.,]/g, '');
+  }
+
+  isAllowedCharacter(value) {
+    return /^[0-9.,]$/.test(value);
+  }
+
+  handleKeydown(event) {
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+    if (event.key.length !== 1) return;
+
+    if (!this.isAllowedCharacter(event.key)) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  handleBeforeInput(event) {
+    if (!event.data) return;
+
+    if (this.sanitizeValue(event.data) !== event.data) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+  }
+
+  handlePaste(event) {
+    const pastedValue = event.clipboardData?.getData('text') ?? '';
+    const sanitizedValue = this.sanitizeValue(pastedValue);
+
+    if (pastedValue === sanitizedValue) return;
+
+    event.preventDefault();
+    this.insertText(sanitizedValue);
+  }
+
+  handleDrop(event) {
+    const droppedValue = event.dataTransfer?.getData('text') ?? '';
+    const sanitizedValue = this.sanitizeValue(droppedValue);
+
+    if (droppedValue === sanitizedValue) return;
+
+    event.preventDefault();
+    this.insertText(sanitizedValue);
+  }
+
+  insertText(text) {
+    if (!text) return;
+
+    const input = this.eInput;
+    const start = input.selectionStart ?? input.value.length;
+    const end = input.selectionEnd ?? input.value.length;
+
+    input.value = `${input.value.slice(0, start)}${text}${input.value.slice(end)}`;
+    const cursorPosition = start + text.length;
+    input.setSelectionRange(cursorPosition, cursorPosition);
+    this.syncValue();
+  }
+
+  syncValue() {
+    const sanitizedValue = this.sanitizeValue(this.eInput.value);
+
+    if (sanitizedValue !== this.eInput.value) {
+      const cursorPosition = this.eInput.selectionStart ?? sanitizedValue.length;
+      this.eInput.value = sanitizedValue;
+      this.eInput.setSelectionRange(
+        Math.min(cursorPosition, sanitizedValue.length),
+        Math.min(cursorPosition, sanitizedValue.length)
+      );
+    }
+
+    this.value = this.eInput.value;
+  }
+
+  getGui() {
+    return this.eInput;
+  }
+
+  afterGuiAttached() {
+    this.eInput.focus();
+    this.eInput.select();
+  }
+
+  getValue() {
+    return this.value;
+  }
+
+  isPopup() {
+    return false;
+  }
+}

--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -38,6 +38,7 @@ import WewebCellRenderer from "./components/WewebCellRenderer.vue";
 import ListFilterRenderer from "./components/ListFilterRenderer.js";
 import ListCellEditor from "./components/ListCellEditor.js";
 import YearMonthCellEditor from "./components/YearMonthCellEditor.js";
+import NumberCellEditor from "./components/NumberCellEditor.js";
 import './components/list-filter.css';
 import { translatePhrase } from "./translation";
 
@@ -640,6 +641,17 @@ export default {
                 );
               };
             }
+            // Garante editor numérico para campos do tipo Number
+            if (col.cellDataType === 'number') {
+              if (isEditable) {
+                result.cellEditor = NumberCellEditor;
+              }
+              result.valueParser = params => this.parseNumberInput(params.newValue, col.numberFormat);
+              if (!col.useCustomLabel) {
+                result.valueFormatter = params => this.formatNumberValue(params.value, col.numberFormat);
+              }
+            }
+
             // Garante filtro de data para campos do tipo Date
             if (col.cellDataType === 'dateString') {
               result.filter = 'agDateColumnFilter';
@@ -1059,6 +1071,51 @@ export default {
       return {
         backgroundColor: this.content.selectedActionRowColor,
       };
+    },
+    parseNumberInput(value, format = 'raw') {
+      if (value === null || value === undefined || value === '') return null;
+      if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+
+      const sanitizedValue = String(value).replace(/[^0-9.,]/g, '');
+      if (!sanitizedValue) return null;
+
+      const normalizedFormat = format || 'raw';
+      let normalizedValue = sanitizedValue;
+
+      if (normalizedFormat === 'pt-BR') {
+        normalizedValue = sanitizedValue.replace(/\./g, '').replace(',', '.');
+      } else if (normalizedFormat === 'en-US') {
+        normalizedValue = sanitizedValue.replace(/,/g, '');
+      } else {
+        const lastCommaIndex = sanitizedValue.lastIndexOf(',');
+        const lastDotIndex = sanitizedValue.lastIndexOf('.');
+        const decimalSeparatorIndex = Math.max(lastCommaIndex, lastDotIndex);
+
+        if (decimalSeparatorIndex >= 0) {
+          const integerPart = sanitizedValue.slice(0, decimalSeparatorIndex).replace(/[.,]/g, '');
+          const decimalPart = sanitizedValue.slice(decimalSeparatorIndex + 1).replace(/[.,]/g, '');
+          normalizedValue = `${integerPart || '0'}.${decimalPart}`;
+        }
+      }
+
+      const parsedValue = Number(normalizedValue);
+      return Number.isFinite(parsedValue) ? parsedValue : null;
+    },
+    formatNumberValue(value, format = 'raw') {
+      if (value === null || value === undefined || value === '') return '';
+
+      const numericValue = this.parseNumberInput(value, format);
+      if (numericValue === null) return value;
+
+      switch (format || 'raw') {
+        case 'pt-BR':
+          return new Intl.NumberFormat('pt-BR').format(numericValue);
+        case 'en-US':
+          return new Intl.NumberFormat('en-US').format(numericValue);
+        case 'raw':
+        default:
+          return numericValue;
+      }
     },
     formatYearMonthValue(value, format = 'YYYY-MM') {
       if (value == null || value === '') return '';

--- a/Project/GridViewInput/ww-config.js
+++ b/Project/GridViewInput/ww-config.js
@@ -1010,6 +1010,20 @@ export default {
                   !array?.item?.useCustomLabel ||
                   array?.item?.cellDataType === "custom",
               },
+              numberFormat: {
+                label: "Number display format",
+                type: "TextSelect",
+                options: {
+                  options: [
+                    { value: "raw", label: "No formatting", default: true },
+                    { value: "pt-BR", label: "Brazilian decimal (1.234,56)" },
+                    { value: "en-US", label: "US decimal (1,234.56)" },
+                  ],
+                },
+                defaultValue: "raw",
+                bindable: true,
+                hidden: array?.item?.cellDataType !== "number",
+              },
               yearMonthFormat: {
                 label: "YearMonth display format",
                 type: "TextSelect",


### PR DESCRIPTION
### Motivation
- Ensure numeric grid columns accept only valid numeric input and support parsing and localized display formatting.

### Description
- Add `NumberCellEditor` component that enforces numeric-only input and sanitizes keyboard input, paste and drop events while keeping cursor position in sync.
- Wire `NumberCellEditor` into `wwElement.vue` for columns with `cellDataType === 'number'` and set `cellEditor`, `valueParser`, and `valueFormatter` for those columns when editable.
- Implement `parseNumberInput` and `formatNumberValue` methods in `wwElement.vue` to convert user input into numeric values and format them according to `numberFormat` (`raw`, `pt-BR`, `en-US`).
- Add a `numberFormat` column config option in `ww-config.js` to allow selecting number display format from the editor UI.

### Testing
- Ran `npm run build` to verify the frontend compiles and the build succeeded.
- Ran `npm test` and the existing automated test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d79957d7483308c96692b73409ae1)