### PR TITLE
GridViewInput: add per-column Required validation and `invalidFields` event

### DIFF
--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -387,6 +387,7 @@ export default {
       pendingEnterEdit: null,
       markedRowId: null,
       inputRowKey: 0,
+      invalidInputFields: [],
     };
   },
   computed: {
@@ -496,6 +497,22 @@ export default {
         const cellClass = cellAlign ? `ag-text-${cellAlign}` : undefined;
         const headerClass = headerAlign ? `ag-header-align-${headerAlign}` : undefined;
         const baseCellStyle = cellAlign ? { textAlign: cellAlign } : undefined;
+        const requiredCellClassRules = col.field
+          ? {
+              "grid-input-invalid-cell": (params) =>
+                !!params.data?.__isInputRow && this.invalidInputFields.includes(col.field),
+            }
+          : undefined;
+
+        const withRequiredValidation = (result) => {
+          if (requiredCellClassRules) {
+            result.cellClassRules = {
+              ...(result.cellClassRules || {}),
+              ...requiredCellClassRules,
+            };
+          }
+          return result;
+        };
 
         const applyCursor = (result) => {
           const cursor = this.content.cellCursor ?? col.cursor;
@@ -508,7 +525,7 @@ export default {
               cursor,
             });
           }
-          return result;
+          return withRequiredValidation(result);
         };
 
         const isEditable = col.editable !== false;
@@ -843,7 +860,9 @@ export default {
       });
     },
     onCellValueChanged(event) {
-      if (!event.data?.__isInputRow) {
+      if (event.data?.__isInputRow) {
+        this.clearValidInputField(event.column.getColId(), event.data);
+      } else {
         this.syncGridData();
       }
       this.$emit("trigger-event", {
@@ -869,10 +888,60 @@ export default {
       }, { __isInputRow: isInputRow, __gridInputRowKey: isInputRow ? this.inputRowKey : undefined });
     },
     addRowFromInput(inputRow) {
+      const invalidColumns = this.getInvalidRequiredColumns(inputRow);
+      if (invalidColumns.length) {
+        this.invalidInputFields = invalidColumns.map((col) => col.field);
+        this.refreshInputRowValidation();
+        this.$emit("trigger-event", {
+          name: "invalidFields",
+          event: {
+            row: this.sanitizeGridRow(inputRow),
+            fields: [...this.invalidInputFields],
+            columns: invalidColumns.map((col) => ({
+              field: col.field,
+              headerName: col.headerName,
+              cellDataType: col.cellDataType,
+            })),
+          },
+        });
+        return;
+      }
+
+      this.invalidInputFields = [];
       const newRow = this.sanitizeGridRow(inputRow);
       const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
       this.setGridRecords([...currentRows, newRow]);
       this.inputRowKey += 1;
+    },
+    getRequiredColumns() {
+      return (this.content.columns || []).filter(
+        (col) => col.required && col.field && col.cellDataType !== "action"
+      );
+    },
+    isEmptyRequiredValue(value) {
+      if (value === null || value === undefined) return true;
+      if (typeof value === "string") return value.trim() === "";
+      if (Array.isArray(value)) return value.length === 0;
+      return false;
+    },
+    getInvalidRequiredColumns(row) {
+      return this.getRequiredColumns().filter((col) =>
+        this.isEmptyRequiredValue(row?.[col.field])
+      );
+    },
+    clearValidInputField(field, row) {
+      if (!field || !this.invalidInputFields.includes(field)) return;
+      if (this.isEmptyRequiredValue(row?.[field])) return;
+      this.invalidInputFields = this.invalidInputFields.filter((item) => item !== field);
+      this.refreshInputRowValidation();
+    },
+    refreshInputRowValidation() {
+      if (!this.gridApi?.refreshCells) return;
+      const inputRowNode = this.gridApi.getDisplayedRowAtIndex?.(0);
+      this.gridApi.refreshCells({
+        rowNodes: inputRowNode ? [inputRowNode] : undefined,
+        force: true,
+      });
     },
     deleteRow(row) {
       const dataIndex = Number(row?.__gridInputRowIndex);
@@ -888,10 +957,10 @@ export default {
     preventActionCellEdit(api, event) {
       event?.preventDefault?.();
       event?.stopPropagation?.();
-      api?.stopEditing?.(true);
+      api?.stopEditing?.();
       api?.clearFocusedCell?.();
       requestAnimationFrame(() => {
-        api?.stopEditing?.(true);
+        api?.stopEditing?.();
         api?.clearFocusedCell?.();
       });
     },
@@ -1273,6 +1342,18 @@ export default {
         field: Object.keys(data[0])[0],
       };
     },
+    getOnInvalidFieldsTestEvent() {
+      const data = this.rowData;
+      if (!data || !data[0]) throw new Error("No data found");
+      const firstColumn = (this.content.columns || []).find((col) => col.field) || {};
+      return {
+        row: data[0],
+        fields: firstColumn.field ? [firstColumn.field] : [],
+        columns: firstColumn.field
+          ? [{ field: firstColumn.field, headerName: firstColumn.headerName, cellDataType: firstColumn.cellDataType }]
+          : [],
+      };
+    },
     /* wwEditor:end */
   },
   /* wwEditor:start */
@@ -1349,6 +1430,11 @@ export default {
     :deep(.grid-input-action-btn i) {
       font-size: 13px;
       line-height: 1;
+    }
+
+    :deep(.ag-cell.grid-input-invalid-cell) {
+      border: 1px solid #e53935 !important;
+      box-shadow: inset 0 0 0 1px #e53935;
     }
     /* wwEditor:start */
     &.editing {

--- a/Project/GridViewInput/ww-config.js
+++ b/Project/GridViewInput/ww-config.js
@@ -167,6 +167,16 @@ export default {
       },
       getTestEvent: "getRowClickedTestEvent",
     },
+    {
+      name: "invalidFields",
+      label: { en: "On invalid fields" },
+      event: {
+        row: null,
+        fields: [],
+        columns: [],
+      },
+      getTestEvent: "getOnInvalidFieldsTestEvent",
+    },
   ],
   actions: [
     {
@@ -986,6 +996,16 @@ export default {
                 label: "Key",
                 type: "Text",
                 hidden: array?.item?.cellDataType === "action",
+              },
+              required: {
+                label: "Required",
+                type: "OnOff",
+                bindable: true,
+                hidden: array?.item?.cellDataType === "action",
+                bindingValidation: {
+                  type: "boolean",
+                  tooltip: "True when the input row must have a value for this column before it can be included.",
+                },
               },
               useCustomLabel: {
                 label: "Custom display value",


### PR DESCRIPTION
### Motivation
- Provide per-column configuration to mark input columns as required so the input-row cannot be added when mandatory values are missing.
- Give the host app a way to react when the user attempts to include a row with missing required fields by emitting an event with details.

### Description
- Added a `required` property to column configuration in `Project/GridViewInput/ww-config.js` to mark columns that must be filled in the input row (not available for action columns). 
- Introduced a new trigger event `invalidFields` (label: `On invalid fields`) in `ww-config.js` that carries the input `row`, an array of `fields`, and `columns` metadata. 
- Implemented validation in `Project/GridViewInput/src/wwElement.vue` that checks required columns before adding the input row and prevents the include when any required fields are empty and keeps the input row values intact. 
- Added UI feedback by tracking `invalidInputFields`, applying a `grid-input-invalid-cell` cell class rule to input cells, and styling it with a red border; the component emits the `invalidFields` event with row and column details when validation fails. 
- Added helper methods: `getRequiredColumns`, `isEmptyRequiredValue`, `getInvalidRequiredColumns`, `clearValidInputField`, and `refreshInputRowValidation`, and adjusted `onCellValueChanged` to clear invalid marks as fields are filled. 
- Small cleanup: removed the boolean `true` argument passed to `api.stopEditing` (now calling `api.stopEditing()`).

### Testing
- Ran `node --check Project/GridViewInput/ww-config.js` to validate configuration JS and it succeeded. 
- Extracted the `<script>` block from `Project/GridViewInput/src/wwElement.vue` and ran `node --check /tmp/GridViewInput-wwElement-script.mjs` which succeeded. 
- Ran whitespace/diff checks with `git -c core.whitespace=cr-at-eol diff --check` which reported no blocking issues after adjustments. 
- Verified the changes by running static checks and committing the modified files `Project/GridViewInput/ww-config.js` and `Project/GridViewInput/src/wwElement.vue`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d888272788330a2f334a287af0585)