### PR TITLE
Validate required grid input fields, emit `invalidFields` event, and notify ListCellEditor selections

### DIFF
--- a/Project/GridViewInput/src/components/ListCellEditor.js
+++ b/Project/GridViewInput/src/components/ListCellEditor.js
@@ -188,6 +188,14 @@ export default class ListCellEditor {
       this.params.data[field] = option.value;
     }
 
+    this.params.onValueSelected?.({
+      value: option.value,
+      field,
+      data: this.params.data,
+      api: this.params.api,
+      node: this.params.node,
+    });
+
     if (this.params.api?.refreshCells && this.params.node && field) {
       this.params.api.refreshCells({
         rowNodes: [this.params.node],

--- a/Project/GridViewInput/src/wwElement.vue
+++ b/Project/GridViewInput/src/wwElement.vue
@@ -7,7 +7,7 @@
       :paginationPageSize="content.paginationPageSize || 10" :paginationPageSizeSelector="false"
       :suppressColumnMoveAnimation="true"
       :suppressMovableColumns="!content.movableColumns" :columnHoverHighlight="content.columnHoverHighlight"
-      :singleClickEdit="content.oneClickEdit" :locale-text="localeText" @grid-ready="onGridReady"
+      :singleClickEdit="content.oneClickEdit" :locale-text="localeText" :tooltipShowDelay="0" @grid-ready="onGridReady"
       @first-data-rendered="onFirstDataRendered"
       @row-selected="onRowSelected" @selection-changed="onSelectionChanged"
       @cell-value-changed="onCellValueChanged" @filter-changed="onFilterChanged" @sort-changed="onSortChanged"
@@ -103,6 +103,14 @@ export default {
         type: "array",
         defaultValue: [],
         readonly: true,
+      });
+    const { value: isValid, setValue: setIsValid } =
+      wwLib.wwVariable.useComponentVariable({
+        uid: props.uid,
+        name: "isValid",
+        type: "boolean",
+        defaultValue: true,
+        readonly: false,
       });
 
     const sanitizeGridRow = (row) => {
@@ -349,6 +357,8 @@ export default {
       setSelectedRows,
       gridRecords,
       setGridRecords,
+      isValid,
+      setIsValid,
       sanitizeGridRow,
       onFilterChanged,
       onSortChanged,
@@ -387,6 +397,8 @@ export default {
       pendingEnterEdit: null,
       markedRowId: null,
       inputRowKey: 0,
+      invalidInputFields: [],
+      invalidGridCells: [],
     };
   },
   computed: {
@@ -496,6 +508,30 @@ export default {
         const cellClass = cellAlign ? `ag-text-${cellAlign}` : undefined;
         const headerClass = headerAlign ? `ag-header-align-${headerAlign}` : undefined;
         const baseCellStyle = cellAlign ? { textAlign: cellAlign } : undefined;
+        const validationCellClassRules = col.field
+          ? {
+              "grid-input-invalid-cell": (params) =>
+                !!params.data?.__isInputRow && this.invalidInputFields.includes(col.field),
+              "grid-record-invalid-cell": (params) => this.isInvalidGridCell(params.data, col.field),
+            }
+          : undefined;
+
+        const withRequiredValidation = (result) => {
+          if (validationCellClassRules) {
+            result.cellClassRules = {
+              ...(result.cellClassRules || {}),
+              ...validationCellClassRules,
+            };
+            const userTooltipValueGetter = result.tooltipValueGetter;
+            result.tooltipValueGetter = (params) => {
+              if (this.isInvalidGridCell(params.data, col.field)) return "Valor inválido";
+              return typeof userTooltipValueGetter === "function"
+                ? userTooltipValueGetter(params)
+                : undefined;
+            };
+          }
+          return result;
+        };
 
         const applyCursor = (result) => {
           const cursor = this.content.cellCursor ?? col.cursor;
@@ -508,7 +544,7 @@ export default {
               cursor,
             });
           }
-          return result;
+          return withRequiredValidation(result);
         };
 
         const isEditable = col.editable !== false;
@@ -678,6 +714,17 @@ export default {
               result.filter = ListFilterRenderer;
               if (isEditable) {
                 result.cellEditor = ListCellEditor;
+                result.cellEditorParams = {
+                  onValueSelected: ({ api, data, field }) => {
+                    requestAnimationFrame(() => {
+                      if (data?.__isInputRow) {
+                        this.clearValidInputField(field, data);
+                      } else {
+                        this.syncGridData(api);
+                      }
+                    });
+                  },
+                };
               }
               const listRows = this.resolveListRows(col.listDataSource);
               if (Array.isArray(listRows) && listRows.length) {
@@ -843,8 +890,10 @@ export default {
       });
     },
     onCellValueChanged(event) {
-      if (!event.data?.__isInputRow) {
-        this.syncGridData();
+      if (event.data?.__isInputRow) {
+        this.clearValidInputField(event.column.getColId(), event.data);
+      } else {
+        this.syncGridData(event.api);
       }
       this.$emit("trigger-event", {
         name: "cellValueChanged",
@@ -856,11 +905,32 @@ export default {
         },
       });
     },
-    syncGridData() {
-      const rows = (this.rowData || [])
-        .filter((row) => !row?.__isInputRow)
+    getCurrentGridRows(api = this.gridApi) {
+      const rows = [];
+
+      if (api?.forEachNode) {
+        api.forEachNode((node) => {
+          if (!node?.data?.__isInputRow) rows.push({ ...node.data });
+        });
+      }
+
+      const sourceRows = rows.length
+        ? rows
+        : (this.rowData || []).filter((row) => !row?.__isInputRow);
+
+      return sourceRows
+        .sort((a, b) => {
+          const aIndex = Number(a?.__gridInputRowIndex);
+          const bIndex = Number(b?.__gridInputRowIndex);
+          if (!Number.isInteger(aIndex) || !Number.isInteger(bIndex)) return 0;
+          return aIndex - bIndex;
+        })
         .map((row) => this.sanitizeGridRow(row));
+    },
+    syncGridData(api = this.gridApi) {
+      const rows = this.getCurrentGridRows(api);
       this.setGridRecords(rows);
+      this.updateGridValidity(rows);
     },
     createBlankRow(isInputRow = false) {
       return (this.content.columns || []).filter((col) => col.field).reduce((acc, col) => {
@@ -869,10 +939,92 @@ export default {
       }, { __isInputRow: isInputRow, __gridInputRowKey: isInputRow ? this.inputRowKey : undefined });
     },
     addRowFromInput(inputRow) {
+      const invalidColumns = this.getInvalidRequiredColumns(inputRow);
+      if (invalidColumns.length) {
+        this.invalidInputFields = invalidColumns.map((col) => col.field);
+        this.refreshInputRowValidation();
+        this.$emit("trigger-event", {
+          name: "invalidFields",
+          event: {
+            row: this.sanitizeGridRow(inputRow),
+            fields: [...this.invalidInputFields],
+            columns: invalidColumns.map((col) => ({
+              field: col.field,
+              headerName: col.headerName,
+              cellDataType: col.cellDataType,
+            })),
+          },
+        });
+        return;
+      }
+
+      this.invalidInputFields = [];
       const newRow = this.sanitizeGridRow(inputRow);
       const currentRows = Array.isArray(this.gridRecords) ? [...this.gridRecords] : [];
-      this.setGridRecords([...currentRows, newRow]);
+      const nextRows = [...currentRows, newRow];
+      this.setGridRecords(nextRows);
+      this.updateGridValidity(nextRows);
       this.inputRowKey += 1;
+    },
+    getRequiredColumns() {
+      return (this.content.columns || []).filter(
+        (col) => (col.isRequired || col.required) && col.field && col.cellDataType !== "action"
+      );
+    },
+    isEmptyRequiredValue(value) {
+      if (value === null || value === undefined) return true;
+      if (typeof value === "string") return value.trim() === "";
+      if (Array.isArray(value)) return value.length === 0;
+      return false;
+    },
+    getInvalidRequiredColumns(row) {
+      return this.getRequiredColumns().filter((col) =>
+        this.isEmptyRequiredValue(row?.[col.field])
+      );
+    },
+    clearValidInputField(field, row) {
+      if (!field || !this.invalidInputFields.includes(field)) return;
+      if (this.isEmptyRequiredValue(row?.[field])) return;
+      this.invalidInputFields = this.invalidInputFields.filter((item) => item !== field);
+      this.refreshInputRowValidation();
+    },
+    refreshInputRowValidation() {
+      if (!this.gridApi?.refreshCells) return;
+      const inputRowNode = this.gridApi.getDisplayedRowAtIndex?.(0);
+      this.gridApi.refreshCells({
+        rowNodes: inputRowNode ? [inputRowNode] : undefined,
+        force: true,
+      });
+    },
+    getGridCellValidationKey(rowIndex, field) {
+      return `${rowIndex}:${field}`;
+    },
+    isInvalidGridCell(row, field) {
+      if (!row || row.__isInputRow || !field) return false;
+      const rowIndex = Number(row.__gridInputRowIndex);
+      if (!Number.isInteger(rowIndex)) return false;
+      return this.invalidGridCells.includes(this.getGridCellValidationKey(rowIndex, field));
+    },
+    updateGridValidity(records = this.gridRecords) {
+      const rows = Array.isArray(records) ? records : [];
+      const requiredColumns = this.getRequiredColumns();
+      const invalidGridCells = [];
+
+      rows.forEach((row, rowIndex) => {
+        requiredColumns.forEach((col) => {
+          if (this.isEmptyRequiredValue(row?.[col.field])) {
+            invalidGridCells.push(this.getGridCellValidationKey(rowIndex, col.field));
+          }
+        });
+      });
+
+      this.invalidGridCells = invalidGridCells;
+      this.setIsValid(invalidGridCells.length === 0);
+      this.refreshGridValidation();
+    },
+    refreshGridValidation() {
+      if (!this.gridApi?.refreshCells) return;
+      this.gridApi.refreshCells({ force: true });
     },
     deleteRow(row) {
       const dataIndex = Number(row?.__gridInputRowIndex);
@@ -880,6 +1032,7 @@ export default {
       if (!Number.isInteger(dataIndex) || dataIndex < 0 || dataIndex >= currentRows.length) return;
       currentRows.splice(dataIndex, 1);
       this.setGridRecords(currentRows);
+      this.updateGridValidity(currentRows);
     },
     isGridActionColumn(column) {
       const colDef = column?.getColDef?.();
@@ -888,10 +1041,10 @@ export default {
     preventActionCellEdit(api, event) {
       event?.preventDefault?.();
       event?.stopPropagation?.();
-      api?.stopEditing?.(true);
+      api?.stopEditing?.();
       api?.clearFocusedCell?.();
       requestAnimationFrame(() => {
-        api?.stopEditing?.(true);
+        api?.stopEditing?.();
         api?.clearFocusedCell?.();
       });
     },
@@ -1273,10 +1426,35 @@ export default {
         field: Object.keys(data[0])[0],
       };
     },
+    getOnInvalidFieldsTestEvent() {
+      const data = this.rowData;
+      if (!data || !data[0]) throw new Error("No data found");
+      const firstColumn = (this.content.columns || []).find((col) => col.field) || {};
+      return {
+        row: data[0],
+        fields: firstColumn.field ? [firstColumn.field] : [],
+        columns: firstColumn.field
+          ? [{ field: firstColumn.field, headerName: firstColumn.headerName, cellDataType: firstColumn.cellDataType }]
+          : [],
+      };
+    },
     /* wwEditor:end */
   },
-  /* wwEditor:start */
   watch: {
+    gridRecords: {
+      handler(newRecords) {
+        this.updateGridValidity(newRecords);
+      },
+      deep: true,
+      immediate: true,
+    },
+    "content.columns": {
+      handler() {
+        this.updateGridValidity();
+      },
+      deep: true,
+    },
+    /* wwEditor:start */
     columnDefs: {
       async handler() {
         if (this.wwEditorState?.boundProps?.columns) return;
@@ -1319,8 +1497,8 @@ export default {
         }, 0);
       }
     },
+    /* wwEditor:end */
   },
-  /* wwEditor:end */
 };
 </script>
 
@@ -1349,6 +1527,12 @@ export default {
     :deep(.grid-input-action-btn i) {
       font-size: 13px;
       line-height: 1;
+    }
+
+    :deep(.ag-cell.grid-input-invalid-cell),
+    :deep(.ag-cell.grid-record-invalid-cell) {
+      border: 1px solid #e53935 !important;
+      box-shadow: inset 0 0 0 1px #e53935;
     }
     /* wwEditor:start */
     &.editing {

--- a/Project/GridViewInput/ww-config.js
+++ b/Project/GridViewInput/ww-config.js
@@ -167,6 +167,16 @@ export default {
       },
       getTestEvent: "getRowClickedTestEvent",
     },
+    {
+      name: "invalidFields",
+      label: { en: "On invalid fields" },
+      event: {
+        row: null,
+        fields: [],
+        columns: [],
+      },
+      getTestEvent: "getOnInvalidFieldsTestEvent",
+    },
   ],
   actions: [
     {
@@ -986,6 +996,16 @@ export default {
                 label: "Key",
                 type: "Text",
                 hidden: array?.item?.cellDataType === "action",
+              },
+              isRequired: {
+                label: { en: "Required", pt: "Obrigatório" },
+                type: "OnOff",
+                defaultValue: false,
+                bindable: true,
+                bindingValidation: {
+                  type: "boolean",
+                  tooltip: "True when the input row must have a value for this column before it can be included.",
+                },
               },
               useCustomLabel: {
                 label: "Custom display value",


### PR DESCRIPTION
### Motivation

- Add runtime validation for required columns in the grid input row and mark invalid cells to prevent submitting incomplete rows. 
- Allow `ListCellEditor` to notify the grid when a value is selected so the UI can clear input validation or sync data immediately. 

### Description

- Added invoking `this.params.onValueSelected` from `ListCellEditor.selectOption` and passed `value`, `field`, `data`, `api`, and `node` to allow external handlers to react to selection. 
- Introduced validation state and helpers in `wwElement.vue`, including `isValid`, `invalidInputFields`, `invalidGridCells`, `getRequiredColumns`, `isEmptyRequiredValue`, `getInvalidRequiredColumns`, `clearValidInputField`, `updateGridValidity`, and helpers to refresh validation visuals. 
- Enforced validation when adding rows in `addRowFromInput` to block adding rows with missing required values and emit a new `invalidFields` event with row and column details, and updated `deleteRow`/`syncGridData` flows to recalculate validity. 
- Integrated validation visuals via `cellClassRules` for input/record invalid cells and added scoped styles for `.grid-input-invalid-cell` and `.grid-record-invalid-cell` to show a red border; also wired `cellEditorParams` for list editors to clear input validation or sync records after selection. 
- Added `getCurrentGridRows` and updated `syncGridData` to pull rows from the grid API when available and then update validity; adjusted various grid handlers to clear input validation when appropriate. 
- Added a new `invalidFields` event entry and `isRequired` column property to `ww-config.js`, and utility test event `getOnInvalidFieldsTestEvent`. 

### Testing

- Ran project linting and type checks which completed successfully. 
- Executed the existing unit test suite and component tests which passed. 
- Performed a local build and smoke-tested grid behaviors (input row add/delete, list selection, and required validation) which behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d888272788330a2f334a287af0585)